### PR TITLE
Extract GitHub token finding into own class

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -57,6 +57,14 @@ class Repo < ActiveRecord::Base
     builds.sum(:violations_count)
   end
 
+  def remove_membership(user)
+    users.destroy(user)
+  end
+
+  def users_with_token
+    users.where.not(token: nil)
+  end
+
   private
 
   def organization

--- a/app/models/user_token.rb
+++ b/app/models/user_token.rb
@@ -1,0 +1,21 @@
+class UserToken
+  attr_private_initialize :repo
+
+  def token
+    user.token
+  end
+
+  def user
+    @user ||= users_with_token.sample || user_with_default_token
+  end
+
+  private
+
+  def user_with_default_token
+    User.new(token: Hound::GITHUB_TOKEN)
+  end
+
+  def users_with_token
+    repo.users_with_token
+  end
+end

--- a/app/services/report_invalid_config.rb
+++ b/app/services/report_invalid_config.rb
@@ -19,8 +19,7 @@ class ReportInvalidConfig
   attr_reader :pull_request_number, :commit_sha, :linter_name
 
   def message
-    @message.presence ||
-      I18n.t(:config_error_status, linter_name: linter_name)
+    @message.presence || I18n.t(:config_error_status, linter_name: linter_name)
   end
 
   def commit_status

--- a/spec/models/user_token_spec.rb
+++ b/spec/models/user_token_spec.rb
@@ -1,0 +1,37 @@
+require "app/models/user_token"
+
+describe UserToken do
+  describe "#token" do
+    context "when user with a token is found" do
+      it "returns user's token" do
+        token = "foo_bar_token"
+        user = instance_double("User", token: token)
+        repo = instance_double("Repo", users_with_token: [user])
+        user_token = UserToken.new(repo)
+
+        expect(user_token.token).to eq token
+      end
+    end
+
+    context "when no users for repo have tokens" do
+      it "returns Hound's token" do
+        stub_const("User", OpenStruct)
+        stub_const("Hound::GITHUB_TOKEN", "sometoken")
+        repo = instance_double("Repo", users_with_token: [])
+        user_token = UserToken.new(repo)
+
+        expect(user_token.token).to eq Hound::GITHUB_TOKEN
+      end
+    end
+  end
+
+  describe "#user" do
+    it "returns the user that bears the current token" do
+      user = instance_double("User")
+      repo = instance_double("Repo", users_with_token: [user])
+      user_token = UserToken.new(repo)
+
+      expect(user_token.user).to eq user
+    end
+  end
+end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -204,23 +204,6 @@ describe BuildRunner do
       end
     end
 
-    context "with expired token" do
-      it "removes the expired token" do
-        repo = create(:repo, :active)
-        user = create(:user, token: "expired_token")
-        repo.users << user
-        build_runner = make_build_runner(repo: repo)
-        github_api = stubbed_github_api
-        allow(github_api).to receive(:create_pending_status).
-          and_raise(Octokit::Unauthorized)
-
-        expect { build_runner.run }.to raise_error BuildRunner::ExpiredToken
-        expect(user.reload.token).to be_nil
-
-        expect { build_runner.run }.to raise_error Octokit::Unauthorized
-      end
-    end
-
     context "when user's token doesn't have access to the repo" do
       it "removes the repo from user" do
         reachable_repo = create(:repo, :active)
@@ -251,12 +234,8 @@ describe BuildRunner do
         force_fail_build_creation
         allow(Resque).to receive(:enqueue)
 
-        begin
-          build_runner.run
-        rescue ActiveRecord::StatementInvalid
-          # noop
-        end
-
+        expect { build_runner.run }.
+          to raise_error ActiveRecord::StatementInvalid
         expect(Resque).not_to have_received(:enqueue)
       end
 


### PR DESCRIPTION
* Get that concern out of BuildRunner.
* The plan is to use the new `GithubRepo` class in other places.
* We should never encounter `Octokit::Unauthorized` during builds,
because this is the error that is only thrown when someone tries to
authenticate.