### PR TITLE
Remove Code Climate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Hound
 
 [![Build Status](https://circleci.com/gh/houndci/hound.svg?style=svg)](https://circleci.com/gh/houndci/hound)
-[![Code Climate](https://codeclimate.com/repos/526ab75ff3ea007df603b773/badges/32cb8e64b2e265d8cad6/gpa.svg)](https://codeclimate.com/repos/526ab75ff3ea007df603b773/feed)
 [![Slack](http://slack.houndci.com/badge.svg)](http://slack.houndci.com)
 
 This codebase is the Rails app for


### PR DESCRIPTION
The badge has said 4.0 for many months (years?) and the Hound team does
not seem to be getting any value from Code Climate's analysis.

Anyone feel that this badge should stay?