### PR TITLE
Allow users to cancel orphaned, private repos

### DIFF
--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -8,7 +8,7 @@ class ReposController < ApplicationController
           current_user.repos.clear
         end
 
-        repos = current_user.repos_by_activation_ability.includes(:subscription)
+        repos = ReposWithMembershipOrSubscriptionQuery.new(current_user).run
 
         render json: repos
       end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -33,7 +33,8 @@ class SubscriptionsController < ApplicationController
   end
 
   def repo
-    @repo ||= current_user.repos.find(params.fetch(:repo_id))
+    @repo ||= current_user.repos.find_by(id: params.fetch(:repo_id)) ||
+      current_user.subscribed_repos.find(params.fetch(:repo_id))
   end
 
   def github_token

--- a/app/queries/repos_with_membership_or_subscription_query.rb
+++ b/app/queries/repos_with_membership_or_subscription_query.rb
@@ -1,0 +1,10 @@
+class ReposWithMembershipOrSubscriptionQuery
+  def initialize(user)
+    @user = user
+  end
+
+  def run
+    @user.subscribed_repos.includes(:subscription) |
+      @user.repos_by_activation_ability.includes(:subscription)
+  end
+end

--- a/app/serializers/repo_serializer.rb
+++ b/app/serializers/repo_serializer.rb
@@ -21,6 +21,20 @@ class RepoSerializer < ActiveModel::Serializer
   end
 
   def admin
-    object.memberships.find_by(user_id: current_user.id).admin?
+    has_admin_membership? || has_subscription?
+  end
+
+  private
+
+  def membership
+    @membership ||= object.memberships.find_by(user_id: current_user.id)
+  end
+
+  def has_admin_membership?
+    membership.present? && membership.admin?
+  end
+
+  def has_subscription?
+    current_user.subscribed_repos.include?(object)
   end
 end

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -18,12 +18,10 @@ class RepoActivator
   end
 
   def deactivate
-    change_repository_state_quietly do
-      if repo.private?
-        remove_hound_from_repo
-      end
-
-      delete_webhook && repo.deactivate
+    if skip_github?
+      repo.deactivate
+    else
+      deactivate_with_github
     end
   end
 
@@ -37,6 +35,24 @@ class RepoActivator
     add_error(error)
     Raven.capture_exception(error)
     false
+  end
+
+  def skip_github?
+    repo.subscription.present? && missing_membership?
+  end
+
+  def missing_membership?
+    Membership.where(repo: repo, user: repo.subscription.user).empty?
+  end
+
+  def deactivate_with_github
+    change_repository_state_quietly do
+      if repo.private?
+        remove_hound_from_repo
+      end
+
+      delete_webhook && repo.deactivate
+    end
   end
 
   def remove_hound_from_repo

--- a/spec/features/user_deactivates_a_repo_spec.rb
+++ b/spec/features/user_deactivates_a_repo_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+feature "user deactivates a repo", js: true do
+  context "when the user has a subscription" do
+    context "when the user does not have a membership" do
+      scenario "successfully deactiavtes the repo" do
+        token = "letmein"
+        user = create(:user, token_scopes: "public_repo,user:email")
+        repo = create(:repo, :active, private: true)
+        create(:subscription, user: user, repo: repo)
+        gateway_subscription = instance_double(
+          PaymentGatewaySubscription,
+          unsubscribe: true,
+        )
+        payment_gateway_customer = instance_double(
+          PaymentGatewayCustomer,
+          retrieve_subscription: gateway_subscription,
+        )
+        allow(PaymentGatewayCustomer).to receive(:new).and_return(
+          payment_gateway_customer
+        )
+
+        sign_in_as(user, token)
+        find(".repos .toggle").click
+
+        expect(page).not_to have_css(".active")
+
+        visit current_path
+
+        expect(page).not_to have_selector(".repo")
+      end
+    end
+  end
+end

--- a/spec/queries/repos_with_membership_or_subscription_query_spec.rb
+++ b/spec/queries/repos_with_membership_or_subscription_query_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe ReposWithMembershipOrSubscriptionQuery do
+  describe "#run" do
+    context "when user is not a member of a repo but has a subscription" do
+      it "includes the orphaned repo" do
+        subscribed_repo = create(:repo, private: true)
+        user = create(:user)
+        create(:subscription, user: user, repo: subscribed_repo)
+
+        repos = ReposWithMembershipOrSubscriptionQuery.new(user).run
+
+        expect(repos).to include(subscribed_repo)
+      end
+    end
+
+    it "does not duplicate subscribed repos" do
+      user = create(:user)
+      subscribed_repo = create(:repo, private: true)
+      user.repos << subscribed_repo
+      create(:subscription, user: user, repo: subscribed_repo)
+
+      repos = ReposWithMembershipOrSubscriptionQuery.new(user).run
+
+      expect(repos).to eq [subscribed_repo]
+    end
+  end
+end

--- a/spec/serializers/repo_serializer_spec.rb
+++ b/spec/serializers/repo_serializer_spec.rb
@@ -27,5 +27,36 @@ describe RepoSerializer do
         expect(serializer.admin).to eq false
       end
     end
+
+    context "when the current user is not a member of the repo" do
+      context "and does not have a subscription for the repo" do
+        it "returns false" do
+          user = create(:user)
+          repo = create(:repo)
+          serializer = RepoSerializer.new(
+            repo,
+            scope: user,
+            scope_name: :current_user,
+          )
+
+          expect(serializer.admin).to eq false
+        end
+      end
+
+      context "and has a subscription for the repo" do
+        it "returns true" do
+          user = create(:user)
+          repo = create(:repo)
+          create(:subscription, user: user, repo: repo)
+          serializer = RepoSerializer.new(
+            repo,
+            scope: user,
+            scope_name: :current_user,
+          )
+
+          expect(serializer.admin).to eq true
+        end
+      end
+    end
   end
 end

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -256,6 +256,32 @@ describe RepoActivator do
         expect(api).to have_received(:remove_collaborator).
           with(repo.full_github_name, Hound::GITHUB_USERNAME)
       end
+
+      context "when the subscribed user does not have a membership" do
+        it "deactivates the repo" do
+          user = create(:user)
+          repo = create(:repo, :active, private: true)
+          create(:subscription, user: user, repo: repo)
+          activator = build_activator(repo: repo)
+
+          activator.deactivate
+
+          expect(repo.reload).not_to be_active
+        end
+
+        it "does not interact with GitHub" do
+          user = create(:user)
+          repo = create(:repo, :active, private: true)
+          create(:subscription, user: user, repo: repo)
+          activator = build_activator(repo: repo)
+          api = stub_github_api
+
+          activator.deactivate
+
+          expect(api).not_to have_received(:remove_collaborator)
+          expect(api).not_to have_received(:remove_hook)
+        end
+      end
     end
 
     context "when repo deactivation succeeds" do


### PR DESCRIPTION
If a user has activated a private repo then loses access to it on
GitHub, they cannot deactivate the repo in Hound and Hound continues to
charge their credit card. This change includes repos in this state in
the user's repo list, so they can deactivate it.

* Adds the `OrphanedAndMembershipReposQuery` query object, which
  returns repos that a user has a membership and/or subscription for.
* Updates the repo list to include repos that have a subscription but not
  a membership.
* Updates `RepoSubscriber#unsubscribe` to only remove the Hound user
  and webhook if the user has a membership for that repo (meaning they
  have access (probably)).

https://trello.com/c/cb3EUNVC