### PR TITLE
Support .eslint.js

### DIFF
--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -1,15 +1,17 @@
 module Config
   class Eslint < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize(_data = nil)
+      Serializer.json(
+        raw_content: load_content,
+        file_name: file_path,
+        hound_config_eslint_version: 2
+      )
     end
 
     private
 
     def parse(file_content)
-      json_with_comments = JsonWithComments.new(file_content)
-      content_without_comments = json_with_comments.without_comments
-      Parser.yaml(content_without_comments)
+      raise "Please don't parse me"
     end
   end
 end

--- a/spec/models/config/eslint_spec.rb
+++ b/spec/models/config/eslint_spec.rb
@@ -8,45 +8,21 @@ require "app/models/config/json_with_comments"
 require "yaml"
 
 describe Config::Eslint do
-  describe "#content" do
-    it "parses the configuration using YAML" do
-      raw_config = <<-EOS.strip_heredoc
-        rules:
-          quotes: [2, "double"]
-      EOS
-      commit = stubbed_commit("config/.eslintrc" => raw_config)
-      config = build_config(commit)
-
-      expect(config.content).to eq("rules" => { "quotes" => [2, "double"] })
-    end
-
-    context "when configuration is linter-flavored JSON format" do
-      it "parses the configuration" do
-        raw_config = <<-EOS.strip_heredoc
-          {
-            "foo": 1, // eslint JSON flavor can have comments
-            "bar": 2,
-          }
-        EOS
-        commit = stubbed_commit("config/.eslintrc" => raw_config)
-        config = build_config(commit)
-
-        expect(config.content).to eq("foo" => 1, "bar" => 2)
-      end
-    end
-  end
-
   describe "#serialize" do
-    it "serializes the content into JSON" do
+    it "serializes the content" do
       raw_config = <<-EOS.strip_heredoc
         rules:
           quotes: [2, "double"]
       EOS
-      commit = stubbed_commit("config/.eslintrc" => raw_config)
+      commit = stubbed_commit("config/.eslintrc.yaml" => raw_config)
       config = build_config(commit)
 
       expect(config.serialize).to eq(
-        "{\"rules\":{\"quotes\":[2,\"double\"]}}",
+        {
+          raw_content: "rules:\n  quotes: [2, \"double\"]\n",
+          file_name: "config/.eslintrc.yaml",
+          hound_config_eslint_version: 2
+        }.to_json
       )
     end
   end
@@ -56,7 +32,10 @@ describe Config::Eslint do
       "HoundConfig",
       commit: commit,
       content: {
-        "eslint" => { "enabled": true, "config_file" => "config/.eslintrc" },
+        "eslint" => {
+          "enabled": true,
+          "config_file" => "config/.eslintrc.yaml"
+        },
       },
     )
 


### PR DESCRIPTION
ESLint is a bit complicated, and one of its complications, is how it handles config files.

In hound currently, we pass the config file to the queue and assume it is JSON.

This change, simply passes through file content as well as the file name so that when eslint goes to run it will know what to do.

This enables support for .eslint.js and .eslint.yaml, as well as .eslint.json and .eslint

In the future, we should probably find a better way to pass around configs? but this should work for now.