### PR TITLE
Rename `enabled_for?` to `linter_enabled?`

### DIFF
--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -24,7 +24,7 @@ class HoundConfig
     @content ||= parse(commit.file_content(CONFIG_FILE))
   end
 
-  def enabled_for?(name)
+  def linter_enabled?(name)
     configured?(name)
   end
 

--- a/app/services/check_enabled_linter.rb
+++ b/app/services/check_enabled_linter.rb
@@ -10,7 +10,7 @@ class CheckEnabledLinter
   def enabled?
     linter_names.any? do |linter_name|
       hound_configs.any? do |hound_config|
-        hound_config.enabled_for?(linter_name)
+        hound_config.linter_enabled?(linter_name)
       end
     end
   end

--- a/spec/models/hound_config_spec.rb
+++ b/spec/models/hound_config_spec.rb
@@ -22,7 +22,7 @@ describe HoundConfig do
     end
   end
 
-  describe "#enabled_for?" do
+  describe "#linter_enabled?" do
     context "given a supported language" do
       it "returns true for all of them" do
         commit = stubbed_commit(".hound.yml" => "")
@@ -172,5 +172,9 @@ describe HoundConfig do
         expect(hound_config.fail_on_violations?).to eq false
       end
     end
+  end
+
+  def be_enabled_for(linter_name)
+    be_linter_enabled(linter_name)
   end
 end

--- a/spec/models/linter/coffee_script_spec.rb
+++ b/spec/models/linter/coffee_script_spec.rb
@@ -40,7 +40,7 @@ describe Linter::CoffeeScript do
   describe "enabled?" do
     context "when configuration is enabled" do
       it "is enabled" do
-        hound_config = double("HoundConfig", enabled_for?: true)
+        hound_config = double("HoundConfig", linter_enabled?: true)
         linter = build_linter(hound_config: hound_config)
 
         expect(linter).to be_enabled
@@ -49,7 +49,7 @@ describe Linter::CoffeeScript do
 
     context "when the config has enabled_for to false" do
       it "is not enabled" do
-        hound_config = double("HoundConfig", enabled_for?: false)
+        hound_config = double("HoundConfig", linter_enabled?: false)
         linter = build_linter(hound_config: hound_config)
 
         expect(linter).not_to be_enabled
@@ -241,6 +241,6 @@ describe Linter::CoffeeScript do
   end
 
   def default_hound_config
-    double("HoundConfig", enabled_for?: true, content: {})
+    double("HoundConfig", linter_enabled?: true, content: {})
   end
 end

--- a/spec/services/check_enabled_linter_spec.rb
+++ b/spec/services/check_enabled_linter_spec.rb
@@ -5,7 +5,7 @@ describe CheckEnabledLinter do
   describe ".run" do
     context "when the hound config is enabled for the given language" do
       it "returns true" do
-        hound_config = double("HoundConfig", enabled_for?: true)
+        hound_config = double("HoundConfig", linter_enabled?: true)
         config = double(
           "Config",
           linter_names: ["ruby"],
@@ -20,7 +20,7 @@ describe CheckEnabledLinter do
 
     context "when the hound config is disabled for the given language" do
       it "returns false" do
-        hound_config = double("HoundConfig", enabled_for?: false)
+        hound_config = double("HoundConfig", linter_enabled?: false)
         config = double(
           "Config",
           linter_names: ["ruby"],


### PR DESCRIPTION
This is a change isolated from https://github.com/houndci/hound/pull/1149. The new naming is clearer and makes `HoundConfig` more readable.