### PR TITLE
Remove users with bad tokens from repo

### DIFF
--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -7,7 +7,7 @@ class BuildRunner
     end
   rescue Config::ParserError => exception
     report_config_file_as_invalid(exception)
-  rescue Octokit::NotFound
+  rescue Octokit::NotFound, Octokit::Unauthorized
     remove_current_user_membership
     raise
   end


### PR DESCRIPTION
GitHub returns `401 - Bad credentials` status when a user with
expired/invalid token tries to set it. We should handle that case and
remove that token from the repo's memberships.