### PR TITLE
Remove comments from ESLint config file

### DIFF
--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -7,7 +7,9 @@ module Config
     private
 
     def parse(file_content)
-      Parser.yaml(file_content)
+      json_with_comments = JsonWithComments.new(file_content)
+      content_without_comments = json_with_comments.without_comments
+      Parser.yaml(content_without_comments)
     end
 
     def default_content

--- a/app/models/config/json_with_comments.rb
+++ b/app/models/config/json_with_comments.rb
@@ -1,0 +1,56 @@
+module Config
+  class JsonWithComments
+    SINGLE_LINE_COMMENT = 1
+    MULTI_LINE_COMMENT = 2
+
+    attr_private_initialize :content
+
+    def without_comments
+      inside_comment = false
+      inside_string = false
+      result = ""
+      offset = 0
+
+      content.each_char.with_index do |current_char, index|
+        next_char = content[index + 1]
+        fragment = "#{current_char}#{next_char}"
+
+        if !inside_comment && current_char == '"'
+          escaped = content[index - 1] == '\\' && content[index - 2] != '\\'
+
+          unless escaped
+            inside_string = !inside_string
+          end
+        end
+
+        unless inside_string
+          if !inside_comment
+            if fragment == "//"
+              result << content[offset...index].gsub(/\s*$/, "")
+              offset = index
+              inside_comment = SINGLE_LINE_COMMENT
+            elsif fragment == "/*"
+              result << content[offset...index]
+              offset = index
+              inside_comment = MULTI_LINE_COMMENT
+            end
+          elsif inside_comment == SINGLE_LINE_COMMENT
+            if current_char == "\n"
+              inside_comment = false
+              offset = index
+            end
+          elsif inside_comment == MULTI_LINE_COMMENT && fragment == "*/"
+            inside_comment = false
+            offset = index + 3
+          end
+        end
+      end
+
+      if inside_comment
+        result
+      else
+        "#{result}#{content[offset..-1]}"
+      end
+    end
+  end
+end

--- a/spec/models/config/eslint_spec.rb
+++ b/spec/models/config/eslint_spec.rb
@@ -2,7 +2,9 @@ require "spec_helper"
 require "app/models/config/base"
 require "app/models/config/eslint"
 require "app/models/config/parser"
+require "app/models/config/parser_error"
 require "app/models/config/serializer"
+require "app/models/config/json_with_comments"
 require "yaml"
 
 describe Config::Eslint do
@@ -16,6 +18,21 @@ describe Config::Eslint do
       config = build_config(commit)
 
       expect(config.content).to eq("rules" => { "quotes" => [2, "double"] })
+    end
+
+    context "when configuration is linter-flavored JSON format" do
+      it "parses the configuration" do
+        raw_config = <<-EOS.strip_heredoc
+          {
+            "foo": 1, // eslint JSON flavor can have comments
+            "bar": 2,
+          }
+        EOS
+        commit = stubbed_commit("config/.eslintrc" => raw_config)
+        config = build_config(commit)
+
+        expect(config.content).to eq("foo" => 1, "bar" => 2)
+      end
     end
   end
 

--- a/spec/models/config/json_with_comments_spec.rb
+++ b/spec/models/config/json_with_comments_spec.rb
@@ -1,0 +1,51 @@
+require "app/models/config/json_with_comments"
+
+describe Config::JsonWithComments do
+  describe "#without_comments" do
+    context "with mixed comments" do
+      it "returns raw JSON content without comments" do
+        config = <<-TEXT.strip_heredoc
+          /* start
+            of
+            file */
+          {
+            "foo": 1, // comments here
+            "bar": 2,
+            "baz": "// hello", // more comments
+          }
+          /* end of file */
+        TEXT
+
+        result = described_class.new(config).without_comments
+
+        expect(result).to eq <<-TEXT.strip_heredoc
+          {
+            "foo": 1,
+            "bar": 2,
+            "baz": "// hello",
+          }
+        TEXT
+      end
+    end
+
+    context "with single line comments" do
+      it "returns raw JSON content without comments" do
+        config = <<-TEXT.strip_heredoc
+          {
+            "foo": 1, // comments here
+            "bar": 2,
+          }
+        TEXT
+
+        result = described_class.new(config).without_comments
+
+        expect(result).to eq <<-TEXT.strip_heredoc
+          {
+            "foo": 1,
+            "bar": 2,
+          }
+        TEXT
+      end
+    end
+  end
+end


### PR DESCRIPTION
ESLint supports a custom JSON format that allows comments.
Neither Ruby's YAML nor JSON can parse that, so we need to remove the
comments before we attempt parsing.

The algorithm was borrowed from
`https://github.com/sindresorhus/strip-json-comments`, which is what
ESLint leverages. [Source](https://github.com/sindresorhus/strip-json-comments/blob/dcc8c7e399ce9ecf4b96aa277a732033fe9dc83a/index.js)