### PR TITLE
Owner level configuration

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -15,7 +15,7 @@ module Config
     end
 
     def merge(config)
-      serialize(content.deep_merge(config.content))
+      content.deep_merge(config.content)
     end
 
     def serialize(data = content)

--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -14,6 +14,10 @@ module Config
       [linter_name]
     end
 
+    def merge(config)
+      serialize(content.deep_merge(config.content))
+    end
+
     def serialize(data = content)
       data
     end

--- a/app/models/config/go.rb
+++ b/app/models/config/go.rb
@@ -5,5 +5,9 @@ module Config
     def content
       DEFAULT_CONFIG
     end
+
+    def merge(_config)
+      DEFAULT_CONFIG
+    end
   end
 end

--- a/app/models/config/scss.rb
+++ b/app/models/config/scss.rb
@@ -4,6 +4,10 @@ module Config
       Serializer.yaml(data)
     end
 
+    def merge(config)
+      serialize(content.deep_merge(config.content))
+    end
+
     private
 
     def parse(file_content)

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -42,7 +42,7 @@ module Linter
     def build_review_job_attributes(commit_file)
       {
         commit_sha: build.commit_sha,
-        config: config.serialize,
+        config: merged_config,
         content: commit_file.content,
         filename: commit_file.filename,
         linter_name: name,
@@ -57,6 +57,18 @@ module Linter
 
     def job_class
       "#{name.classify}ReviewJob".constantize
+    end
+
+    def merged_config
+      owner_config.merge(config)
+    end
+
+    def owner_config
+      @owner_config ||= ConfigBuilder.for(owner_hound_config, name)
+    end
+
+    def owner_hound_config
+      OwnerHoundConfigBuilder.run(build.repo, hound_config)
     end
 
     def config

--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -54,7 +54,7 @@ module Linter
     end
 
     def config_builder
-      RubyConfigBuilder.new(config.content, repository_owner_name)
+      RubyConfigBuilder.new(merged_config, repository_owner_name)
     end
 
     # This is deprecated in favor of RuboCop's DisplayCopNames option.

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -8,4 +8,8 @@ class Owner < ActiveRecord::Base
     owner.save!
     owner
   end
+
+  def has_config_repo?
+    config_enabled? && config_repo.present?
+  end
 end

--- a/app/services/owner_hound_config_builder.rb
+++ b/app/services/owner_hound_config_builder.rb
@@ -1,0 +1,25 @@
+class OwnerHoundConfigBuilder
+  HEAD = "HEAD".freeze
+  def self.run(repo, default)
+    new(repo, default).run
+  end
+
+  def initialize(repo, default)
+    @repo = repo
+    @default = default
+  end
+
+  def run
+    if repo.owner.has_config_repo?
+      github = GithubApi.new(Hound::GITHUB_TOKEN)
+      commit = Commit.new(repo.owner.config_repo, HEAD, github)
+      HoundConfig.new(commit)
+    else
+      default
+    end
+  end
+
+  private
+
+  attr_reader :repo, :default
+end

--- a/db/migrate/20160608183021_add_config_to_owner.rb
+++ b/db/migrate/20160608183021_add_config_to_owner.rb
@@ -1,0 +1,13 @@
+class AddConfigToOwner < ActiveRecord::Migration
+  def up
+    add_column :owners, :config_enabled, :boolean, null: false, default: false
+    add_column :owners, :config_repo, :string
+
+    Owner.update_all(config_enabled: true, config_repo: "houndci/legacy-config")
+  end
+
+  def down
+    remove_column :owners, :config_enabled
+    remove_column :owners, :config_repo
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160513205551) do
+ActiveRecord::Schema.define(version: 20160608183021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,11 +70,13 @@ ActiveRecord::Schema.define(version: 20160513205551) do
   add_index "memberships", ["user_id", "repo_id"], name: "index_memberships_on_user_id_and_repo_id", unique: true, using: :btree
 
   create_table "owners", force: :cascade do |t|
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.integer  "github_id",                    null: false
-    t.string   "name",                         null: false
-    t.boolean  "organization", default: false, null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "github_id",                      null: false
+    t.string   "name",                           null: false
+    t.boolean  "organization",   default: false, null: false
+    t.boolean  "config_enabled", default: false, null: false
+    t.string   "config_repo"
   end
 
   add_index "owners", ["github_id"], name: "index_owners_on_github_id", unique: true, using: :btree

--- a/spec/models/config/base_spec.rb
+++ b/spec/models/config/base_spec.rb
@@ -135,6 +135,26 @@ describe Config::Base do
     end
   end
 
+  describe "#merge" do
+    context "when the override contains keys not in the base config" do
+      it "returns a hash contains all keys and values" do
+        hound_config = instance_double(
+          "HoundConfig",
+          content: {
+            "test" => { "config_file" => "config-file.txt" }
+           },
+           commit: stubbed_commit("config-file.txt" => "some key: some value"),
+        )
+        base_config = build_config(hound_config: hound_config)
+        override_config = build_config(hound_config: hound_config)
+
+        merged_config = base_config.merge(override_config)
+
+        expect(merged_config).to include("some key" => "some value")
+      end
+    end
+  end
+
   def build_config(hound_config: build_hound_config)
     Config::Test.new(hound_config)
   end

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -115,6 +115,7 @@ describe Linter::Eslint do
       content: content,
       excluded_paths: excluded_paths,
       serialize: content.to_s,
+      merge: content.to_s,
     )
     allow(Config::Eslint).to receive(:new).and_return(stubbed_eslint_config)
 

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -39,6 +39,7 @@ describe Linter::Eslint do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.js")
       linter = build_linter
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -49,6 +50,7 @@ describe Linter::Eslint do
     it "schedules a review job" do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       stub_eslint_config(content: {})
+      stub_owner_hound_config
       commit_file = build_commit_file(filename: "lib/a.js")
       allow(Resque).to receive(:enqueue)
       linter = build_linter(build)

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -23,6 +23,7 @@ describe Linter::Go do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "a.go")
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -34,6 +35,7 @@ describe Linter::Go do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       linter = build_linter(build)
       commit_file = build_commit_file(filename: "a.go")
+      stub_owner_hound_config
       allow(Resque).to receive(:enqueue)
 
       linter.file_review(commit_file)

--- a/spec/models/linter/haml_spec.rb
+++ b/spec/models/linter/haml_spec.rb
@@ -25,6 +25,7 @@ describe Linter::Haml do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.haml")
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -36,6 +37,7 @@ describe Linter::Haml do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       linter = build_linter(build)
       stub_haml_config({})
+      stub_owner_hound_config
       commit_file = build_commit_file(filename: "lib/a.haml")
       allow(Resque).to receive(:enqueue)
 

--- a/spec/models/linter/haml_spec.rb
+++ b/spec/models/linter/haml_spec.rb
@@ -61,6 +61,7 @@ describe Linter::Haml do
       "HamlConfig",
       content: config,
       serialize: config.to_s,
+      merge: config.to_s,
     )
     allow(Config::Haml).to receive(:new).and_return(stubbed_haml_config)
 

--- a/spec/models/linter/jscs_spec.rb
+++ b/spec/models/linter/jscs_spec.rb
@@ -73,6 +73,7 @@ describe Linter::Jscs do
       "JscsConfig",
       content: content,
       serialize: content.to_s,
+      merge: content.to_s,
     )
     allow(Config::Jscs).to receive(:new).and_return(stubbed_jscs_config)
 

--- a/spec/models/linter/jscs_spec.rb
+++ b/spec/models/linter/jscs_spec.rb
@@ -39,6 +39,7 @@ describe Linter::Jscs do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.js")
       linter = build_linter
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -52,6 +53,7 @@ describe Linter::Jscs do
       commit_file = build_commit_file(filename: "lib/a.js")
       allow(Resque).to receive(:enqueue)
       linter = build_linter(build)
+      stub_owner_hound_config
 
       linter.file_review(commit_file)
 

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -73,6 +73,7 @@ describe Linter::Jshint do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.js")
       linter = build_linter
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -83,6 +84,7 @@ describe Linter::Jshint do
     it "schedules a review job" do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       stub_jshint_config(content: {})
+      stub_owner_hound_config
       commit_file = build_commit_file(filename: "lib/a.js")
       allow(Resque).to receive(:enqueue)
       linter = build_linter(build)

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -105,7 +105,7 @@ describe Linter::Jshint do
   def stub_jshint_config(options = {})
     default_options = {
       content: {},
-      serialize: "{}",
+      merge: "{}",
     }
     stubbed_jshint_config = double(
       "JshintConfig",

--- a/spec/models/linter/python_spec.rb
+++ b/spec/models/linter/python_spec.rb
@@ -24,6 +24,7 @@ describe Linter::Python do
       linter = build_linter
       commit_file = build_commit_file
       stub_python_config
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -36,6 +37,7 @@ describe Linter::Python do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       linter = build_linter(build)
       stub_python_config("config")
+      stub_owner_hound_config
       commit_file = build_commit_file
 
       linter.file_review(commit_file)

--- a/spec/models/linter/python_spec.rb
+++ b/spec/models/linter/python_spec.rb
@@ -80,6 +80,7 @@ describe Linter::Python do
       "PythonConfig",
       content: config,
       serialize: config,
+      merge: config,
     )
     allow(Config::Python).to receive(:new).and_return(stubbed_python_config)
 

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -31,6 +31,7 @@ describe Linter::Remark do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.md")
       linter = build_linter
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -41,6 +42,7 @@ describe Linter::Remark do
     it "schedules a review job" do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       stub_remark_config(content: {})
+      stub_owner_hound_config
       commit_file = build_commit_file(filename: "lib/a.md")
       allow(Resque).to receive(:enqueue)
       linter = build_linter(build)

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -49,13 +49,13 @@ describe Linter::Remark do
 
       expect(Resque).to have_received(:enqueue).with(
         RemarkReviewJob,
-        filename: commit_file.filename,
         commit_sha: build.commit_sha,
-        linter_name: "remark",
-        pull_request_number: build.pull_request_number,
-        patch: commit_file.patch,
-        content: commit_file.content,
         config: "{}",
+        content: commit_file.content,
+        filename: commit_file.filename,
+        linter_name: "remark",
+        patch: commit_file.patch,
+        pull_request_number: build.pull_request_number,
       )
     end
   end
@@ -65,6 +65,7 @@ describe Linter::Remark do
       "RemarkConfig",
       content: content,
       serialize: content.to_s,
+      merge: content.to_s,
     )
     allow(Config::Remark).to receive(:new).and_return(stubbed_remark_config)
 

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -702,13 +702,21 @@ describe Linter::Ruby do
     )
       Linter::Ruby.new(
         hound_config: hound_config,
-        build: build(:build),
+        build: build(:build, repo: repo_without_owner_config),
         repository_owner_name: repository_owner_name,
       )
     end
 
+    def repo_without_owner_config
+      build(:repo, owner: owner_without_config_repo)
+    end
+
+    def owner_without_config_repo
+      build(:owner, config_enabled: false)
+    end
+
     def stub_ruby_config(config = {})
-      stubbed_ruby_config = double("RubyConfig", content: config)
+      stubbed_ruby_config = double("RubyConfig", content: config, merge: config)
       allow(Config::Ruby).to receive(:new).and_return(stubbed_ruby_config)
 
       stubbed_ruby_config

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -24,6 +24,7 @@ describe Linter::Ruby do
 
     it "returns a saved and completed file review" do
       linter = build_linter
+      stub_owner_hound_config
 
       result = linter.file_review(build_file("test"))
 
@@ -651,6 +652,7 @@ describe Linter::Ruby do
           )
           file = double("CommitFile", filename: "ignore.rb")
           linter = build_linter(config: config)
+          stub_owner_hound_config
 
           expect(linter.file_included?(file)).to eq false
         end
@@ -661,6 +663,7 @@ describe Linter::Ruby do
           config = stub_ruby_config("AllCops" => { "Exclude" => [] })
           file = double("CommitFile", filename: "app.rb")
           linter = build_linter(config: config)
+          stub_owner_hound_config
 
           expect(linter.file_included?(file)).to eq true
         end
@@ -680,6 +683,7 @@ describe Linter::Ruby do
         config: config,
         repository_owner_name: repository_owner_name,
       )
+      stub_owner_hound_config
 
       linter.
         file_review(build_file(content)).
@@ -702,17 +706,9 @@ describe Linter::Ruby do
     )
       Linter::Ruby.new(
         hound_config: hound_config,
-        build: build(:build, repo: repo_without_owner_config),
+        build: build(:build),
         repository_owner_name: repository_owner_name,
       )
-    end
-
-    def repo_without_owner_config
-      build(:repo, owner: owner_without_config_repo)
-    end
-
-    def owner_without_config_repo
-      build(:owner, config_enabled: false)
     end
 
     def stub_ruby_config(config = {})

--- a/spec/models/linter/scss_spec.rb
+++ b/spec/models/linter/scss_spec.rb
@@ -23,6 +23,7 @@ describe Linter::Scss do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.scss")
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -34,6 +35,7 @@ describe Linter::Scss do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       linter = build_linter(build)
       stub_scss_config({})
+      stub_owner_hound_config
       commit_file = build_commit_file(filename: "lib/a.scss")
       allow(Resque).to receive(:enqueue)
 

--- a/spec/models/linter/scss_spec.rb
+++ b/spec/models/linter/scss_spec.rb
@@ -57,6 +57,7 @@ describe Linter::Scss do
       "ScssConfig",
       content: config,
       serialize: config.to_s,
+      merge: config.to_s,
     )
     allow(Config::Scss).to receive(:new).and_return(stubbed_scss_config)
 

--- a/spec/models/linter/swift_spec.rb
+++ b/spec/models/linter/swift_spec.rb
@@ -23,6 +23,7 @@ describe Linter::Swift do
     it "returns a saved, incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "a.swift")
+      stub_owner_hound_config
 
       result = linter.file_review(commit_file)
 
@@ -35,6 +36,7 @@ describe Linter::Swift do
       build = build(:build, commit_sha: "foo", pull_request_number: 123)
       linter = build_linter(build)
       stub_swift_config({})
+      stub_owner_hound_config
       commit_file = build_commit_file(filename: "a.swift")
 
       linter.file_review(commit_file)

--- a/spec/models/linter/swift_spec.rb
+++ b/spec/models/linter/swift_spec.rb
@@ -57,6 +57,7 @@ describe Linter::Swift do
       "SwiftConfig",
       content: config,
       serialize: config.to_s,
+      merge: config.to_s,
     )
     allow(Config::Swift).to receive(:new).and_return(stubbed_swift_config)
 

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -139,14 +139,11 @@ describe StyleChecker do
   end
 
   def pull_request_violation_messages(pull_request)
-    build = build(:build, repo: repo_without_owner_config)
+    build = build(:build)
+    stub_owner_hound_config
     StyleChecker.new(pull_request, build).review_files
 
     build.violations.flat_map(&:messages)
-  end
-
-  def repo_without_owner_config
-    build(:repo, owner: build(:owner, config_enabled: false))
   end
 
   def stub_pull_request(options = {})

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -139,10 +139,14 @@ describe StyleChecker do
   end
 
   def pull_request_violation_messages(pull_request)
-    build = build(:build)
+    build = build(:build, repo: repo_without_owner_config)
     StyleChecker.new(pull_request, build).review_files
 
     build.violations.flat_map(&:messages)
+  end
+
+  def repo_without_owner_config
+    build(:repo, owner: build(:owner, config_enabled: false))
   end
 
   def stub_pull_request(options = {})

--- a/spec/services/owner_hound_config_builder_spec.rb
+++ b/spec/services/owner_hound_config_builder_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe OwnerHoundConfigBuilder do
+  describe "#run" do
+    context "when the owner has a configuration set" do
+      it "returns the configuration of that repo" do
+        hound_config = instance_double("HoundConfig")
+        owner = instance_double(
+          "Owner",
+          has_config_repo?: true,
+          config_repo: "thoughtbot/guides",
+        )
+        commit = stubbed_commit(
+          ".hound.yml" => <<~EOS
+            ruby:
+              enabled: true
+          EOS
+        )
+        allow(Commit).to receive(:new).and_return(commit)
+        repo = instance_double("Repo", owner: owner)
+
+        owner_config = OwnerHoundConfigBuilder.run(repo, hound_config)
+
+        expect(owner_config.content).to eq("ruby" => {"enabled" => true})
+      end
+    end
+
+    context "when the owner does not have a configuration set"
+      it "returns the default it was passed" do
+        hound_config = instance_double("HoundConfig")
+        owner = instance_double(
+          "Owner",
+          has_config_repo?: false,
+          config_repo: "thoughtbot/guides",
+        )
+        repo = instance_double("Repo", owner: owner)
+
+        owner_config = OwnerHoundConfigBuilder.run(repo, hound_config)
+
+        expect(owner_config).to eq(hound_config)
+      end
+  end
+end

--- a/spec/support/helpers/linter_helper.rb
+++ b/spec/support/helpers/linter_helper.rb
@@ -4,9 +4,6 @@ module LinterHelper
     extra_files = {}
   )
     head_commit = double("Commit", file_content: "{}")
-    unless build.nil?
-      stub_build_to_return_repo(build)
-    end
     stub_commit_to_return_hound_config(head_commit)
     stub_commit_to_return_extra_files(head_commit, extra_files)
     described_class.new(
@@ -14,10 +11,6 @@ module LinterHelper
       build: build,
       repository_owner_name: "ralph",
     )
-  end
-
-  def stub_build_to_return_repo(build)
-    allow(build).to receive(:repo).and_return(repo_without_organization_config)
   end
 
   def repo_without_organization_config

--- a/spec/support/helpers/linter_helper.rb
+++ b/spec/support/helpers/linter_helper.rb
@@ -1,6 +1,12 @@
 module LinterHelper
-  def build_linter(build = build(:build), extra_files = {})
+  def build_linter(
+    build = build(:build),
+    extra_files = {}
+  )
     head_commit = double("Commit", file_content: "{}")
+    unless build.nil?
+      stub_build_to_return_repo(build)
+    end
     stub_commit_to_return_hound_config(head_commit)
     stub_commit_to_return_extra_files(head_commit, extra_files)
     described_class.new(
@@ -8,6 +14,14 @@ module LinterHelper
       build: build,
       repository_owner_name: "ralph",
     )
+  end
+
+  def stub_build_to_return_repo(build)
+    allow(build).to receive(:repo).and_return(repo_without_organization_config)
+  end
+
+  def repo_without_organization_config
+    build(:repo, owner: build(:owner, config_enabled: false))
   end
 
   def raw_hound_config

--- a/spec/support/helpers/linter_helper.rb
+++ b/spec/support/helpers/linter_helper.rb
@@ -1,8 +1,5 @@
 module LinterHelper
-  def build_linter(
-    build = build(:build),
-    extra_files = {}
-  )
+  def build_linter(build = build(:build), extra_files = {})
     head_commit = double("Commit", file_content: "{}")
     stub_commit_to_return_hound_config(head_commit)
     stub_commit_to_return_extra_files(head_commit, extra_files)
@@ -11,10 +8,6 @@ module LinterHelper
       build: build,
       repository_owner_name: "ralph",
     )
-  end
-
-  def repo_without_organization_config
-    build(:repo, owner: build(:owner, config_enabled: false))
   end
 
   def raw_hound_config
@@ -70,6 +63,12 @@ module LinterHelper
     end
 
     commit
+  end
+
+  def stub_owner_hound_config
+    allow(OwnerHoundConfigBuilder).to receive(:run) do |repo, default|
+      default
+    end
   end
 end
 


### PR DESCRIPTION
As a user, I'd like to be able to specify a repository which acts as the default configuration for all of a particular owner's repos.

**Changes**

 - `config_repo`, and `config_enabled` columns added to `owners` table
 - all configs get a `merge` method which takes another config and returns the result of combining them
 - `OwnerHoundConfigBuilder` takes a repo and a `HoundConfig` and returns either the repo owner's `HoundConfig` or, failing that, the `HoundConfig` it was passed.
 - stub `OwnerHoundConfigBuilder` in a lot of tests (I don't love this but I don't see a great way around it either)

**Still working on**

 - higher-level specs for opening pull requests where owner level configs should be used and verifying that they are generated correctly.