### PR TITLE
Add file_reviews.linter_name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,16 +150,18 @@ Resque queue.
 
 Linter jobs are created with the following arguments:
 
+* `commit_sha` - The git commit SHA of the code snippet. This should be passed
+  through to the outbound queue.
 * `config` - The configuration for the linter. This will be linter specific.
 * `content` - The source code to check for violations.
 * `filename` - The name of the source file for the code snippet. This should be
   passed through to the outbound queue.
-* `commit_sha` - The git commit SHA of the code snippet. This should be passed
-  through to the outbound queue.
-* `pull_request_number` - The GitHub pull request number. This should be passed
-  through to the outbound queue.
+* `linter_name` - A string that identifies which linter is assigned to this
+  linter job. This must be passed through to the outbound queue unmodified.
 * `patch` - The patch content from GitHub for the file being reviewed. This
   should be passed through to the outbound queue.
+* `pull_request_number` - The GitHub pull request number. This should be passed
+  through to the outbound queue.
 
 Once linting is complete, resulting violations should be posted to the outbound
 "CompletedFileReviewJob" queue:
@@ -173,8 +175,8 @@ Once linting is complete, resulting violations should be posted to the outbound
   provided by the inbound queue.
 * `commit_sha` - The git commit SHA of the code snippet. This is provided by the
   inbound queue.
-* `pull_request_number` - The GitHub pull request number. This is provided by the
-  inbound queue.
+* `linter_name` - A string that identifies which linter is assigned to this
+  linter job. This is provided by the inbound queue.
 * `patch` - The patch content from GitHub for the file being reviewed. This is
   provided by the inbound queue.
 

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -15,6 +15,7 @@ module Linter
       file_review = FileReview.create!(
         build: build,
         filename: commit_file.filename,
+        linter_name: name,
       )
 
       enqueue_job(attributes)
@@ -44,6 +45,7 @@ module Linter
         config: config.serialize,
         content: commit_file.content,
         filename: commit_file.filename,
+        linter_name: name,
         patch: commit_file.patch,
         pull_request_number: build.pull_request_number,
       }

--- a/app/models/linter/coffee_script.rb
+++ b/app/models/linter/coffee_script.rb
@@ -6,7 +6,10 @@ module Linter
     FILE_REGEXP = /.+\.coffee(\.js)?(\.erb)?\z/
 
     def file_review(commit_file)
-      FileReview.create!(filename: commit_file.filename) do |file_review|
+      FileReview.create!(
+        filename: commit_file.filename,
+        linter_name: name,
+      ) do |file_review|
         content = content_for_file(commit_file)
 
         lint(content).each do |violation|

--- a/app/models/linter/haml.rb
+++ b/app/models/linter/haml.rb
@@ -7,7 +7,10 @@ module Linter
     def file_review(commit_file)
       @commit_file = commit_file
 
-      FileReview.create!(filename: commit_file.filename) do |file_review|
+      FileReview.create!(
+        filename: commit_file.filename,
+        linter_name: name,
+      ) do |file_review|
         run_linters.map do |violation|
           line = commit_file.line_at(violation.line)
 

--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -15,7 +15,10 @@ module Linter
     private
 
     def perform_file_review(commit_file)
-      FileReview.create!(filename: commit_file.filename) do |file_review|
+      FileReview.create!(
+        filename: commit_file.filename,
+        linter_name: name,
+      ) do |file_review|
         permitted_rubocop_offenses(commit_file).each do |violation|
           line = commit_file.line_at(violation.line)
           file_review.build_violation(line, violation.message)

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -47,8 +47,21 @@ class CompleteFileReview
   end
 
   def file_review
-    @file_review ||= build.file_reviews.
-      find_by!(filename: attributes.fetch("filename"))
+    @file_review ||= build.file_reviews.find_by!(file_review_properties)
+  end
+
+  def file_review_properties
+    if attributes.has_key?("linter_name")
+      legacy_file_review_search_properties.merge(
+        linter_name: attributes.fetch("linter_name"),
+      )
+    else
+      legacy_file_review_search_properties
+    end
+  end
+
+  def legacy_file_review_search_properties
+    { filename: attributes.fetch("filename") }
   end
 
   def commit_file

--- a/db/migrate/20160314122828_add_linter_name_to_file_reviews.rb
+++ b/db/migrate/20160314122828_add_linter_name_to_file_reviews.rb
@@ -1,0 +1,9 @@
+class AddLinterNameToFileReviews < ActiveRecord::Migration
+  def up
+    add_column :file_reviews, :linter_name, :string
+  end
+
+  def down
+    remove_column :file_reviews, :linter_name
+  end
+end

--- a/db/migrate/20160430171015_backfill_linter_names_add_null_constraint.rb
+++ b/db/migrate/20160430171015_backfill_linter_names_add_null_constraint.rb
@@ -1,0 +1,35 @@
+class BackfillLinterNamesAddNullConstraint < ActiveRecord::Migration
+  def up
+    sql = <<-SQL
+      UPDATE file_reviews
+      SET linter_name = CASE
+        WHEN filename ~* '\\.coffee(\\.js)?(\\.erb)?\\Z' THEN 'coffee_script'
+        WHEN filename ~* '\\.go\\Z' THEN 'go'
+        WHEN filename ~* '\\.haml\\Z' THEN 'haml'
+        WHEN filename ~* '(\\.es6|\\.es6\\.js)\\Z' THEN 'eslint'
+        WHEN filename ~* '\\.js\\Z' THEN 'jshint'
+        WHEN filename ~* '(\\.md|\\.markdown)\\Z' THEN 'remark'
+        WHEN filename ~* '\\.py\\Z' THEN 'python'
+        WHEN filename ~* '\\.rb\\Z' THEN 'ruby'
+        WHEN filename ~* '\\.scss\\Z' THEN 'scss'
+        WHEN filename ~* '\\.swift\\Z' THEN 'swift'
+        ELSE 'unsupported'
+        END;
+    SQL
+
+    execute(sql)
+
+    change_column_null :file_reviews, :linter_name, false
+  end
+
+  def down
+    change_column_null :file_reviews, :linter_name, true
+
+    sql = <<-SQL
+      UPDATE file_reviews
+      SET linter_name = null;
+    SQL
+
+    execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 20160513002940) do
     t.datetime "created_at",   null: false
     t.datetime "updated_at",   null: false
     t.string   "filename",     null: false
+    t.string   "linter_name",  null: false
   end
 
   add_index "file_reviews", ["build_id"], name: "index_file_reviews_on_build_id", using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     build
 
     filename "the_thing.rb"
+    linter_name "ruby"
   end
 
   factory :repo do

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -59,6 +59,7 @@ describe Linter::Eslint do
         EslintReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "eslint",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -42,6 +42,7 @@ describe Linter::Go do
         GoReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "go",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/models/linter/jscs_spec.rb
+++ b/spec/models/linter/jscs_spec.rb
@@ -59,6 +59,7 @@ describe Linter::Jscs do
         JscsReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "jscs",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -93,6 +93,7 @@ describe Linter::Jshint do
         JshintReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "jshint",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/models/linter/python_spec.rb
+++ b/spec/models/linter/python_spec.rb
@@ -47,6 +47,7 @@ describe Linter::Python do
           args: [
             filename: commit_file.filename,
             commit_sha: build.commit_sha,
+            linter_name: "python",
             pull_request_number: build.pull_request_number,
             patch: commit_file.patch,
             content: commit_file.content,

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -51,6 +51,7 @@ describe Linter::Remark do
         RemarkReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "remark",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/models/linter/scss_spec.rb
+++ b/spec/models/linter/scss_spec.rb
@@ -43,6 +43,7 @@ describe Linter::Scss do
         ScssReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "scss",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/models/linter/swift_spec.rb
+++ b/spec/models/linter/swift_spec.rb
@@ -43,6 +43,7 @@ describe Linter::Swift do
         SwiftReviewJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
+        linter_name: "swift",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,


### PR DESCRIPTION
[Related Github issue](https://github.com/houndci/hound/issues/1101)

Generally speaking, for any given language, Hound supports only one linter. For
example, Rubocop will handle all `.rb` files; SCSS-lint will lint `.scss` files
and so on.

And then there's JavaScript.

For JavaScript, Hound supports three linters: JShint, JSCS, and ESlint,
each of which can be individually enabled or disabled. If both JShint and
JSCS are enabled, however, Hound code reviews will never complete for a given
build, and this is because `CompleteFileReivew#file_review` will only look up
a `FileReview` by its `filename` attribute, and when multiple linters are
working on a single file, that is not enough information. The second through nth
`FileReivew` for that file never gets found, and its `completed_at` never gets
updated. When that happens, `Build#complete?` always returns false.

This change creates a migration that adds a new column to the `file_reviews`
table, which will store the name of the linter assigned to a given file review.
The corresponding `FileReview` model will acquire a model-level validation to
ensure the presence of this new linter-name attribute.

It then updates `Linter::Base#enqueue_job` to add the linter_name attribute to
the hash of review-job attributes so that linters can pick up this new
attribute. When their reviews are complete, the linters can be configured to
pass the linter name back to Hound, along with any errors and the filename, just
as before.

The last part of this solution involves updating
`CompleteFileReview#file_review` to anticipate an optional `linter_name`
attribute in its dequeued job attributes, which it will use to perform a more
precise search of `FileReview` objects in the relevant build. In order to avoid
a large coordinated upgrade effort, this method will fall back to the previous
locator logic, which only operates on the job's `filename` attribute.