### PR TITLE
Set JSCS default config as string, not hash

### DIFF
--- a/app/models/config/jscs.rb
+++ b/app/models/config/jscs.rb
@@ -9,9 +9,5 @@ module Config
     def parse(file_content)
       Parser.yaml(file_content)
     end
-
-    def default_content
-      {}
-    end
   end
 end

--- a/spec/models/config/jscs_spec.rb
+++ b/spec/models/config/jscs_spec.rb
@@ -18,7 +18,7 @@ describe Config::Jscs do
   end
 
   describe "#serialize" do
-    it "serializes the parsed content into YAML" do
+    it "serializes the parsed content into JSON" do
       raw_config = <<-EOS.strip_heredoc
         { "disallowKeywordsInComments": true }
       EOS


### PR DESCRIPTION
Given a basic JSCS configuration of

```
jscs:
  enabled: true
```

Instances of `SmallBuildJob` will log an exception to Resque's `failed` queue.
The exception reads "no implicit conversion of Hash into String."

The root cause turned out to be `Config::Jscs#default_content`. Instead of being
a string, it was a Ruby hash, and when a user provided no configuration file in
his `.hound.yml`, `Config::Jscs` attempted to parse that hash via `YAML.parse`,
resulting in the exception.

This change removes `Config::Jscs#default_content`, delegating to
`Config::Base#default_content`, which is already a String. It also changes the
parser used from YAML to JSON, which more closely aligns with the implementation
of `Config::Jshint` and the format of JSCS's configuration file.