### PR TITLE
Individual cops can be excluded for files#571

### DIFF
--- a/app/models/style_guide/ruby.rb
+++ b/app/models/style_guide/ruby.rb
@@ -28,7 +28,7 @@ module StyleGuide
     end
 
     def parsed_source(file)
-      RuboCop::ProcessedSource.new(file.content)
+      RuboCop::ProcessedSource.new(file.content, file.filename)
     end
 
     def config

--- a/spec/models/style_guide/ruby_spec.rb
+++ b/spec/models/style_guide/ruby_spec.rb
@@ -420,6 +420,24 @@ end
 
         expect(violations).to be_empty
       end
+
+      it 'allows a cop to be excluded for specific files or directories' do
+        config = {
+          "StringLiterals" => {
+            "EnforcedStyle" => "single_quotes"
+          },
+          "HashSyntax" => {
+            "Exclude" => ["lib/**/*"]
+          }
+        }
+
+        violations = violations_with_config(config)
+
+        expect(violations).to eq [
+          "Prefer single-quoted strings when you don't need string "\
+          "interpolation or special symbols."
+        ]
+      end
     end
 
     def violations_with_config(config)


### PR DESCRIPTION
- Pass the file's path into ProcessedSource initializer
- This path is later used in the Commissioner object to determine if a specific Cop is applicable
- https://github.com/thoughtbot/hound/issues/522
