### PR TITLE
Use info log level in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Houndapp::Application.configure do
   # config.force_ssl = true
 
   # See everything in the log (default is :info)
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
At some point, Rails changed the default log level when generating a new
app to `debug`. When we upgraded to that version, we started [seeing
warnings][1] about the missing config value, so we went with `debug` to
match the default.

This has resulted in our production logs being filled with SQL queries
that are not useful to us there, making it difficult to find other
information and exhausting our Papertrail quota.

This changes the production log level to `info`, to cut down on our log
size.

[1]: https://github.com/houndci/hound/commit/5e0aedf4feb28daafdb272178861a259b642d301