### PR TITLE
Update links to point to the new organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Here are a few technical guidelines to follow:
 1. [Squash your commits][squash] after receiving feedback.
 1. Party!
 
-[issues]: https://github.com/thoughtbot/hound/issues
+[issues]: https://github.com/houndci/hound/issues
 [squash]: https://github.com/thoughtbot/guides/tree/master/protocol/git#write-a-feature
 
 ## Configure Hound on Your Local Development Environment
@@ -110,38 +110,38 @@ To test Stripe payments on staging use this fake credit card number.
 ## Linters
 
 To better understand the architecture of Hound, here is a list of the linters
-being used and the default configs for each linter.
+and services being used, and the default configuration for each linter.
 
 1. Ruby
  * [RuboCop](https://github.com/bbatsov/rubocop)
- * [config](https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/ruby.yml)
+ * [config](https://raw.githubusercontent.com/houndci/hound/master/config/style_guides/ruby.yml)
 
 1. CoffeeScript
  * [CoffeeLint](https://github.com/clutchski/coffeelint)
- * [config](https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/coffeescript.json)
+ * [config](https://raw.githubusercontent.com/houndci/hound/master/config/style_guides/coffeescript.json)
 
-1. JavaScript
- * [JSHint](https://github.com/thoughtbot/hound-jshint)
- * [config](https://raw.githubusercontent.com/thoughtbot/hound-jshint/master/config/.jshintrc)
+1. JavaScript (JSHint)
+ * [houndci/jshint](https://github.com/houndci/jshint)
+ * [config](https://raw.githubusercontent.com/houndci/jshint/master/config/.jshintrc)
 
 1. SCSS
- * [hound-scss](https://github.com/thoughtbot/hound-scss)
- * [config](https://raw.githubusercontent.com/thoughtbot/hound-scss/master/config/default.yml)
+ * [houndci/scss](https://github.com/houndci/scss)
+ * [config](https://raw.githubusercontent.com/houndci/scss/master/config/default.yml)
 
 1. Haml
  * [haml-lint](https://github.com/brigade/haml-lint)
- * [config](https://raw.githubusercontent.com/thoughtbot/hound/master/config/style_guides/haml.yml)
+ * [config](https://raw.githubusercontent.com/houndci/hound/master/config/style_guides/haml.yml)
 
 1. Go
- * [hound-go](https://github.com/thoughtbot/hound-go)
+ * [houndci/go](https://github.com/houndci/go)
 
 1. Markdown (beta)
- * [hound-remark](https://github.com/houndci/hound-remark)
+ * [houndci/remark](https://github.com/houndci/remark)
  * [config](https://github.com/wooorm/remark-lint#rules)
 
 1. Swift (beta)
- * [hound-swift](https://github.com/thoughtbot/hound-swift)
- * [config](https://github.com/thoughtbot/hound-swift/blob/master/config/default.yml)
+ * [houndci/swift](https://github.com/houndci/swift)
+ * [config](https://github.com/houndci/swift/blob/master/config/default.yml)
 
 ### Writing a Linter
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hound
 
-[![Build Status](https://circleci.com/gh/thoughtbot/hound/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/hound/tree/master)
+[![Build Status](https://circleci.com/gh/houndci/hound.svg?style=svg)](https://circleci.com/gh/houndci/hound)
 [![Code Climate](https://codeclimate.com/repos/526ab75ff3ea007df603b773/badges/32cb8e64b2e265d8cad6/gpa.svg)](https://codeclimate.com/repos/526ab75ff3ea007df603b773/feed)
 [![Slack](http://slack.houndci.com/badge.svg)](http://slack.houndci.com)
 

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -1,18 +1,18 @@
 module ConfigurationHelper
   def ruby_config_url
-    config_url("thoughtbot/hound", "config/style_guides/ruby.yml")
+    config_url("houndci/hound", "config/style_guides/ruby.yml")
   end
 
   def coffeescript_config_url
-    config_url("thoughtbot/hound", "config/style_guides/coffeescript.json")
+    config_url("houndci/hound", "config/style_guides/coffeescript.json")
   end
 
   def javascript_config_url
-    config_url("thoughtbot/hound-jshint", "config/.jshintrc")
+    config_url("houndci/jshint", "config/.jshintrc")
   end
 
   def javascript_ignore_url
-    config_url("thoughtbot/hound", "config/style_guides/.jshintignore")
+    config_url("houndci/hound", "config/style_guides/.jshintignore")
   end
 
   def jscs_config_url
@@ -20,19 +20,19 @@ module ConfigurationHelper
   end
 
   def eslint_config_url
-    config_url("thoughtbot/hound-eslint", "config/.eslintrc")
+    config_url("houndci/eslint", "config/.eslintrc")
   end
 
   def scss_config_url
-    config_url("thoughtbot/hound-scss", "config/default.yml")
+    config_url("houndci/scss", "config/default.yml")
   end
 
   def haml_config_url
-    config_url("thoughtbot/hound", "config/style_guides/haml.yml")
+    config_url("houndci/hound", "config/style_guides/haml.yml")
   end
 
   def swift_config_url
-    config_url("thoughtbot/hound-swift", "config/default.yml")
+    config_url("houndci/swift", "config/default.yml")
   end
 
   private

--- a/app/views/application/_footer.haml
+++ b/app/views/application/_footer.haml
@@ -1,15 +1,15 @@
 %footer
   %ul.footer-nav
     %li
-      = link_to "Source Code", "https://github.com/thoughtbot/hound"
+      = link_to "Source Code", "https://github.com/houndci/hound"
     %li
       = link_to "FAQ", faq_path
     %li
-      = link_to "Terms", "https://github.com/thoughtbot/hound/blob/master/doc/TERMS.md"
+      = link_to "Terms", "https://github.com/houndci/hound/blob/master/doc/TERMS.md"
     %li
-      = link_to "Privacy", "https://github.com/thoughtbot/hound/blob/master/doc/PRIVACY.md"
+      = link_to "Privacy", "https://github.com/houndci/hound/blob/master/doc/PRIVACY.md"
     %li
-      = link_to "Security", "https://github.com/thoughtbot/hound/blob/master/doc/SECURITY.md"
+      = link_to "Security", "https://github.com/houndci/hound/blob/master/doc/SECURITY.md"
 
   %article.legal
     %p
@@ -21,7 +21,7 @@
     %p
       Hound is Copyright &copy; #{Date.today.year} thoughtbot. It is open source
       software and may be redistributed under the terms specified in the
-      #{link_to "LICENSE", "https://github.com/thoughtbot/hound/blob/master/LICENSE"}.
+      #{link_to "LICENSE", "https://github.com/houndci/hound/blob/master/LICENSE"}.
 
     %p
       The names and logos for Hound are trademarks of thoughtbot.

--- a/app/views/errors/500.haml
+++ b/app/views/errors/500.haml
@@ -6,7 +6,7 @@
 
 %p
   Feel free to
-  %a{ href: "https://github.com/thoughtbot/hound/issues" }
+  %a{ href: "https://github.com/houndci/hound/issues" }
     open an issue on GitHub
   to help us track down the error.
 

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -187,6 +187,6 @@
         access we need and why.
 
       .actions
-        = link_to "https://github.com/thoughtbot/hound/blob/master/doc/SECURITY.md",
+        = link_to "https://github.com/houndci/hound/blob/master/doc/SECURITY.md",
           target: "_blank", class: "security-policy" do
           %span Read our security policy

--- a/app/views/pages/faq.html.haml
+++ b/app/views/pages/faq.html.haml
@@ -63,7 +63,7 @@
       %p
         Please see our
         = link_to('security page.',
-          'https://github.com/thoughtbot/hound/blob/master/doc/SECURITY.md')
+          'https://github.com/houndci/hound/blob/master/doc/SECURITY.md')
 
 
     %article
@@ -72,7 +72,7 @@
         Not at the current time. A user has shared their method of getting it to
         work
         = link_to('here in this GitHub issue',
-          'https://github.com/thoughtbot/hound/issues/426')
+          'https://github.com/houndci/hound/issues/426')
         but it is not an officially supported approach.
 
     %article

--- a/doc/PRIVACY.md
+++ b/doc/PRIVACY.md
@@ -36,7 +36,7 @@ Source Code
 
 * Hound does not store GitHub credentials.
 
-* Hound&#8217;s [source code](https://github.com/thoughtbot/hound) is openly available. Browse the code and [email](mailto:hound@thoughtbot.com) us with questions.
+* Hound&#8217;s [source code](https://github.com/houndci/hound) is openly available. Browse the code and [email](mailto:hound@thoughtbot.com) us with questions.
 
 Disclosure
 ----------

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -9,7 +9,7 @@ Because [Hound is open source][oss],
 in this document we refer to portions of the application code and its dependent
 libraries, frameworks, and programming languages.
 
-[oss]: https://github.com/thoughtbot/hound
+[oss]: https://github.com/houndci/hound
 
 Vulnerability Reporting
 -----------------------

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -4,7 +4,7 @@ describe CommitStatus do
   describe "#set_pending" do
     it "sets the pending status on GithubApi" do
       github_api = stubbed_github_api(:create_pending_status)
-      repo_name = "thoughtbot/hound"
+      repo_name = "houndci/hound"
       sha = "abc123"
       token = "token"
       commit_status = CommitStatus.new(
@@ -26,7 +26,7 @@ describe CommitStatus do
   describe "#set_success" do
     it "sets the create success status on GithubApi" do
       github_api = stubbed_github_api(:create_success_status)
-      repo_name = "thoughtbot/hound"
+      repo_name = "houndci/hound"
       sha = "abc123"
       token = "token"
       violation_count = 5
@@ -49,7 +49,7 @@ describe CommitStatus do
   describe "#set_failure" do
     it "sets the error status for GithubApi" do
       github_api = stubbed_github_api(:create_error_status)
-      repo_name = "thoughtbot/hound"
+      repo_name = "houndci/hound"
       sha = "abc123"
       token = "token"
       violation_count = 5
@@ -72,7 +72,7 @@ describe CommitStatus do
   describe "#set_config_error" do
     it "sets the error status for GithubApi" do
       github_api = stubbed_github_api(:create_error_status)
-      repo_name = "thoughtbot/hound"
+      repo_name = "houndci/hound"
       sha = "abc123"
       token = "token"
       message = "invalid config"
@@ -96,7 +96,7 @@ describe CommitStatus do
   describe "#set_internal_error" do
     it "sets the error status for GithubApi" do
       github_api = stubbed_github_api(:create_error_status)
-      repo_name = "thoughtbot/hound"
+      repo_name = "houndci/hound"
       sha = "abc123"
       token = "token"
       commit_status = CommitStatus.new(

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -18,7 +18,7 @@ describe Repo do
     context "when repo is bulk" do
       it "returns true" do
         create(:bulk_customer, org: "thoughtbot")
-        repo = Repo.new(full_github_name: "thoughtbot/hound")
+        repo = Repo.new(full_github_name: "thoughtbot/hub")
 
         expect(repo).to be_bulk
       end

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -5,7 +5,7 @@ describe ReportInvalidConfig do
     context "given a custom message" do
       it "reports the file as an invalid config file to Github" do
         commit_status = stubbed_commit_status(:set_config_error)
-        stubbed_build(repo_name: "thoughtbot/hound")
+        stubbed_build(repo_name: "houndci/hound")
         pull_request_number = "42"
         commit_sha = "abc123"
         linter_name = "ruby"
@@ -29,7 +29,7 @@ describe ReportInvalidConfig do
     context "not given a custom message" do
       it "reports the file as an invalid config file to Github" do
         commit_status = stubbed_commit_status(:set_config_error)
-        stubbed_build(repo_name: "thoughtbot/hound")
+        stubbed_build(repo_name: "houndci/hound")
         pull_request_number = "42"
         commit_sha = "abc123"
         linter_name = "ruby"

--- a/spec/support/fixtures/config_contents.json
+++ b/spec/support/fixtures/config_contents.json
@@ -1,17 +1,17 @@
 {
   "_links": {
-    "git": "https://api.github.com/repos/thoughtbot/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
-    "html": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
-    "self": "https://api.github.com/repos/thoughtbot/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
+    "git": "https://api.github.com/repos/houndci/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
+    "html": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
+    "self": "https://api.github.com/repos/houndci/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
   },
   "content": "U3RyaW5nTGl0ZXJhbHM6CiAgRW5hYmxlZDogZmFsc2UK\n",
   "encoding": "base64",
-  "git_url": "https://api.github.com/repos/thoughtbot/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
-  "html_url": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
+  "git_url": "https://api.github.com/repos/houndci/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
+  "html_url": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
   "name": "unicorn.rb",
   "path": "config/unicorn.rb",
   "sha": "f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
   "size": 582,
   "type": "file",
-  "url": "https://api.github.com/repos/thoughtbot/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
+  "url": "https://api.github.com/repos/houndci/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
 }

--- a/spec/support/fixtures/contents.json
+++ b/spec/support/fixtures/contents.json
@@ -1,17 +1,17 @@
 {
   "_links": {
-    "git": "https://api.github.com/repos/thoughtbot/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
-    "html": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/.hound.yml",
-    "self": "https://api.github.com/repos/thoughtbot/hound/contents/.hound.yml?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
+    "git": "https://api.github.com/repos/houndci/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
+    "html": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/.hound.yml",
+    "self": "https://api.github.com/repos/houndci/hound/contents/.hound.yml?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
   },
   "content": "ZGVmIGJsYWgKICBwdXRzICJibGFoIgplbmQK\n",
   "encoding": "base64",
-  "git_url": "https://api.github.com/repos/thoughtbot/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
-  "html_url": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/.hound.yml",
+  "git_url": "https://api.github.com/repos/houndci/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
+  "html_url": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/.hound.yml",
   "name": ".hound.yml",
   "path": ".hound.yml",
   "sha": "f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
   "size": 582,
   "type": "file",
-  "url": "https://api.github.com/repos/thoughtbot/hound/contents/.hound.yml?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
+  "url": "https://api.github.com/repos/houndci/hound/contents/.hound.yml?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
 }

--- a/spec/support/fixtures/contents_with_violations.json
+++ b/spec/support/fixtures/contents_with_violations.json
@@ -1,17 +1,17 @@
 {
   "_links": {
-    "git": "https://api.github.com/repos/thoughtbot/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
-    "html": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
-    "self": "https://api.github.com/repos/thoughtbot/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
+    "git": "https://api.github.com/repos/houndci/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
+    "html": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
+    "self": "https://api.github.com/repos/houndci/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
   },
   "content": "ZGVmIHNvbWVfbWV0aG9kKCkgIAplbmQK\n",
   "encoding": "base64",
-  "git_url": "https://api.github.com/repos/thoughtbot/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
-  "html_url": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
+  "git_url": "https://api.github.com/repos/houndci/hound/git/blobs/f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
+  "html_url": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
   "name": "unicorn.rb",
   "path": "config/unicorn.rb",
   "sha": "f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
   "size": 582,
   "type": "file",
-  "url": "https://api.github.com/repos/thoughtbot/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
+  "url": "https://api.github.com/repos/houndci/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc"
 }

--- a/spec/support/fixtures/pull_request_comments.json
+++ b/spec/support/fixtures/pull_request_comments.json
@@ -1,6 +1,6 @@
 [
   {
-    "url": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195368",
+    "url": "https://api.github.com/repos/houndci/hound/pulls/comments/12195368",
     "id": 12195368,
     "diff_hunk": "@@ -15,6 +15,16 @@\n       end\n     end\n \n+    describe 'for single line conditional' do\n+      it 'returns no violations' do\n+        expect(violations_in(<<-CODE)).to eq []\n+if signed_in? then redirect_to dashboard_path end",
     "path": "spec/models/style_guide_spec.rb",
@@ -30,22 +30,22 @@
     "body": "inline if's and while's are not violations?",
     "created_at": "2014-05-01T16:57:49Z",
     "updated_at": "2014-05-01T17:17:03Z",
-    "html_url": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195368",
-    "pull_request_url": "https://api.github.com/repos/thoughtbot/hound/pulls/253",
+    "html_url": "https://github.com/houndci/hound/pull/253#discussion_r12195368",
+    "pull_request_url": "https://api.github.com/repos/houndci/hound/pulls/253",
     "_links": {
       "self": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195368"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/comments/12195368"
       },
       "html": {
-        "href": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195368"
+        "href": "https://github.com/houndci/hound/pull/253#discussion_r12195368"
       },
       "pull_request": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/253"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/253"
       }
     }
   },
   {
-    "url": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195668",
+    "url": "https://api.github.com/repos/houndci/hound/pulls/comments/12195668",
     "id": 12195668,
     "diff_hunk": "@@ -15,6 +15,16 @@\n       end\n     end\n \n+    describe 'for single line conditional' do\n+      it 'returns no violations' do\n+        expect(violations_in(<<-CODE)).to eq []\n+if signed_in? then redirect_to dashboard_path end",
     "path": "spec/models/style_guide_spec.rb",
@@ -75,22 +75,22 @@
     "body": "Can Rubocop detect `do_something if something`?",
     "created_at": "2014-05-01T17:05:09Z",
     "updated_at": "2014-05-01T17:17:03Z",
-    "html_url": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195668",
-    "pull_request_url": "https://api.github.com/repos/thoughtbot/hound/pulls/253",
+    "html_url": "https://github.com/houndci/hound/pull/253#discussion_r12195668",
+    "pull_request_url": "https://api.github.com/repos/houndci/hound/pulls/253",
     "_links": {
       "self": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195668"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/comments/12195668"
       },
       "html": {
-        "href": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195668"
+        "href": "https://github.com/houndci/hound/pull/253#discussion_r12195668"
       },
       "pull_request": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/253"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/253"
       }
     }
   },
   {
-    "url": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195672",
+    "url": "https://api.github.com/repos/houndci/hound/pulls/comments/12195672",
     "id": 12195672,
     "diff_hunk": "@@ -15,6 +15,16 @@\n       end\n     end\n \n+    describe 'for single line conditional' do\n+      it 'returns no violations' do\n+        expect(violations_in(<<-CODE)).to eq []\n+if signed_in? then redirect_to dashboard_path end",
     "path": "spec/models/style_guide_spec.rb",
@@ -120,22 +120,22 @@
     "body": "They are, but this change is to avoid suggesting them. I will follow up with a rule that comments on them or overrides the description from RuboCop to suggest what we prefer.",
     "created_at": "2014-05-01T17:05:22Z",
     "updated_at": "2014-05-01T17:17:03Z",
-    "html_url": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195672",
-    "pull_request_url": "https://api.github.com/repos/thoughtbot/hound/pulls/253",
+    "html_url": "https://github.com/houndci/hound/pull/253#discussion_r12195672",
+    "pull_request_url": "https://api.github.com/repos/houndci/hound/pulls/253",
     "_links": {
       "self": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195672"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/comments/12195672"
       },
       "html": {
-        "href": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195672"
+        "href": "https://github.com/houndci/hound/pull/253#discussion_r12195672"
       },
       "pull_request": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/253"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/253"
       }
     }
   },
   {
-    "url": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195842",
+    "url": "https://api.github.com/repos/houndci/hound/pulls/comments/12195842",
     "id": 12195842,
     "diff_hunk": "@@ -15,6 +15,16 @@\n       end\n     end\n \n+    describe 'for single line conditional' do\n+      it 'returns no violations' do\n+        expect(violations_in(<<-CODE)).to eq []\n+if signed_in? then redirect_to dashboard_path end",
     "path": "spec/models/style_guide_spec.rb",
@@ -165,17 +165,17 @@
     "body": "@gylaz, not sure yet. I think `IfUnlessModifier` will do it, but the description is way off and violates our guide. I'm planning on using that cop and changing the description, or creating our own, in a separate pull request.",
     "created_at": "2014-05-01T17:09:52Z",
     "updated_at": "2014-05-01T17:17:03Z",
-    "html_url": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195842",
-    "pull_request_url": "https://api.github.com/repos/thoughtbot/hound/pulls/253",
+    "html_url": "https://github.com/houndci/hound/pull/253#discussion_r12195842",
+    "pull_request_url": "https://api.github.com/repos/houndci/hound/pulls/253",
     "_links": {
       "self": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/comments/12195842"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/comments/12195842"
       },
       "html": {
-        "href": "https://github.com/thoughtbot/hound/pull/253#discussion_r12195842"
+        "href": "https://github.com/houndci/hound/pull/253#discussion_r12195842"
       },
       "pull_request": {
-        "href": "https://api.github.com/repos/thoughtbot/hound/pulls/253"
+        "href": "https://api.github.com/repos/houndci/hound/pulls/253"
       }
     }
   }

--- a/spec/support/fixtures/pull_request_files.json
+++ b/spec/support/fixtures/pull_request_files.json
@@ -1,13 +1,13 @@
 [
   {
     "additions": 22,
-    "blob_url": "https://github.com/thoughtbot/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
+    "blob_url": "https://github.com/houndci/hound/blob/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
     "changes": 22,
-    "contents_url": "https://api.github.com/repos/thoughtbot/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc",
+    "contents_url": "https://api.github.com/repos/houndci/hound/contents/config/unicorn.rb?ref=55ec63080d30509e148b78d50a2f39fb239c41bc",
     "deletions": 0,
     "filename": "config/unicorn.rb",
     "patch": "@@ -0,0 +1,22 @@\n+worker_processes Integer(ENV[\"WEB_CONCURRENCY\"] || 3)\n+timeout 15\n+preload_app true\n+\n+before_fork do |server, worker|\n+  Signal.trap 'TERM' do\n+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'\n+    Process.kill 'QUIT', Process.pid\n+  end\n+\n+  defined?(ActiveRecord::Base) and\n+    ActiveRecord::Base.connection.disconnect!\n+end\n+\n+after_fork do |server, worker|\n+  Signal.trap 'TERM' do\n+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'\n+  end\n+\n+  defined?(ActiveRecord::Base) and\n+    ActiveRecord::Base.establish_connection\n+end",
-    "raw_url": "https://github.com/thoughtbot/hound/raw/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
+    "raw_url": "https://github.com/houndci/hound/raw/55ec63080d30509e148b78d50a2f39fb239c41bc/config/unicorn.rb",
     "sha": "f6e59b8f27c8c5d92403f62b79cc1644c0fa2f73",
     "status": "added"
   }


### PR DESCRIPTION
* `thoughtbot` -> `houndci` rename.
* Take into accoun the `hound-` prefix removal.