### PR TITLE
Lookup ignore files using the linter's name

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -251,6 +251,14 @@ Style/MethodName:
   SupportedStyles:
   - snake_case
   - camelCase
+Style/MultilineMethodCallIndentation:
+  Description: Checks indentation of method calls with the dot operator
+    that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+  SupportedStyles:
+    - aligned
+    - indented
 Style/MultilineOperationIndentation:
   Description: Checks indentation of binary operations that span more than one line.
   Enabled: true

--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -10,7 +10,7 @@ module Linter
     private
 
     def jsignore
-      @jsignore ||= JsIgnore.new(hound_config, IGNORE_FILENAME)
+      @jsignore ||= JsIgnore.new(name, hound_config, IGNORE_FILENAME)
     end
   end
 end

--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -10,7 +10,7 @@ module Linter
     private
 
     def jsignore
-      @jsignore ||= JsIgnore.new(hound_config, IGNORE_FILENAME)
+      @jsignore ||= JsIgnore.new(name, hound_config, IGNORE_FILENAME)
     end
   end
 end

--- a/lib/js_ignore.rb
+++ b/lib/js_ignore.rb
@@ -1,10 +1,7 @@
 class JsIgnore
   DEFAULT_EXCLUDED_PATHS = %w(vendor/*).freeze
 
-  def initialize(hound_config, ignore_filename)
-    @hound_config = hound_config
-    @ignore_filename = ignore_filename
-  end
+  attr_private_initialize :linter_name, :hound_config, :default_filename
 
   def file_included?(commit_file)
     excluded_paths.none? do |pattern|
@@ -13,8 +10,6 @@ class JsIgnore
   end
 
   private
-
-  attr_reader :hound_config, :ignore_filename
 
   def excluded_paths
     ignored_paths.presence || DEFAULT_EXCLUDED_PATHS
@@ -31,7 +26,7 @@ class JsIgnore
   def ignore_filename
     @ignore_filename ||= hound_config.
       content.
-      fetch("javascript", {}).
-      fetch("ignore_file", ignore_filename)
+      fetch(linter_name, {}).
+      fetch("ignore_file", default_filename)
   end
 end

--- a/spec/lib/js_ignore_spec.rb
+++ b/spec/lib/js_ignore_spec.rb
@@ -5,23 +5,31 @@ describe JsIgnore do
   describe "#file_included?" do
     context "file is in excluded file list" do
       it "returns false" do
-        jsignore = build_js_ignore(["foo.js"])
-        commit_file = double("CommitFile", filename: "foo.js")
+        jsignore = build_js_ignore("javascript", "foo/*")
+        commit_file = double("CommitFile", filename: "foo/bar.js")
 
         expect(jsignore.file_included?(commit_file)).to eq false
+      end
+
+      context "with a different linter" do
+        it "returns false" do
+          jsignore = build_js_ignore("eslint", "foo/*")
+          commit_file = instance_double("CommitFile", filename: "foo/bar.js")
+
+          expect(jsignore.file_included?(commit_file)).to be false
+        end
       end
     end
 
     context "file is not excluded" do
       it "returns true" do
-        jsignore = build_js_ignore(["foo.js"])
-        commit_file = double("CommitFile", filename: "bar.js")
+        jsignore = build_js_ignore("javascript", "foo/*")
+        commit_file = double("CommitFile", filename: "foo.js")
 
         expect(jsignore.file_included?(commit_file)).to eq true
       end
 
       it "matches a glob pattern" do
-        jsignore = build_js_ignore(["app/assets/javascripts/*.js", "vendor/*"])
         commit_file1 = double(
           "CommitFile",
           filename: "app/assets/javascripts/bar.js",
@@ -30,17 +38,34 @@ describe JsIgnore do
           "CommitFile",
           filename: "vendor/assets/javascripts/foo.js",
         )
+        ignore_file_content = <<~TEXT
+          app/assets/javascripts/*.js\n
+          vendor/*
+        TEXT
+        jsignore = build_js_ignore("javascript", ignore_file_content)
 
         expect(jsignore.file_included?(commit_file1)).to be false
         expect(jsignore.file_included?(commit_file2)).to be false
       end
     end
 
-    def build_js_ignore(paths)
-      jsignore = JsIgnore.new({}, ".jsignore")
-      allow(jsignore).to receive(:ignored_paths).and_return(paths)
+    def build_js_ignore(linter, content)
+      hound_config = build_hound_config(linter, ".jsignore", content)
 
-      jsignore
+      JsIgnore.new("javascript", hound_config, ".jsignore")
+    end
+
+    def build_hound_config(linter, ignore_filename, content)
+      config_content = {
+        linter => {
+          "ignore_file" => ignore_filename,
+        },
+      }
+      commit = instance_double("Commit")
+      allow(commit).to receive(:file_content).with(ignore_filename).
+        and_return(content)
+
+      instance_double("HoundConfig", content: config_content, commit: commit)
     end
   end
 end


### PR DESCRIPTION
There was a bug where `JsIgnore` looked up the ignore file only for the
`javascript` linter. It now takes in a linter name and uses that as the
key to look up in `.hound.yml`.