### PR TITLE
Don't rescue Octokit::NotFound when setting status

### DIFF
--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -143,7 +143,5 @@ class GithubApi
       description: description,
       target_url: target_url
     )
-  rescue Octokit::NotFound
-    # noop
   end
 end

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -231,23 +231,6 @@ describe GithubApi do
 
       expect(request).to have_been_requested
     end
-
-    describe "when setting the status returns 404" do
-      it "does not crash" do
-        sha = "abc"
-        api = GithubApi.new(Hound::GITHUB_TOKEN)
-        stub_failed_status_creation_request(
-          full_repo_name,
-          sha,
-          "pending",
-          "description"
-        )
-
-        expect do
-          api.create_pending_status(full_repo_name, sha, "description")
-        end.not_to raise_error
-      end
-    end
   end
 
   describe "#create_success_status" do

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -76,24 +76,6 @@ module GithubApiHelper
     )
   end
 
-  def stub_failed_status_creation_request(repo_name, sha, state, description)
-    stub_request(
-      :post,
-      "https://api.github.com/repos/#{repo_name}/statuses/#{sha}"
-    ).with(
-      headers: { "Authorization" => "token #{hound_token}" },
-      body: {
-        context: "hound",
-        description: description,
-        state: state,
-        target_url: nil
-      }
-    ).to_return(
-      status: 404,
-      headers: { "Content-Type" => "application/json; charset=utf-8" }
-    )
-  end
-
   def stub_hook_removal_request(full_repo_name, hook_id)
     url = "https://api.github.com/repos/#{full_repo_name}/hooks/#{hook_id}"
     stub_request(:delete, url).


### PR DESCRIPTION
Introduced in e9836eea64baefb0699952c5f35fd65a9ca2df41, the logic was in
regard to adding Hound user to teams. Since, we are not doing that
anymore this is not longer relevant to the original problem.

Currently, there is an issue where we choose a user token to handle the
repo, since a repo could be public, the user's token will work for
processing the build/review.
But, it will fail silently when it tries to set the status. This is the
cause of the GitHub status sometimes not being set, a token that was
picked does not have status setting privileges.
If we raise, the pending status will fail and the job will retry using a
new token.