### PR TITLE
Add BuildOwnerHoundConfig service

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -8,4 +8,8 @@ class Owner < ActiveRecord::Base
     owner.save!
     owner
   end
+
+  def has_config_repo?
+    config_enabled? && config_repo.present?
+  end
 end

--- a/app/services/build_owner_hound_config.rb
+++ b/app/services/build_owner_hound_config.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+class BuildOwnerHoundConfig
+  LATEST_SHA = "HEAD"
+
+  def self.run(*args)
+    new(*args).run
+  end
+
+  def initialize(owner)
+    @owner = owner
+  end
+
+  def run
+    if owner.has_config_repo?
+      github = GithubApi.new(user_token)
+      commit = Commit.new(config_repo.full_github_name, LATEST_SHA, github)
+      HoundConfig.new(commit)
+    end
+  end
+
+  private
+
+  attr_reader :owner
+
+  def user_token
+    UserToken.new(config_repo).token
+  end
+
+  def config_repo
+    Repo.find_or_create_with(full_github_name: owner.config_repo)
+  end
+end

--- a/db/migrate/20160608183021_add_config_to_owner.rb
+++ b/db/migrate/20160608183021_add_config_to_owner.rb
@@ -1,0 +1,24 @@
+class AddConfigToOwner < ActiveRecord::Migration
+  def up
+    add_column :owners, :config_enabled, :boolean, null: false, default: false
+    add_column :owners, :config_repo, :string
+
+    execute <<~SQL
+      UPDATE
+        owners
+      SET
+        config_repo = 'houndci/legacy-config',
+        config_enabled = true
+      FROM
+        repos
+      WHERE
+        repos.owner_id = owners.id AND repos.active = true;
+    SQL
+
+  end
+
+  def down
+    remove_column :owners, :config_enabled
+    remove_column :owners, :config_repo
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160513205551) do
+ActiveRecord::Schema.define(version: 20160608183021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,11 +70,13 @@ ActiveRecord::Schema.define(version: 20160513205551) do
   add_index "memberships", ["user_id", "repo_id"], name: "index_memberships_on_user_id_and_repo_id", unique: true, using: :btree
 
   create_table "owners", force: :cascade do |t|
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.integer  "github_id",                    null: false
-    t.string   "name",                         null: false
-    t.boolean  "organization", default: false, null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.integer  "github_id",                      null: false
+    t.string   "name",                           null: false
+    t.boolean  "organization",   default: false, null: false
+    t.boolean  "config_enabled", default: false, null: false
+    t.string   "config_repo"
   end
 
   add_index "owners", ["github_id"], name: "index_owners_on_github_id", unique: true, using: :btree

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -36,4 +36,30 @@ describe Owner do
       end
     end
   end
+
+  describe "#has_config_repo?" do
+    context "when the owner has a config repo set and enabled" do
+      it "returns true" do
+        owner = create(:owner, config_repo: "org/style", config_enabled: true)
+
+        expect(owner).to have_config_repo
+      end
+    end
+
+    context "when the owner has a config repo set and disabled" do
+      it "returns false" do
+        owner = create(:owner, config_repo: "org/style", config_enabled: false)
+
+        expect(owner).not_to have_config_repo
+      end
+    end
+
+    context "when the owner does not have a config repo set" do
+      it "returns false" do
+        owner = create(:owner, config_repo: "")
+
+        expect(owner).not_to have_config_repo
+      end
+    end
+  end
 end

--- a/spec/services/build_owner_hound_config_spec.rb
+++ b/spec/services/build_owner_hound_config_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe BuildOwnerHoundConfig do
+  describe "#run" do
+    context "when the owner has a configuration set" do
+      it "returns the configuration of that repo" do
+        owner = instance_double(
+          "Owner",
+          has_config_repo?: true,
+          config_repo: "thoughtbot/guides",
+        )
+        commit = stubbed_commit(
+          ".hound.yml" => <<~EOS
+            ruby:
+              enabled: true
+          EOS
+        )
+        allow(Commit).to receive(:new).and_return(commit)
+
+        owner_config = BuildOwnerHoundConfig.run(owner)
+
+        expect(owner_config.content).to eq("ruby" => { "enabled" => true })
+      end
+    end
+
+    context "when the owner does not have a configuration set" do
+      it "returns nil" do
+        owner = instance_double(
+          "Owner",
+          has_config_repo?: false,
+          config_repo: "thoughtbot/guides",
+        )
+
+        owner_config = BuildOwnerHoundConfig.run(owner)
+
+        expect(owner_config).to be_nil
+      end
+    end
+
+    context "when the owner's configuration is unreachable" do
+      it "returns an empty hound config" do
+        owner = instance_double(
+          "Owner",
+          has_config_repo?: true,
+          config_repo: "organization/private_style_guides",
+        )
+        stub_failure_on_repo(repo: "organization/private_style_guides")
+
+        owner_config = BuildOwnerHoundConfig.run(owner)
+
+        expect(owner_config.content).to eq({})
+      end
+    end
+  end
+
+  def stub_failure_on_repo(repo:)
+    stub_request(
+      :get,
+      %r"https://api.github.com/repos/#{repo}/contents/*",
+    ).to_return(status: 404, headers: {})
+  end
+end


### PR DESCRIPTION
I just realized I can split these owner level config changes up and not change anything on the user facing side, so here's the first of several smaller PR's.

Owners can now have a config repository configured. When given an
`owner` `BuildOwnerHoundConfig` will fetch the HEAD commit of the repo
and give back a `HoundConfig` built from it. If the owner does not have
a config repo or it is disabled `BuildOwnerHoundConfig` will return
false.