### PR TITLE
Display repos grouped by repo owner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "haml-rails"
 gem "high_voltage"
 gem "inifile"
 gem "jquery-rails", "~> 4.0.0"
+gem 'rails-assets-lodash', source: 'https://rails-assets.org'
 gem "neat"
 gem "octokit"
 gem "omniauth-github"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,6 @@
 GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actionmailer (4.2.5.2)
       actionpack (= 4.2.5.2)
@@ -222,6 +223,7 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.2.5.2)
       sprockets-rails
+    rails-assets-lodash (4.13.1)
     rails-deprecated_sanitizer (1.0.3)
       activesupport (>= 4.2.0.alpha)
     rails-dom-testing (1.0.7)
@@ -388,6 +390,7 @@ DEPENDENCIES
   puma
   rack-timeout
   rails (= 4.2.5.2)
+  rails-assets-lodash!
   rails_12factor
   resque (~> 1.25.0)
   resque-scheduler
@@ -407,4 +410,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.3
+   1.12.4

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require angular
 //= require angular-resource
+//= require lodash
 //= require namespaced
 //= require_self
 //= require_tree .

--- a/app/assets/javascripts/directives/organization.js.coffee
+++ b/app/assets/javascripts/directives/organization.js.coffee
@@ -1,0 +1,4 @@
+App.directive 'organization', [ ->
+  scope: true
+  templateUrl: '/templates/organization'
+]

--- a/app/assets/javascripts/directives/organization_list.js.coffee.erb
+++ b/app/assets/javascripts/directives/organization_list.js.coffee.erb
@@ -1,0 +1,64 @@
+App.directive 'organizationList',
+['Repo', 'Sync', 'User', '$timeout', (Repo, Sync, User, $timeout) ->
+  scope: {}
+  templateUrl: '/templates/organization_list'
+  link: (scope, element, attributes) ->
+    scope.includePrivateReposButtonText = '<%= I18n.t('include_private_repos') %>'
+
+    loadRepos = ->
+      scope.syncingRepos = false
+
+      repos = Repo.query()
+      repos.$promise.then((results) ->
+        scope.repos = results
+        organizations = scope.repos.map((repo) ->
+          repo.owner
+        )
+        scope.organizations = _.uniqWith(organizations, _.isEqual)
+      , ->
+        alert('Your repos failed to load.')
+      )
+
+    loadUserPaymentInfo = ->
+      user = User.get()
+      user.$promise
+        .then (result) -> scope.userCardExists = result.card_exists
+        .catch -> alert("Failed to load current user.")
+
+    pollSyncStatus = ->
+      successfulSync = (user) ->
+        if user.refreshing_repos
+          pollSyncStatus()
+        else
+          loadRepos()
+
+      failedSync = ->
+        pollSyncStatus()
+
+      getSyncs = ->
+        user = User.get()
+        user.$promise.then(successfulSync, failedSync)
+
+      $timeout getSyncs, 3000
+
+    scope.sync = ->
+      scope.syncingRepos = true
+
+      sync = Sync.save().$promise.then(->
+        pollSyncStatus()
+      , ->
+        scope.syncingRepos = false
+        alert('Your repos failed to sync.')
+      )
+
+    scope.$watch 'syncingRepos', (newValue, oldValue) ->
+      if newValue
+        scope.syncButtonText = '<%= I18n.t('syncing_repos') %>'
+      else
+        scope.syncButtonText = '<%= I18n.t('sync_repos') %>'
+
+    loadRepos().then ->
+      loadUserPaymentInfo().then ->
+        if scope.repos.length == 0
+          scope.sync()
+]

--- a/app/assets/javascripts/directives/repo_list.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo_list.js.coffee.erb
@@ -1,60 +1,9 @@
 App.directive 'repoList', ['Repo', 'Sync', 'User', '$timeout', (Repo, Sync, User, $timeout) ->
-  scope: {}
+  scope: true
   templateUrl: '/templates/repo_list'
 
   link: (scope, element, attributes) ->
-    scope.includePrivateReposButtonText = '<%= I18n.t('include_private_repos') %>'
-
-    loadRepos = ->
-      scope.syncingRepos = false
-
-      repos = Repo.query()
-      repos.$promise.then((results) ->
-        scope.repos = results
-      , ->
-        alert('Your repos failed to load.')
-      )
-
-    loadUserPaymentInfo = ->
-      user = User.get()
-      user.$promise
-        .then (result) -> scope.userCardExists = result.card_exists
-        .catch -> alert("Failed to load current user.")
-
-    pollSyncStatus = ->
-      successfulSync = (user) ->
-        if user.refreshing_repos
-          pollSyncStatus()
-        else
-          loadRepos()
-
-      failedSync = ->
-        pollSyncStatus()
-
-      getSyncs = ->
-        user = User.get()
-        user.$promise.then(successfulSync, failedSync)
-
-      $timeout getSyncs, 3000
-
-    scope.sync = ->
-      scope.syncingRepos = true
-
-      sync = Sync.save().$promise.then(->
-        pollSyncStatus()
-      , ->
-        scope.syncingRepos = false
-        alert('Your repos failed to sync.')
-      )
-
-    scope.$watch 'syncingRepos', (newValue, oldValue) ->
-      if newValue
-        scope.syncButtonText = '<%= I18n.t('syncing_repos') %>'
-      else
-        scope.syncButtonText = '<%= I18n.t('sync_repos') %>'
-
-    loadRepos().then ->
-      loadUserPaymentInfo().then ->
-        if scope.repos.length < 1
-          scope.sync()
+    scope.repos = scope.repos.filter((repo) ->
+      repo.owner.name == scope.organization.name
+    )
 ]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -57,7 +57,8 @@ class User < ActiveRecord::Base
   def repos_by_activation_ability
     repos.
       order("memberships.admin DESC").
-      order(active: :desc, full_github_name: :asc)
+      order(active: :desc).
+      order("LOWER(full_github_name) ASC")
   end
 
   private

--- a/app/serializers/repo_serializer.rb
+++ b/app/serializers/repo_serializer.rb
@@ -7,6 +7,7 @@ class RepoSerializer < ActiveModel::Serializer
     :github_id,
     :id,
     :in_organization,
+    :owner,
     :price_in_cents,
     :price_in_dollars,
     :private,

--- a/app/views/repos/index.haml
+++ b/app/views/repos/index.haml
@@ -5,5 +5,5 @@
 - if display_onboarding?
   = render 'onboarding'
 
-%section.repo-listing{ 'repo-list': '' }
-= render 'preload_template', template: 'repo_list'
+%section.organization-list{ 'organization-list' => '' }
+= render 'preload_template', template: 'organization_list'

--- a/app/views/templates/organization.haml
+++ b/app/views/templates/organization.haml
@@ -1,0 +1,16 @@
+%header.organization-header
+  %h2.organization-header-title
+    {{ organization.name }}
+  -# .organization-header-toggle
+  -#   %p.organization-header-label
+  -#     Use organization-wide config
+  -#   %input#toggle{ 'class' => 'organization-header-toggle-input',
+  -#     'type' => 'checkbox', 'name' => 'toggle' }
+  -#   %label.organization-header-toggle-switch{ 'for' => 'toggle' }
+  -# .organization-header-config
+  -#   %p.organization-header-label
+  -#     Use hound.yml from
+  -#   %select.organization-header-select
+  -#     %option thoughtbot/hound
+%section.repo_listing{ 'repo-list' => '' }
+= render 'preload_template', template: 'repo_list'

--- a/app/views/templates/organization_list.haml
+++ b/app/views/templates/organization_list.haml
@@ -1,0 +1,22 @@
+.repo-tools
+  .repo-tools-search
+    %input.repo-search-tools-input{ 'type' => 'text',
+      'placeholder' => t('search_placeholder'),
+      'ng-model' => 'search.full_github_name' }
+  - unless current_user.has_access_to_private_repos?
+    .repo-tools-private
+      = button_to '/auth/github?access=full',
+        class: 'repo-tools-private-button', 'ng-disabled' => 'syncingRepos' do
+        %span {{ includePrivateReposButtonText }}
+  .repo-tools-refresh
+    %button{ 'class' => 'repo-tools-refresh-button',
+      'ng-click' => 'sync()', 'ng-disabled' => 'syncingRepos' }
+      %span {{ syncButtonText }}
+.repos-syncing{ 'ng-show' => 'syncingRepos' }
+  .dot
+  .dot
+  .dot
+%ul.organizations
+  .organization{ 'organization' => '',
+                'ng-repeat' => 'organization in organizations'}
+= render 'preload_template', template: 'organization'

--- a/app/views/templates/repo.haml
+++ b/app/views/templates/repo.haml
@@ -1,6 +1,6 @@
 .repo-name
   {{ repo.full_github_name }}
-.repo-activation-toggle{ "ng-class": "{'repo-activation-toggle--private': repo.private}" }
+.repo-activation-toggle{ "ng-class": "{ 'repo-activation-toggle--private': repo.private }" }
   %span.repo-private-label Private - $12
   %button.repo-toggle{ "ng-click": "toggle()",
     "ng-disabled": "processing",

--- a/app/views/templates/repo_list.haml
+++ b/app/views/templates/repo_list.haml
@@ -1,42 +1,6 @@
-.repo-tools
-  .repo-tools-search
-    %input.repo-search-tools-input{ 'type' => 'text',
-      'placeholder' => t('search_placeholder'),
-      'ng-model' => 'search.full_github_name' }
-  - unless current_user.has_access_to_private_repos?
-    .repo-tools-private
-      = button_to '/auth/github?access=full',
-        class: 'repo-tools-private-button', 'ng-disabled' => 'syncingRepos' do
-        %span {{ includePrivateReposButtonText }}
-  .repo-tools-refresh
-    %button{ 'class' => 'repo-tools-refresh-button',
-      'ng-click' => 'sync()', 'ng-disabled' => 'syncingRepos' }
-      %span {{ syncButtonText }}
-
-.repos-syncing{ 'ng-show' => 'syncingRepos' }
-  .dot
-  .dot
-  .dot
-
-.organization{ 'ng-hide' => 'syncingRepos' }
-  %header.organization-header
-    %h2.organization-header-title
-      Some Organization Name
-    .organization-header-toggle
-      %span.organization-header-label
-        Use organization-wide config
-      %input#toggle{ 'class' => 'organization-header-toggle-input',
-        'type' => 'checkbox', 'name' => 'toggle' }
-      %label.toggle-switch{ 'for' => 'toggle' }
-    .organization-header-config
-      %span.organization-header-label
-        Use hound.yml from
-      %select.organization-header-select
-        %option thoughtbot/hound
-
-  %ul.repos
-    %li.repo{ 'repo' => '',
-      'ng-repeat' => 'repo in repos | filter:search',
-      'ng-class' => '{ "repo--active": repo.active, "repo--processing": processing }' }
-
-  = render 'preload_template', template: 'repo'
+%ul.repos
+  %li.repo{ 'repo' => '',
+    'ng-repeat' => 'repo in repos | filter:search',
+      'ng-class' => '{"repo--active": repo.active, |
+        "repo--processing": processing}' }
+= render 'preload_template', template: 'repo'


### PR DESCRIPTION
 - Eventually we will display options for a github account level style guide configuration. Part of that change that we can implement before having the backend done is splitting the repos page by owner. This way, we can add in @smharley's work more easily when the time comes.

Changes:

 - Add `organization_list` and `organization` templates and directives.
  - Move some logic from `repo_list` directive (which was the top-level directive before) to `organization_list` (the top-level directive now)
 - Add lodash because we have to filter objects based on property equality, and for all its other handy helpers.

<img width="1252" alt="display repos by organization" src="https://cloud.githubusercontent.com/assets/5903784/15716126/f0a0a296-27d5-11e6-85e7-17c51501ea13.png">

