### PR TITLE
Track repo activation on the client side

### DIFF
--- a/app/assets/javascripts/directives/repo.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo.js.coffee.erb
@@ -6,6 +6,7 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
       scope.processing = true
 
       scope.repo.$activate()
+        .then((repo) -> track_repo_activated(repo))
         .catch((response) -> alert(errorMessage(response.data)))
         .finally(-> scope.processing = false)
 
@@ -54,6 +55,7 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
 
     saveSubscription = (subscription) ->
       subscription.$save().then((response) ->
+        track_repo_activated(response)
         scope.repo.active = true
         scope.repo.stripe_subscription_id = response.stripe_subscription_id
       ).catch(->
@@ -84,4 +86,14 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
           deactivateRepo()
       else
         createSubscription()
+
+    track_repo_activated = (repo) ->
+      window.analytics.track(
+        "Repo Activated",
+        properties: {
+          name: repo.full_github_name,
+          private: repo.private,
+          revenue: repo.price_in_dollars
+        }
+      )
 ]

--- a/app/controllers/activations_controller.rb
+++ b/app/controllers/activations_controller.rb
@@ -6,7 +6,6 @@ class ActivationsController < ApplicationController
 
   def create
     if activator.activate
-      analytics.track_repo_activated(repo)
       render json: repo, status: :created
     else
       analytics.track_repo_activation_failed(repo)

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -6,8 +6,6 @@ class SubscriptionsController < ApplicationController
 
   def create
     if activator.activate && create_subscription
-      analytics.track_repo_activated(repo)
-
       render json: repo, status: :created
     else
       activator.deactivate

--- a/app/models/analytics.rb
+++ b/app/models/analytics.rb
@@ -20,17 +20,6 @@ class Analytics
     )
   end
 
-  def track_repo_activated(repo)
-    track(
-      event: "Repo Activated",
-      properties: {
-        name: repo.full_github_name,
-        private: repo.private,
-        revenue: repo.plan_price,
-      }
-    )
-  end
-
   def track_repo_deactivated(repo)
     track(
       event: "Repo Deactivated",

--- a/app/serializers/repo_serializer.rb
+++ b/app/serializers/repo_serializer.rb
@@ -8,12 +8,17 @@ class RepoSerializer < ActiveModel::Serializer
     :id,
     :in_organization,
     :price_in_cents,
+    :price_in_dollars,
     :private,
     :stripe_subscription_id,
   )
 
   def price_in_cents
     object.plan_price * 100
+  end
+
+  def price_in_dollars
+    object.plan_price
   end
 
   def full_plan_name

--- a/spec/controllers/activations_controller_spec.rb
+++ b/spec/controllers/activations_controller_spec.rb
@@ -21,15 +21,6 @@ describe ActivationsController, "#create" do
       expect(activator).to have_received(:activate)
       expect(RepoActivator).to have_received(:new).
         with(repo: repo, github_token: membership.user.token)
-      expect(analytics).to have_tracked("Repo Activated").
-        for_user(membership.user).
-        with(
-          properties: {
-            name: repo.full_github_name,
-            private: false,
-            revenue: 0,
-          }
-        )
     end
   end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -23,15 +23,6 @@ describe SubscriptionsController, "#create" do
         with(repo: repo, github_token: membership.user.token)
       expect(RepoSubscriber).to have_received(:subscribe).
         with(repo, membership.user, "cardtoken")
-      expect(analytics).to have_tracked("Repo Activated").
-        for_user(membership.user).
-        with(
-          properties: {
-            name: repo.name,
-            private: true,
-            revenue: repo.plan_price,
-          }
-        )
     end
 
     it "updates the current user's email address" do


### PR DESCRIPTION
In order to get correct statistics for our paid marketing efforts we
need conversion events to be tracked on the client side so that segment
can drop in the appropriate conversion pixels.

https://trello.com/c/sublWZZi