### PR TITLE
Remove JSCS documenation

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -15,10 +15,6 @@ module ConfigurationHelper
     config_url("houndci/hound", "config/style_guides/.jshintignore")
   end
 
-  def jscs_config_url
-    config_url("thoughtbot/guides", "style/javascript/.jscsrc")
-  end
-
   def eslint_config_url
     config_url("houndci/eslint", "config/.eslintrc")
   end

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -12,8 +12,6 @@
       %li
         = link_to "Javascript", "#javascript"
       %li
-        = link_to "JSCS", "#jscs"
-      %li
         = link_to "ESLint", "#eslint"
       %li
         = link_to "SCSS", "#scss"
@@ -187,48 +185,6 @@
           :preserve
             javascript:
               enabled: false
-
-    %article#jscs
-      %h3 JSCS (beta)
-
-      %p
-        Add the following code to your
-        %em.code .hound.yml
-        to enable JSCS style checking.
-
-        %code.code-block
-          :preserve
-            jscs:
-              enabled: true
-
-      %p
-        Hound uses
-        = link_to "JSCS",
-          "http://jscs.info/",
-          target: :blank
-        with this
-        = link_to "config", jscs_config_url, target: :blank
-
-      %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", jscs_config_url, target: :blank}.
-        into your project, make changes and reference the file in your
-        %em.code .hound.yml
-
-      %p
-        %code.code-block
-          :preserve
-            jscs:
-              enabled: true
-              config_file: .jscsrc
-
-      %p
-        For more information on the available rules in your
-        %em.code config_file
-        , you can read about them on the
-        = link_to "JSCS Rules Documentation",
-          "http://jscs.info/rules",
-          target: :blank
 
     %article#eslint
       %h3 ESLint (beta)


### PR DESCRIPTION
In preparation for dropping support of JSCS,
we're removing the documenation so users don't discover it.