### PR TITLE
Add index for builds pr number and sha

### DIFF
--- a/db/migrate/20160513205551_add_index_for_builds_pull_request_number_and_commit_sha.rb
+++ b/db/migrate/20160513205551_add_index_for_builds_pull_request_number_and_commit_sha.rb
@@ -1,0 +1,5 @@
+class AddIndexForBuildsPullRequestNumberAndCommitSha < ActiveRecord::Migration
+  def change
+    add_index :builds, [:commit_sha, :pull_request_number]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160513002940) do
+ActiveRecord::Schema.define(version: 20160513205551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(version: 20160513002940) do
     t.integer  "violations_count"
   end
 
+  add_index "builds", ["commit_sha", "pull_request_number"], name: "index_builds_on_commit_sha_and_pull_request_number", using: :btree
   add_index "builds", ["repo_id"], name: "index_builds_on_repo_id", using: :btree
   add_index "builds", ["uuid"], name: "index_builds_on_uuid", unique: true, using: :btree
 


### PR DESCRIPTION
When completing a file review job, we find the associated build record
by pull request number and commit sha. With about 1.6 million records
in the table, this query is averaging 1820ms to execute.

This adds an index on the pull_request_number/commit_sha pair to improve
the performance of that query.