### PR TITLE
Improve formatting of failed jobs admin page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 ruby "2.3.1"
 
 gem "active_model_serializers", "0.9.5"
-gem "administrate", ">= 0.1.3"
+gem "administrate", ">= 0.2.0"
 gem "analytics-ruby", "~> 2.0.0", require: "segment/analytics"
 gem "angular_rails_csrf"
 gem "angularjs-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    administrate (0.1.5)
+    administrate (0.2.2)
       autoprefixer-rails (~> 6.0)
       datetime_picker_rails (~> 0.0.7)
       jquery-rails (~> 4.0)
@@ -59,9 +59,9 @@ GEM
     astrolabe (1.3.1)
       parser (~> 2.2)
     attr_extras (4.4.0)
-    autoprefixer-rails (6.3.5)
+    autoprefixer-rails (6.3.6.1)
       execjs
-    bourbon (4.2.6)
+    bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
@@ -93,7 +93,7 @@ GEM
       execjs
       json
     columnize (0.8.9)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
@@ -109,7 +109,7 @@ GEM
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)
-    execjs (2.6.0)
+    execjs (2.7.0)
     factory_girl (4.4.0)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.4.1)
@@ -157,10 +157,10 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    mime-types (2.99.1)
+    mime-types (2.99.2)
     mini_portile2 (2.0.0)
-    minitest (5.8.4)
-    momentjs-rails (2.11.0)
+    minitest (5.9.0)
+    momentjs-rails (2.11.1)
       railties (>= 3.1)
     mono_logger (1.1.0)
     multi_json (1.11.1)
@@ -315,7 +315,7 @@ GEM
       redis-namespace (>= 1.1.0)
       simple-random
       sinatra (>= 1.2.6)
-    sprockets (3.5.2)
+    sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.0.4)
@@ -328,7 +328,7 @@ GEM
       rest-client (~> 1.4)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (2.0.4)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.2)
@@ -352,7 +352,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (= 0.9.5)
-  administrate (>= 0.1.3)
+  administrate (>= 0.2.0)
   analytics-ruby (~> 2.0.0)
   angular_rails_csrf
   angularjs-rails

--- a/app/assets/stylesheets/admin/administrate.scss
+++ b/app/assets/stylesheets/admin/administrate.scss
@@ -1,0 +1,11 @@
+.collection-data {
+  th {
+    td {
+      white-space: nowrap;
+    }
+  }
+
+  td {
+    white-space: normal;
+  }
+}

--- a/app/views/admin/job_failures/index.haml
+++ b/app/views/admin/job_failures/index.haml
@@ -11,7 +11,7 @@
       %td.cell-label.cell-label--string.cell-label--false
         Error message
       %td.cell-label.cell-label--string.cell-label--false
-        Job indexes
+        Failure indexes
       %td
 
   %tbody
@@ -22,6 +22,6 @@
         %td.cell-data.cell-data--array
           = job_failures.map(&:index).join(", ")
         %td
-          = link_to "Remove failures",
+          = link_to "Remove",
             admin_job_failure_path(job_failures.map(&:index).join(",")),
             method: :delete

--- a/config/initializers/administrate.rb
+++ b/config/initializers/administrate.rb
@@ -1,0 +1,2 @@
+Rails.application.config.assets.precompile += %w( admin/administrate.css )
+Administrate::Engine.add_stylesheet("admin/administrate")


### PR DESCRIPTION
Make it so things are visible on the screen, rather than scrolling
horizontally.

Uses features from the latest Administrate release, to provide custom
CSS styles.