### PR TITLE
HoundConfig merges default and user configurations

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -10,21 +10,17 @@ module Config
       []
     end
 
-    def linter_names
-      [linter_name]
-    end
-
     def serialize(data = content)
       data
+    end
+
+    def linter_name
+      self.class.name.demodulize.underscore
     end
 
     private
 
     attr_implement :parse, [:file_content]
-
-    def linter_name
-      self.class.name.demodulize.underscore
-    end
 
     def safe_parse(content)
       parse(content)
@@ -83,7 +79,7 @@ module Config
     end
 
     def linter_config
-      hound_config.content.slice(*linter_names).values.first
+      hound_config.content.slice(linter_name).values.first
     end
 
     def commit

--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -1,12 +1,5 @@
 module Config
   class CoffeeScript < Base
-    def linter_names
-      [
-        linter_name,
-        linter_name.sub("_", ""),
-      ]
-    end
-
     private
 
     def parse(file_content)

--- a/app/models/config/jshint.rb
+++ b/app/models/config/jshint.rb
@@ -1,13 +1,5 @@
 module Config
   class Jshint < Base
-    def linter_names
-      [
-        "javascript",
-        "java_script",
-        linter_name,
-      ]
-    end
-
     def serialize(data = content)
       Serializer.json(data)
     end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -12,48 +12,45 @@ class HoundConfig
   attr_reader_initialize :commit
 
   def content
-    @content ||= parse(commit.file_content(CONFIG_FILE))
+    @_content ||= default_config.deep_merge(resolved_aliases_config)
   end
 
   def linter_enabled?(name)
-    configured?(name)
+    key = name.downcase
+    config = options_for(key)
+
+    !!config["enabled"]
   end
 
   def fail_on_violations?
-    !!(content["fail_on_violations"])
+    !!content["fail_on_violations"]
   end
 
   private
+
+  def default_config
+    Linter::Collection.linter_names.each.with_object({}) do |name, config|
+      config[name] = { "enabled" => !BETA_LINTERS.include?(name) }
+    end
+  end
+
+  def resolved_aliases_config
+    ResolveConfigAliases.run(normalized_config)
+  end
+
+  def normalized_config
+    NormalizeConfig.run(parsed_config)
+  end
+
+  def parsed_config
+    parse(commit.file_content(CONFIG_FILE))
+  end
 
   def parse(file_content)
     Config::Parser.yaml(file_content) || {}
   end
 
-  def configured?(name)
-    key = normalize_key(name)
-    config = options_for(key)
-
-    enabled?(config)
-  end
-
-  def enabled?(config)
-    config["enabled"] || config["Enabled"]
-  end
-
   def options_for(name)
-    config = content[name] || {}
-    default_options_for(name).merge(config)
-  end
-
-  def default_options_for(name)
-    { "enabled" => !beta?(name) }
-  end
-
-  def beta?(name)
-    BETA_LINTERS.include?(name)
-  end
-
-  def normalize_key(key)
-    key.downcase.sub("_", "")
+    content.fetch(name, {})
   end
 end

--- a/app/services/check_enabled_linter.rb
+++ b/app/services/check_enabled_linter.rb
@@ -18,7 +18,7 @@ class CheckEnabledLinter
   private
 
   def linter_names
-    @configs.flat_map(&:linter_names)
+    @configs.flat_map(&:linter_name)
   end
 
   def hound_configs

--- a/app/services/normalize_config.rb
+++ b/app/services/normalize_config.rb
@@ -1,0 +1,27 @@
+class NormalizeConfig
+  def self.run(config)
+    new(config).run
+  end
+
+  def initialize(config)
+    @config = config
+  end
+
+  def run
+    @config.reduce({}) do |normalized_config, (key, value)|
+      normalized_key = normalize_key(key)
+      if value.is_a? Hash
+        normalized_config[normalized_key] = NormalizeConfig.run(value)
+      else
+        normalized_config[normalized_key] = value
+      end
+      normalized_config
+    end
+  end
+
+  private
+
+  def normalize_key(key)
+    key.downcase
+  end
+end

--- a/app/services/resolve_config_aliases.rb
+++ b/app/services/resolve_config_aliases.rb
@@ -1,0 +1,26 @@
+class ResolveConfigAliases
+  ALIASES = {
+    "javascript" => "jshint",
+    "java_script" => "jshint",
+    "coffeescript" => "coffee_script",
+  }.freeze
+
+  def self.run(config)
+    new(config).run
+  end
+
+  def initialize(config)
+    @config = config
+  end
+
+  def run
+    @config.reduce({}) do |resolved_config, (key, value)|
+      if ALIASES.keys.include? key
+        resolved_config[ALIASES[key]] = value
+      else
+        resolved_config[key] = value
+      end
+      resolved_config
+    end
+  end
+end

--- a/spec/models/config/base_spec.rb
+++ b/spec/models/config/base_spec.rb
@@ -127,14 +127,6 @@ describe Config::Base do
     end
   end
 
-  describe "#linter_names" do
-    it "returns a list of names the linter is accessible under" do
-      config = build_config
-
-      expect(config.linter_names).to eq ["test"]
-    end
-  end
-
   def build_config(hound_config: build_hound_config)
     Config::Test.new(hound_config)
   end

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -57,21 +57,12 @@ describe Config::CoffeeScript do
     end
   end
 
-  describe "#linter_names" do
-    it "returns the names that the linter can be reached as" do
-      commit = double("Commit")
-      config = build_config(commit)
-
-      expect(config.linter_names).to eq ["coffee_script", "coffeescript"]
-    end
-  end
-
   def build_config(commit)
     hound_config = double(
       "HoundConfig",
       commit: commit,
       content: {
-        "coffeescript" => {
+        "coffee_script" => {
           "enabled" => true,
           "config_file" => "config/coffeescript.json",
         },

--- a/spec/models/config/jshint_spec.rb
+++ b/spec/models/config/jshint_spec.rb
@@ -34,15 +34,6 @@ describe Config::Jshint do
     end
   end
 
-  describe "#linter_names" do
-    it "returns the names that the linter is accessible under" do
-      commit = stubbed_commit({})
-      config = build_config(commit)
-
-      expect(config.linter_names).to match_array %w(javascript java_script jshint)
-    end
-  end
-
   def build_config(commit)
     Config::Jshint.new(stubbed_hound_config(commit))
   end
@@ -52,7 +43,7 @@ describe Config::Jshint do
       "HoundConfig",
       commit: commit,
       content: {
-        "javascript" => {
+        "jshint" => {
           "enabled" => true,
           "config_file" => "config/jshint.json",
         },

--- a/spec/services/build_owner_hound_config_spec.rb
+++ b/spec/services/build_owner_hound_config_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe BuildOwnerHoundConfig do
   describe "#run" do
     context "when the owner has a configuration set" do
-      it "returns the configuration of that repo" do
+      it "returns the owner's config merged with the default HoundConfig" do
         owner = instance_double(
           "Owner",
           has_config_repo?: true,
@@ -11,7 +11,7 @@ describe BuildOwnerHoundConfig do
         )
         commit = stubbed_commit(
           ".hound.yml" => <<~EOS
-            ruby:
+            remark:
               enabled: true
           EOS
         )
@@ -20,12 +20,13 @@ describe BuildOwnerHoundConfig do
 
         owner_config = BuildOwnerHoundConfig.run(owner)
 
-        expect(owner_config.content).to eq("ruby" => { "enabled" => true })
+        expect(owner_config.content).
+          to eq(default_hound_config.merge("remark" => { "enabled" => true }))
       end
     end
 
     context "when the owner does not have a configuration set" do
-      it "returns an empty hound config" do
+      it "returns the default HoundConfig" do
         owner = instance_double(
           "Owner",
           has_config_repo?: false,
@@ -34,12 +35,12 @@ describe BuildOwnerHoundConfig do
 
         owner_config = BuildOwnerHoundConfig.run(owner)
 
-        expect(owner_config.content).to eq({})
+        expect(owner_config.content).to eq(default_hound_config)
       end
     end
 
     context "when the owner's configuration is unreachable" do
-      it "returns an empty hound config" do
+      it "returns the default HoundConfig" do
         owner = instance_double(
           "Owner",
           has_config_repo?: true,
@@ -49,12 +50,12 @@ describe BuildOwnerHoundConfig do
 
         owner_config = BuildOwnerHoundConfig.run(owner)
 
-        expect(owner_config.content).to eq({})
+        expect(owner_config.content).to eq(default_hound_config)
       end
     end
 
     context "when the owner's configuration is improperly formatted" do
-      it "returns an empty hound config" do
+      it "returns the default HoundConfig" do
         owner = instance_double(
           "Owner",
           has_config_repo?: true,
@@ -63,7 +64,7 @@ describe BuildOwnerHoundConfig do
 
         owner_config = BuildOwnerHoundConfig.run(owner)
 
-        expect(owner_config.content).to eq({})
+        expect(owner_config.content).to eq(default_hound_config)
       end
     end
   end
@@ -76,5 +77,9 @@ describe BuildOwnerHoundConfig do
   def stub_success_on_repo(repo_name)
     stub_request(:get, "https://api.github.com/repos/#{repo_name}").
       to_return(status: 200, body: "", headers: {})
+  end
+
+  def default_hound_config
+    HoundConfig.new(EmptyCommit.new).content
   end
 end

--- a/spec/services/check_enabled_linter_spec.rb
+++ b/spec/services/check_enabled_linter_spec.rb
@@ -8,7 +8,7 @@ describe CheckEnabledLinter do
         hound_config = double("HoundConfig", linter_enabled?: true)
         config = double(
           "Config",
-          linter_names: ["ruby"],
+          linter_name: ["ruby"],
           hound_config: hound_config,
         )
 
@@ -23,7 +23,7 @@ describe CheckEnabledLinter do
         hound_config = double("HoundConfig", linter_enabled?: false)
         config = double(
           "Config",
-          linter_names: ["ruby"],
+          linter_name: ["ruby"],
           hound_config: hound_config,
         )
 

--- a/spec/services/normalize_config_spec.rb
+++ b/spec/services/normalize_config_spec.rb
@@ -1,0 +1,15 @@
+require "app/services/normalize_config"
+
+describe NormalizeConfig do
+  describe "#run" do
+    context "given a hash with keys containing capital letters" do
+      it "downcases the keys" do
+        config = { "Ruby" => { "Enabled" => true } }
+
+        expect(NormalizeConfig.run(config)).to eq(
+          "ruby" => { "enabled" => true },
+        )
+      end
+    end
+  end
+end

--- a/spec/services/resolve_config_aliases_spec.rb
+++ b/spec/services/resolve_config_aliases_spec.rb
@@ -1,0 +1,17 @@
+require "app/services/resolve_config_aliases"
+
+describe ResolveConfigAliases do
+  describe "#run" do
+    context "when the config contains aliases" do
+      it "renames them to the appropriate linter" do
+        config = {
+          "javascript" => { "enabled" => false },
+          "ruby" => { "enabled" => false },
+        }
+
+        expect(ResolveConfigAliases.run(config).keys).
+          to match_array(["jshint", "ruby"])
+      end
+    end
+  end
+end

--- a/spec/support/helpers/commit_helper.rb
+++ b/spec/support/helpers/commit_helper.rb
@@ -1,0 +1,12 @@
+module CommitHelper
+  def stub_commit(files)
+    stubbed_commit = instance_double("Commit")
+    files.each do |name, content|
+      allow(stubbed_commit).
+        to receive(:file_content).
+        with(name).
+        and_return(content)
+    end
+    stubbed_commit
+  end
+end


### PR DESCRIPTION
Previously, `hound_config#enabled_for?` would return `true` for any value that was not:

 - Explicitly set to false in the supplied config file
 - A language marked as beta

Additionally, HoundConfig didn't account for aliases. This could result in someone disabling an alias (e.g. `javascript`) but still running the actual linter (e.g. `jshint`). Instead of trying to perform boolean logic about what is and is not activated, this strategy just starts with a default configuration and merges the user-specified configuration into it using a series of transforms.

Thanks to @jackvnimble for the idea!