### PR TITLE
Add ESLint to lists of linters

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,9 +120,13 @@ and services being used, and the default configuration for each linter.
  * [CoffeeLint](https://github.com/clutchski/coffeelint)
  * [config](https://raw.githubusercontent.com/houndci/hound/master/config/style_guides/coffeescript.json)
 
-1. JavaScript (JSHint)
- * [houndci/jshint](https://github.com/houndci/jshint)
- * [config](https://raw.githubusercontent.com/houndci/jshint/master/config/.jshintrc)
+1. JavaScript
+  * JSHint
+    * [houndci/jshint](https://github.com/houndci/jshint)
+    * [config](https://raw.githubusercontent.com/houndci/jshint/master/config/.jshintrc)
+  * ESLint
+    * [houndci/eslint](https://github.com/houndci/eslint)
+    * [config](https://raw.githubusercontent.com/houndci/eslint/master/config/.eslintrc)
 
 1. SCSS
  * [houndci/scss](https://github.com/houndci/scss)

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -195,7 +195,9 @@ that we use to check the style of the code in each pull request notification:
 
 * Ruby: [RuboCop](https://github.com/bbatsov/rubocop)
 * CoffeeScript: [CoffeeLint](http://www.coffeelint.org/)
-* JavaScript: [JSHint](https://github.com/jshint/jshint/)
+* JavaScript: 
+  * [JSHint](https://github.com/jshint/jshint)
+  * [ESLint](https://github.com/eslint/eslint)
 * SCSS: [SCSS-Lint](https://github.com/brigade/scss-lint)
 * Go: [golint](https://github.com/golang/lint)
 


### PR DESCRIPTION
There are two places in the docs where we list our linters but leave out ESLint. I've added in references in the styles of the other linters.