### PR TITLE
Update for the mdast -> remark rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ being used and the default configs for each linter.
  * [hound-go](https://github.com/thoughtbot/hound-go)
 
 1. Markdown (beta)
- * [hound-mdast](https://github.com/thoughtbot/hound-mdast)
+ * [hound-remark](https://github.com/houndci/hound-remark)
  * [config](https://github.com/wooorm/remark-lint#rules)
 
 1. Swift (beta)

--- a/app/jobs/mdast_review_job.rb
+++ b/app/jobs/mdast_review_job.rb
@@ -1,3 +1,0 @@
-class MdastReviewJob
-  @queue = :mdast_review
-end

--- a/app/jobs/remark_review_job.rb
+++ b/app/jobs/remark_review_job.rb
@@ -1,0 +1,3 @@
+class RemarkReviewJob
+  @queue = :remark_review
+end

--- a/app/models/config/remark.rb
+++ b/app/models/config/remark.rb
@@ -1,5 +1,5 @@
 module Config
-  class Mdast < Base
+  class Remark < Base
     def serialize(data = content)
       Serializer.json(data)
     end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -4,7 +4,7 @@ class HoundConfig
     eslint
     jscs
     jshint
-    mdast
+    remark
     python
   )
   LANGUAGES = %w(

--- a/app/models/linter/collection.rb
+++ b/app/models/linter/collection.rb
@@ -7,7 +7,7 @@ module Linter
       Linter::Haml,
       Linter::Jscs,
       Linter::Jshint,
-      Linter::Mdast,
+      Linter::Remark,
       Linter::Python,
       Linter::Ruby,
       Linter::Scss,

--- a/app/models/linter/remark.rb
+++ b/app/models/linter/remark.rb
@@ -1,5 +1,5 @@
 module Linter
-  class Mdast < Base
+  class Remark < Base
     FILE_REGEXP = /.+\.(?:md|markdown)\z/
   end
 end

--- a/spec/models/config/remark_spec.rb
+++ b/spec/models/config/remark_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
 require "app/models/config/base"
-require "app/models/config/mdast"
+require "app/models/config/remark"
 require "app/models/config/parser"
 require "app/models/config/serializer"
 
-describe Config::Mdast do
+describe Config::Remark do
   describe "#content" do
     it "parses the configuration using JSON" do
       raw_config = <<-EOS.strip_heredoc
@@ -12,7 +12,7 @@ describe Config::Mdast do
           "heading-style": "setext"
         }
       EOS
-      commit = stubbed_commit("config/.mdastrc" => raw_config)
+      commit = stubbed_commit("config/.remarkrc" => raw_config)
       config = build_config(commit)
 
       expect(config.content).to eq Config::Parser.json(raw_config)
@@ -20,13 +20,13 @@ describe Config::Mdast do
   end
 
   describe "#serialize" do
-    it "serializes the content into YAML" do
+    it "serializes the content into JSON" do
       raw_config = <<-EOS.strip_heredoc
         {
-        "heading-style": "setext"
+          "heading-style": "setext"
         }
       EOS
-      commit = stubbed_commit("config/.mdastrc" => raw_config)
+      commit = stubbed_commit("config/.remarkrc" => raw_config)
       config = build_config(commit)
 
       expect(config.serialize).to eq "{\"heading-style\":\"setext\"}"
@@ -38,10 +38,10 @@ describe Config::Mdast do
       "HoundConfig",
       commit: commit,
       content: {
-        "mdast" => { "enabled": true, "config_file" => "config/.mdastrc" },
+        "remark" => { "enabled": true, "config_file" => "config/.remarkrc" },
       },
     )
 
-    Config::Mdast.new(hound_config, "mdast")
+    Config::Remark.new(hound_config, "remark")
   end
 end

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-describe Linter::Mdast do
+describe Linter::Remark do
   describe ".can_lint?" do
     context "given an .md file" do
       it "returns true" do
-        result = Linter::Mdast.can_lint?("foo.md")
+        result = Linter::Remark.can_lint?("foo.md")
 
         expect(result).to eq true
       end
@@ -12,7 +12,7 @@ describe Linter::Mdast do
 
     context "given an .markdown file" do
       it "returns true" do
-        result = Linter::Mdast.can_lint?("foo.markdown")
+        result = Linter::Remark.can_lint?("foo.markdown")
 
         expect(result).to eq true
       end
@@ -20,7 +20,7 @@ describe Linter::Mdast do
 
     context "given a non-markdown file" do
       it "returns false" do
-        result = Linter::Mdast.can_lint?("foo.txt")
+        result = Linter::Remark.can_lint?("foo.txt")
 
         expect(result).to eq false
       end
@@ -40,7 +40,7 @@ describe Linter::Mdast do
 
     it "schedules a review job" do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
-      stub_mdast_config(content: {})
+      stub_remark_config(content: {})
       commit_file = build_commit_file(filename: "lib/a.md")
       allow(Resque).to receive(:enqueue)
       linter = build_linter(build)
@@ -48,7 +48,7 @@ describe Linter::Mdast do
       linter.file_review(commit_file)
 
       expect(Resque).to have_received(:enqueue).with(
-        MdastReviewJob,
+        RemarkReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
         pull_request_number: build.pull_request_number,
@@ -59,22 +59,22 @@ describe Linter::Mdast do
     end
   end
 
-  def stub_mdast_config(content: {})
-    stubbed_mdast_config = double(
-      "MdastConfig",
+  def stub_remark_config(content: "")
+    stubbed_remark_config = double(
+      "RemarkConfig",
       content: content,
       serialize: content.to_s,
     )
-    allow(Config::Mdast).to receive(:new).and_return(stubbed_mdast_config)
+    allow(Config::Remark).to receive(:new).and_return(stubbed_remark_config)
 
-    stubbed_mdast_config
+    stubbed_remark_config
   end
 
   def raw_hound_config
     <<-EOS.strip_heredoc
-      mdast:
+      remark:
         enabled: true
-        config_file: config/.mdastrc
+        config_file: config/.remarkrc
     EOS
   end
 end


### PR DESCRIPTION
The hound service is being updated to use `remark`, which is `mdast`'s new name, in https://github.com/thoughtbot/hound-mdast/pull/7. This change brings _that_ name change into Hound so everything is consistent.

https://trello.com/c/vFLTg8IQ