### PR TITLE
Ensure uniqueness of repos by github_id

### DIFF
--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -10,7 +10,6 @@ class Repo < ActiveRecord::Base
   delegate :type, :price, to: :plan, prefix: true
   delegate :price, to: :subscription, prefix: true
 
-  validates :full_github_name, uniqueness: true, presence: true
   validates :github_id, uniqueness: true, presence: true
 
   def self.active
@@ -18,8 +17,8 @@ class Repo < ActiveRecord::Base
   end
 
   def self.find_or_create_with(attributes)
-    repo = find_by(full_github_name: attributes[:full_github_name]) ||
-      find_by(github_id: attributes[:github_id]) ||
+    repo = find_by(github_id: attributes[:github_id]) ||
+      find_by(full_github_name: attributes[:full_github_name]) ||
       Repo.new
 
     begin

--- a/db/migrate/20160513002940_add_github_id_uniqueness_on_repos.rb
+++ b/db/migrate/20160513002940_add_github_id_uniqueness_on_repos.rb
@@ -1,0 +1,23 @@
+class AddGithubIdUniquenessOnRepos < ActiveRecord::Migration
+  def up
+    remove_uniqueness(:full_github_name)
+    add_uniqueness(:github_id)
+  end
+
+  def down
+    remove_uniqueness(:github_id)
+    add_uniqueness(:full_github_name)
+  end
+
+  private
+
+  def remove_uniqueness(column)
+    remove_index :repos, column
+    add_index :repos, column
+  end
+
+  def add_uniqueness(column)
+    remove_index :repos, column
+    add_index :repos, column, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151216235118) do
+ActiveRecord::Schema.define(version: 20160513002940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,8 +91,8 @@ ActiveRecord::Schema.define(version: 20151216235118) do
   end
 
   add_index "repos", ["active"], name: "index_repos_on_active", using: :btree
-  add_index "repos", ["full_github_name"], name: "index_repos_on_full_github_name", unique: true, using: :btree
-  add_index "repos", ["github_id"], name: "index_repos_on_github_id", using: :btree
+  add_index "repos", ["full_github_name"], name: "index_repos_on_full_github_name", using: :btree
+  add_index "repos", ["github_id"], name: "index_repos_on_github_id", unique: true, using: :btree
   add_index "repos", ["owner_id"], name: "index_repos_on_owner_id", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|

--- a/lib/tasks/repo.rake
+++ b/lib/tasks/repo.rake
@@ -13,21 +13,4 @@ namespace :repo do
       )
     SQL
   end
-
-  desc "Delete repos with duplicate github_ids"
-  task remove_duplicate_github_ids: :environment do
-    ActiveRecord::Base.connection.execute <<-SQL
-      WITH del AS (
-        SELECT
-          id,
-          row_number() OVER (
-            PARTITION BY github_id ORDER BY active desc, id desc
-          ) as rn
-        FROM repos
-      )
-      DELETE FROM repos
-      USING del
-      WHERE repos.id = del.id AND del.rn > 1
-    SQL
-  end
 end

--- a/spec/lib/tasks/repo_spec.rb
+++ b/spec/lib/tasks/repo_spec.rb
@@ -22,42 +22,4 @@ describe "namespace repo" do
       expect(Repo.all).to eq([repo])
     end
   end
-
-  describe "task remove_duplicate_github_ids" do
-    def run
-      task = Rake::Task["repo:remove_duplicate_github_ids"]
-      task.reenable
-      task.invoke
-    end
-
-    it "does not effect unduplicated rows" do
-      repo = create(:repo)
-
-      run
-
-      expect(Repo.all).to eq([repo])
-    end
-
-    it "removes duplicate rows" do
-      repo1 = create(:repo)
-      repo2 = create(:repo)
-      repo2.update_attribute :github_id, repo1.github_id
-
-      run
-
-      expect(Repo.count).to eq(1)
-    end
-
-    it "prefers active repos to inactive repos" do
-      repo1 = create(:repo)
-      repo2 = create(:repo, active: true)
-      repo3 = create(:repo)
-      repo2.update_attribute :github_id, repo1.github_id
-      repo3.update_attribute :github_id, repo1.github_id
-
-      run
-
-      expect(Repo.all).to eq([repo2])
-    end
-  end
 end

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -3,12 +3,7 @@ require "rails_helper"
 describe RepoSynchronization do
   describe "#start" do
     it "saves privacy flag" do
-      stub_github_api_repos(
-        repo_id: 456,
-        owner_id: 1,
-        owner_name: "thoughtbot",
-        repo_name: "user/newrepo"
-      )
+      stub_github_api_repos(repo_id: 456, repo_name: "user/newrepo")
       user = create(:user)
       synchronization = RepoSynchronization.new(user)
 
@@ -18,13 +13,7 @@ describe RepoSynchronization do
     end
 
     it "saves organization flag" do
-      stub_github_api_repos(
-        repo_id: 456,
-        owner_id: 1,
-        owner_name: "thoughtbot",
-        private_repo: false,
-        repo_name: "user/newrepo"
-      )
+      stub_github_api_repos(repo_id: 456, repo_name: "user/newrepo")
       user = create(:user)
       synchronization = RepoSynchronization.new(user)
 
@@ -37,8 +26,6 @@ describe RepoSynchronization do
       it "the memberships admin flag is true" do
         stub_github_api_repos(
           repo_id: 456,
-          owner_id: 1,
-          owner_name: "thoughtbot",
           repo_name: "user/newrepo",
           admin: true,
         )
@@ -55,8 +42,6 @@ describe RepoSynchronization do
       it "the membership admin flag is false" do
         stub_github_api_repos(
           repo_id: 456,
-          owner_id: 1,
-          owner_name: "thoughtbot",
           repo_name: "user/newrepo",
           admin: false,
         )
@@ -70,13 +55,7 @@ describe RepoSynchronization do
     end
 
     it "replaces existing repos" do
-      stub_github_api_repos(
-        repo_id: 456,
-        owner_id: 1,
-        owner_name: "thoughtbot",
-        private_repo: false,
-        repo_name: "user/newrepo"
-      )
+      stub_github_api_repos(repo_id: 456, repo_name: "user/newrepo")
       membership = create(:membership)
       user = membership.user
       synchronization = RepoSynchronization.new(user)
@@ -116,11 +95,7 @@ describe RepoSynchronization do
       it "creates another membership" do
         first_membership = create(:membership)
         repo = first_membership.repo
-        stub_github_api_repos(
-          repo_id: repo.github_id,
-          owner_id: 1,
-          owner_name: "thoughtbot"
-        )
+        stub_github_api_repos(repo_id: repo.github_id, repo_name: repo.name)
         second_user = create(:user)
         synchronization = RepoSynchronization.new(second_user)
 
@@ -135,19 +110,18 @@ describe RepoSynchronization do
         it "creates and associates an owner to the repo" do
           user = create(:user)
           owner_github_id = 1234
-          owner_name = "thoughtbot"
           repo_github_id = 321
           stub_github_api_repos(
             repo_id: repo_github_id,
+            repo_name: "foo/bar",
             owner_id: owner_github_id,
-            owner_name: owner_name
           )
           synchronization = RepoSynchronization.new(user)
 
           synchronization.start
 
           owner = Owner.find_by(github_id: owner_github_id)
-          expect(owner.name).to eq(owner_name)
+          expect(owner.name).to eq("thoughtbot")
           expect(owner.repos.map(&:github_id)).to eq([repo_github_id])
         end
       end
@@ -159,8 +133,8 @@ describe RepoSynchronization do
           repo_github_id = 321
           stub_github_api_repos(
             repo_id: repo_github_id,
+            repo_name: "foo/bar",
             owner_id: owner.github_id,
-            owner_name: owner.name
           )
           synchronization = RepoSynchronization.new(user)
 
@@ -172,29 +146,12 @@ describe RepoSynchronization do
       end
     end
 
-    def stub_github_api_repos(
-      repo_id:,
-      owner_id:,
-      owner_name:,
-      private_repo: true,
-      repo_name: "thoughtbot/newrepo",
-      admin: false
-    )
-      attributes = {
-        full_name: repo_name,
-        id: repo_id,
-        private: private_repo,
-        owner: {
-          id: owner_id,
-          login: owner_name,
-          type: "Organization",
-        },
-        permissions: {
-          admin: admin,
-        }
-      }
-      resource = double(:resource, to_hash: attributes)
-      api = double("GithubApi", repos: [resource])
+    def stub_github_api_repos(repo_name:, repo_id:, owner_id: 1, admin: false)
+      repo = build_github_repo(id: repo_id, name: repo_name)
+      repo[:owner][:id] = owner_id
+      repo[:permissions][:admin] = admin
+
+      api = double("GithubApi", repos: [repo])
       allow(GithubApi).to receive(:new).and_return(api)
     end
 


### PR DESCRIPTION
Previously, we were ensuring repo uniqueness by name, but since we are
tightly coupled to GitHub, we should be using their ids.

There was a recent bug that led to this:

* On GitHub, `thoughtbot/constable-api` repo was renamed to `thoughtbot/constable`
* On GitHub, `thoughtbot/constable` repo was renamed to `thoughtbot/constable-react`
* When we were syncing repos, we would find the `thoughtbot/constable`
  and create a membership for it
* Then we would see the `thoughtbot/constable-react`. Nnot find it
  by name, then look it up by `github_id` and pull up the same
  `thoughtbot/constable` record and try to create a membership,
  which would fail.

If we relied on `github_id` for uniquness we would eventually update the
names to match what GitHub has.