### PR TITLE
Update configuration.haml for #scss exclude example

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -302,9 +302,8 @@
 
         %code.code-block
           :preserve
-            scss:
-              exclude:
-                - "app/assets/stylesheets/plugins/**"
+            exclude:
+              - "app/assets/stylesheets/plugins/**"
 
       %p
         Add the following code to your


### PR DESCRIPTION
I tried the existing example for #scss exclusion, and it doesn't seem to work. If I remove the `scss:` line in the `.scss-style.yml` file, it does work. Cross-confirmed with an example in the linter documentation:

https://github.com/brigade/scss-lint#configuration

Discussion and :+1: in this thread: https://github.com/houndci/hound/issues/1018#issuecomment-186394304

Please merge accordingly if things look good. Cheers!