### PR TITLE
Configure operator indentation for thoughtbot

### DIFF
--- a/config/style_guides/thoughtbot/ruby.yml
+++ b/config/style_guides/thoughtbot/ruby.yml
@@ -361,5 +361,10 @@ Style/MultilineBlockChain:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
   Enabled: false
 
+Style/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span multiple lines.
+  Enabled: true
+  EnforcedStyle: indented
+
 Metrics/AbcSize:
   Enabled: false


### PR DESCRIPTION
Splitting continuous line at the operator, causes Hound to find a
violation. RuboCop's default is to align the operators, but we want the
next line to be indented one extra level.