### PR TITLE
RubyConfigParser should return a Config, not a Hash, on error

### DIFF
--- a/app/services/ruby_config_builder.rb
+++ b/app/services/ruby_config_builder.rb
@@ -21,7 +21,7 @@ class RubyConfigBuilder
   def combined_overrides
     RuboCop::ConfigLoader.merge(normalized_hound_config, normalized_overrides)
   rescue TypeError
-    hound_config
+    normalized_hound_config
   end
 
   def normalized_overrides

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -1,6 +1,7 @@
 require "rubocop"
 require "app/models/default_config_file"
 require "app/services/ruby_config_builder"
+require "app/models/config/parser"
 
 RSpec.describe RubyConfigBuilder do
   context "when there is no custom configuration" do

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe RubyConfigBuilder do
     end
   end
 
+  context "when the custom configuration returns a type error from rubocop" do
+    it "returns the default config" do
+      overrides = { "this isn't parsible" => ["foo", "bar"] }
+      builder = RubyConfigBuilder.new(overrides)
+
+      config = builder.config
+
+      expect(config["Rails/ActionFilter"]).to match enabled_rule
+      expect(config["Style/StringLiterals"]).to match hound_override_rule
+      expect(config["Style/VariableName"]).to match rubocop_default_rule
+    end
+  end
+
   def customer_override_rule
     hash_including("EnforcedStyle" => "camel_case", "Enabled" => true)
   end


### PR DESCRIPTION
When hound rescues from a `TypeError` right now it is returning a `Hash`, but if the operation had succeeded it would have returned a `RuboCop::Config`.

Change: return the default `RuboCop::Config` in `rescue` block.

See: https://github.com/houndci/hound/issues/1146 and a reproduced failure: 
![failure](https://cloud.githubusercontent.com/assets/5903784/15725696/edcf4438-2801-11e6-96d7-e0465f6aa37c.png)
