### PR TITLE
Remove incorrect default content for ESLint

### DIFF
--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -11,9 +11,5 @@ module Config
       content_without_comments = json_with_comments.without_comments
       Parser.yaml(content_without_comments)
     end
-
-    def default_content
-      {}
-    end
   end
 end


### PR DESCRIPTION
`default_content` should be a string, which it is in `Base`.