### PR TITLE
Rescue parse error of inherited RuboCop configs

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -3,9 +3,7 @@ module Config
     attr_reader_initialize :hound_config, :linter_name
 
     def content
-      @content ||= parse(load_content)
-    rescue JSON::ParserError, Psych::Exception => exception
-      raise_parse_error(exception.message)
+      @content ||= ensure_correct_type(safe_parse(load_content))
     end
 
     def excluded_files
@@ -24,16 +22,22 @@ module Config
 
     attr_implement :parse, [:file_content]
 
-    def ensure_correct_type(result)
-      if result.is_a? Hash
-        result
+    def safe_parse(content)
+      parse(content)
+    rescue JSON::ParserError, Psych::Exception => exception
+      raise_parse_error(exception.message)
+    end
+
+    def ensure_correct_type(config)
+      if config.is_a? Hash
+        config
       else
         raise_type_error
       end
     end
 
     def raise_type_error
-      raise_parse_error("`#{file_path}` must be a Hash")
+      raise_parse_error(%{"#{file_path}" must be a Hash})
     end
 
     def load_content

--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -10,9 +10,7 @@ module Config
     private
 
     def parse(file_content)
-      result = Parser.json(file_content)
-
-      ensure_correct_type(result)
+      Parser.json(file_content)
     end
   end
 end

--- a/app/models/config/haml.rb
+++ b/app/models/config/haml.rb
@@ -3,9 +3,7 @@ module Config
     private
 
     def parse(file_content)
-      result = Parser.yaml(file_content)
-
-      ensure_correct_type(result)
+      Parser.yaml(file_content)
     end
   end
 end

--- a/app/models/config/python.rb
+++ b/app/models/config/python.rb
@@ -1,7 +1,7 @@
 module Config
   class Python < Base
     def content
-      @content ||= super || default_content
+      @content ||= super.presence || default_content
     end
 
     def serialize(data = content)
@@ -11,7 +11,7 @@ module Config
     private
 
     def parse(file_content)
-      Parser.ini(file_content).presence
+      Parser.ini(file_content)
     end
 
     def default_content

--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -4,9 +4,7 @@ module Config
       if legacy?
         hound_config.content
       else
-        result = super
-        ensure_correct_type(result)
-        parse_inherit_from(result)
+        parse_inherit_from(super)
       end
     end
 
@@ -21,7 +19,7 @@ module Config
 
       inherited_config = inherit_from.reduce({}) do |result, ancestor_file_path|
         raw_ancestor_config = commit.file_content(ancestor_file_path)
-        ancestor_config = parse(raw_ancestor_config) || {}
+        ancestor_config = safe_parse(raw_ancestor_config) || {}
         result.merge(ancestor_config)
       end
 

--- a/spec/models/config/base_spec.rb
+++ b/spec/models/config/base_spec.rb
@@ -12,7 +12,7 @@ class Config::Test < Config::Base
   private
 
   def parse(file_content)
-    file_content
+    YAML.load(file_content)
   end
 end
 
@@ -28,16 +28,17 @@ describe Config::Base do
 
     context "when there is no specified filepath" do
       it "returns a default value" do
-        hound_config = double(
+        config_content = {}
+        hound_config = instance_double(
           "HoundConfig",
           commit: double("Commit"),
           content: {
-            "test" => {},
+            "test" => config_content,
           },
         )
         config = build_config(hound_config: hound_config)
 
-        expect(config.content).to eq("{}")
+        expect(config.content).to eq(config_content)
       end
     end
 
@@ -57,16 +58,12 @@ describe Config::Base do
             LineLength:
               Max: 90
           EOS
-          stub_request(
-            :get,
-            "http://example.com/rubocop.yml",
-          ).to_return(
-            status: 200,
-            body: response,
-          )
+          parsed_result = { "LineLength" => { "Max" => 90 } }
+          stub_request(:get, "http://example.com/rubocop.yml").
+            to_return(status: 200, body: response)
           config = build_config(hound_config: hound_config)
 
-          expect(config.content).to eq response
+          expect(config.content).to eq parsed_result
         end
       end
 

--- a/spec/models/config/haml_spec.rb
+++ b/spec/models/config/haml_spec.rb
@@ -36,7 +36,7 @@ describe Config::Haml do
 
           expect { config.content }.to raise_error(
             Config::ParserError,
-            %r(`config/haml\.yml` must be a Hash),
+            %r("config/haml\.yml" must be a Hash),
           )
         end
       end

--- a/spec/models/config/python_spec.rb
+++ b/spec/models/config/python_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 require "app/models/config/base"
 require "app/models/config/python"
 require "app/models/config/parser"
+require "app/models/config/parser_error"
 require "app/models/config/serializer"
 require "inifile"
 

--- a/spec/models/config/ruby_spec.rb
+++ b/spec/models/config/ruby_spec.rb
@@ -89,9 +89,7 @@ describe Config::Ruby do
           Style/Encoding:
             Enabled: true
         EOS
-        rubocop_todo = <<-EOS.strip_heredoc
-          # this is an empty file
-        EOS
+        rubocop_todo = "# this is an empty file"
         commit = stubbed_commit(
           "config/rubocop.yml" => rubocop,
           "config/rubocop_todo.yml" => rubocop_todo,
@@ -103,21 +101,31 @@ describe Config::Ruby do
         )
       end
     end
+
+    context "with invalid `inherit_from` content" do
+      it "raises a parser error" do
+        rubocop = "inherit_from: config/rubocop_todo.yml"
+        rubocop_todo = "foo: bar: "
+        commit = stubbed_commit(
+          "config/rubocop.yml" => rubocop,
+          "config/rubocop_todo.yml" => rubocop_todo,
+        )
+        config = build_config(commit)
+
+        expect { config.content }.to raise_error(Config::ParserError)
+      end
+    end
   end
 
   context "when the given content is invalid" do
     context "when the result is not a hash" do
       it "raises a type exception" do
-        commit = stubbed_commit(
-          "config/rubocop.yml" => <<-EOS.strip_heredoc
-            !
-          EOS
-        )
+        commit = stubbed_commit("config/rubocop.yml" => "[]")
         config = build_config(commit)
 
         expect { config.content }.to raise_error(
           Config::ParserError,
-          %r(`config/rubocop.yml` must be a Hash),
+          %r("config/rubocop\.yml" must be a Hash),
         )
       end
     end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -146,13 +146,15 @@ describe StyleChecker do
 
       context "when Eslint is enabled" do
         it "creates violations" do
+          hound_config_content = <<-EOS.strip_heredoc
+            eslint:
+              enabled: true
+              config_file: config/.eslintrc
+          EOS
           commit_file = stub_commit_file("test.js", "var test = 'test'")
           head_commit = stub_head_commit(
-            HoundConfig::CONFIG_FILE => <<-EOS.strip_heredoc
-              eslint:
-                enabled: true
-                config_file: config/.eslintrc
-            EOS
+            HoundConfig::CONFIG_FILE => hound_config_content,
+            "config/.eslintrc" => "{}",
           )
           pull_request = stub_pull_request(
             commit_files: [commit_file],
@@ -167,13 +169,15 @@ describe StyleChecker do
 
       context "when JSCS is enabled" do
         it "creates violations" do
+          hound_config_content = <<-EOS.strip_heredoc
+            jscs:
+              enabled: true
+              config_file: config/.jscsrc
+          EOS
           commit_file = stub_commit_file("test.js", "var test = 'test'")
           head_commit = stub_head_commit(
-            HoundConfig::CONFIG_FILE => <<-EOS.strip_heredoc
-              jscs:
-                enabled: true
-                config_file: config/.jscsrc
-            EOS
+            HoundConfig::CONFIG_FILE => hound_config_content,
+            "config/.jscsrc" => "{}",
           )
           pull_request = stub_pull_request(
             commit_files: [commit_file],


### PR DESCRIPTION
We were getting errors because we weren't handling potential errors from
parsing the `inherit_from` files.

Restructure code to make it harder to make this mistake in the future.