### PR TITLE
WIP: Rubocop config with nested inherit_froms

### DIFF
--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -23,7 +23,13 @@ module Config
         result.merge(ancestor_config)
       end
 
-      inherited_config.merge(config.except("inherit_from"))
+      merged_config = inherited_config.merge(config.except("inherit_from"))
+
+      if merged_config.has_key?("inherit_from")
+        parse_inherit_from(merged_config)
+      else
+        merged_config
+      end
     end
 
     def legacy?

--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -14,19 +14,24 @@ module Config
       Parser.yaml(file_content)
     end
 
-    def parse_inherit_from(config)
+    def parse_inherit_from(config, parsed_files = [])
       inherit_from = Array(config.fetch("inherit_from", []))
 
       inherited_config = inherit_from.reduce({}) do |result, ancestor_file_path|
-        raw_ancestor_config = commit.file_content(ancestor_file_path)
-        ancestor_config = safe_parse(raw_ancestor_config) || {}
-        result.merge(ancestor_config)
+        if !parsed_files.include? ancestor_file_path
+          parsed_files << ancestor_file_path
+          raw_ancestor_config = commit.file_content(ancestor_file_path)
+          ancestor_config = safe_parse(raw_ancestor_config) || {}
+          result.merge(ancestor_config)
+        else
+          {}
+        end
       end
 
       merged_config = inherited_config.merge(config.except("inherit_from"))
 
       if merged_config.has_key?("inherit_from")
-        parse_inherit_from(merged_config)
+        parse_inherit_from(merged_config, parsed_files)
       else
         merged_config
       end

--- a/app/services/ruby_config_builder.rb
+++ b/app/services/ruby_config_builder.rb
@@ -21,7 +21,7 @@ class RubyConfigBuilder
   def combined_overrides
     RuboCop::ConfigLoader.merge(normalized_hound_config, normalized_overrides)
   rescue TypeError
-    hound_config
+    normalized_hound_config
   end
 
   def normalized_overrides

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -1,6 +1,7 @@
 require "rubocop"
 require "app/models/default_config_file"
 require "app/services/ruby_config_builder"
+require "app/models/config/parser"
 
 RSpec.describe RubyConfigBuilder do
   context "when there is no custom configuration" do

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe RubyConfigBuilder do
     end
   end
 
+  context "when the custom configuration returns a type error from rubocop" do
+    it "returns the default config" do
+      overrides = { "this isn't parsible" => ["foo", "bar"] }
+      builder = RubyConfigBuilder.new(overrides)
+
+      config = builder.config
+
+      expect(config["Rails/ActionFilter"]).to match enabled_rule
+      expect(config["Style/StringLiterals"]).to match hound_override_rule
+      expect(config["Style/VariableName"]).to match rubocop_default_rule
+    end
+  end
+
   def customer_override_rule
     hash_including("EnforcedStyle" => "camel_case", "Enabled" => true)
   end


### PR DESCRIPTION
Hound can only follow one `inherit_from` configuration. [Rubocop supports nested `inherit_from`s](http://rubocop.readthedocs.io/en/latest/configuration/#inheritance), and we can do the same by recursively parsing the inherited file until we no longer can find any `inherited_from` statement in the config. 

Still to do: get this to work with relative file paths and possibly even URL's