### PR TITLE
ignore NPM packages from JavaScript linting

### DIFF
--- a/config/style_guides/.jshintignore
+++ b/config/style_guides/.jshintignore
@@ -1,1 +1,2 @@
+node_modules/*
 vendor/*


### PR DESCRIPTION
`node_modules/` is equivalent to a `vendor/` folder, so it should be ignored by default when running JSHint.