### PR TITLE
Add script to show what isn't on production

### DIFF
--- a/bin/production-status
+++ b/bin/production-status
@@ -1,0 +1,34 @@
+#!/usr/bin/env ruby --disable-gems
+
+require "pathname"
+
+parent_directory = File.expand_path("../../..", __FILE__)
+Dir.chdir(parent_directory)
+child_directories = `ls -d */`.split
+git_directories = child_directories.select do |child_directory|
+  Dir.exists?(File.join(child_directory, ".git"))
+end
+
+git_directories.each do |git_directory|
+  puts git_directory
+
+  Dir.chdir(File.join(parent_directory, git_directory))
+  remotes = `git remote`.split
+
+  if remotes.include?("origin") && remotes.include?("production")
+    `git fetch origin > /dev/null`
+    `git fetch production > /dev/null`
+
+    commits_not_on_production = `git log --graph --pretty='format:%C(yellow)%h %C(green)%ar %C(cyan)%an %C(reset)%s' production/master..origin/master`
+    if commits_not_on_production.empty?
+      puts "up-to-date!"
+    else
+      puts commits_not_on_production
+    end
+  else
+    missing_remotes = %w{origin production} - remotes
+    puts "missing remotes: #{missing_remotes.join(", ")}"
+  end
+
+  puts
+end


### PR DESCRIPTION
The goal is to get a bird's eye view of what needs to be deployed to
production.

The script assumes all of the hound related repositories are in the same
directory as the main one (this one). It loops over them and attempts to
compare production/master to origin/master, showing the results.

![production-status](https://cloud.githubusercontent.com/assets/72176/13542393/55def720-e217-11e5-810d-dd0f8cfdd8e2.png)
