### PR TITLE
Owner Level Ruby Configuration

### DIFF
--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -4,7 +4,7 @@ module Linter
       self::FILE_REGEXP === filename
     end
 
-    def initialize(hound_config:, build:, repository_owner_name:)
+    def initialize(hound_config:, build:, repository_owner_name: "")
       @hound_config = hound_config
       @build = build
       @repository_owner_name = repository_owner_name

--- a/app/services/ruby_config_builder.rb
+++ b/app/services/ruby_config_builder.rb
@@ -14,14 +14,16 @@ class RubyConfigBuilder
   end
 
   def merge(overrides)
-    RuboCop::ConfigLoader.merge(content, normalize_config(overrides))
-  rescue NoMethodError, TypeError
-    config
+    normalize_config(merge_hashes(config, overrides))
   end
 
   private
 
   attr_reader :content
+
+  def merge_hashes(a, b)
+    RuboCop::ConfigLoader.merge(a, b)
+  end
 
   def normalized_content
     normalize_config(content)

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -23,7 +23,8 @@ describe Linter::Ruby do
     include ConfigurationHelper
 
     it "returns a saved and completed file review" do
-      linter = build_linter
+      stub_ruby_config
+      linter = build_linter(build: build_with_stubbed_owner_config(""))
 
       result = linter.file_review(build_file("test"))
 
@@ -31,22 +32,30 @@ describe Linter::Ruby do
       expect(result).to be_completed
     end
 
-    context "with default configuration" do
+    context "with default rubocop config" do
       it "returns no violations for code with the lonely operator" do
-        expect(violations_in("user.subscription&.amount\n")).to eq []
+        code = "user.subscription&.amount\n"
+
+        violations = violations_in(code)
+
+        expect(violations).to eq []
       end
 
-      describe "for private prefix" do
+      context "for private prefix" do
         it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
+          code = <<~CODE
             private def foo
               bar
             end
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq []
         end
       end
 
-      describe "for trailing commas" do
+      context "for trailing commas" do
         it "returns no violations" do
           code = <<-CODE.strip_heredoc
             _one = [
@@ -60,167 +69,115 @@ describe Linter::Ruby do
             }
           CODE
 
-          expect(violations_in(code)).to eq []
+          violations = violations_in(code)
+
+          expect(violations).to eq []
         end
       end
 
-      describe "for single line conditional" do
+      context "when using detect" do
         it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
-            if signed_in? then redirect_to dashboard_path end
-          CODE
+          code = "users.detect(&:active?)\n"
+
+          violations = violations_in(code)
+
+          expect(violations).to eq []
         end
       end
 
-      describe "for has_* method name" do
+      context "when using select" do
         it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
-            def has_something?
-              "something"
-            end
-          CODE
+          code = "users.select(&:active?)\n"
+
+          violations = violations_in(code)
+
+          expect(violations).to eq []
         end
       end
 
-      describe "for is_* method name" do
-        it "returns violations" do
-          violations = ["Rename `is_something?` to `something?`."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            def is_something?
-              "something"
-            end
-          CODE
-        end
-      end
-
-      describe "when using detect" do
+      context "when using map" do
         it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
-            users.detect(&:active?)
-          CODE
+          code = "users.map(&:active?)\n"
+
+          violations = violations_in(code)
+
+          expect(violations).to eq []
         end
       end
 
-      describe "when using find" do
-        it "returns violations" do
-          violations = ["Prefer `detect` over `find`."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            users.find(&:active?)
-          CODE
-        end
-      end
-
-      describe "when using select" do
+      context "when using inject" do
         it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
-            users.select(&:active?)
-          CODE
-        end
-      end
-
-      describe "when using find_all" do
-        it "returns violations" do
-          violations = ["Prefer `select` over `find_all`."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            users.find_all(&:active?)
-          CODE
-        end
-      end
-
-      describe "when using map" do
-        it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
-            users.map(&:active?)
-          CODE
-        end
-      end
-
-      describe "when using collect" do
-        it "returns violations" do
-          violations = ["Prefer `map` over `collect`."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            users.collect(&:active?)
-          CODE
-        end
-      end
-
-      describe "when using inject" do
-        it "returns no violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq []
+          code = <<~CODE
             users.inject(0) do |sum, user|
               sum + user.age
             end
           CODE
-        end
-      end
 
-      describe "when using reduce" do
-        it "returns violations" do
-          violations = ["Prefer `inject` over `reduce`."]
+          violations = violations_in(code)
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            users.reduce(0) do |_, user|
-              user.age
-            end
-          CODE
+          expect(violations).to eq []
         end
       end
 
       context "for long line" do
         it "returns violation" do
-          violations = ["Line is too long. [81/80]"]
+          expected_violations = ["Line is too long. [81/80]"]
+          code = "a" * 81 + "\n"
 
-          expect(violations_in("a" * 81 + "\n")).to eq violations
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for trailing whitespace" do
         it "returns violation" do
-          violations = ["Trailing whitespace detected."]
+          expected_violations = ["Trailing whitespace detected."]
+          code = "[1, 2].sum \n"
 
-          expect(violations_in("[1, 2].sum \n")).to eq violations
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for spaces after (" do
         it "returns violations" do
-          violations = ["Space inside parentheses detected."]
+          expected_violations = ["Space inside parentheses detected."]
+          code = "logger( 'test')\n"
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            logger( "test")
-          CODE
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for spaces before )" do
         it "returns violations" do
-          violations = ["Space inside parentheses detected."]
+          expected_violations = ["Space inside parentheses detected."]
+          code = "logger('test' )\n"
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            logger("test" )
-          CODE
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for spaces before ]" do
         it "returns violations" do
-          violations = ["Space inside square brackets detected."]
+          expected_violations = ["Space inside square brackets detected."]
+          code = "a['test' ]\n"
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            a["test" ]
-          CODE
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for private methods indented more than public methods" do
         it "returns violations" do
-          violations = ["Inconsistent indentation detected."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
+          expected_violations = ["Inconsistent indentation detected."]
+          code = <<~CODE
             def one
               1
             end
@@ -231,41 +188,35 @@ describe Linter::Ruby do
                 2
               end
           CODE
-        end
-      end
 
-      context "for leading dot used for multi-line method chain" do
-        it "returns violations" do
-          violations = ["Place the . on the previous line, together with the "\
-                        "method call receiver."]
+          violations = violations_in(code)
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            one
-              .two
-          CODE
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for tab indentation" do
         it "returns violations" do
-          violations = [
+          expected_violations = [
             "Use 2 (not 1) spaces for indentation.",
             "Tab detected."
           ]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
+          code = <<~CODE
             def test
-            \tlogger "test"
+            \tlogger 'test'
             end
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for two methods without newline separation" do
         it "returns violations" do
-          violations = ["Use empty lines between method definitions."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
+          expected_violations = ["Use empty lines between method definitions."]
+          code = <<~CODE
             def one
               1
             end
@@ -273,113 +224,155 @@ describe Linter::Ruby do
               2
             end
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq(expected_violations)
         end
       end
 
       context "for operator without surrounding spaces" do
         it "returns violations" do
-          violation = "Surrounding space missing for operator `+`."
-          expect(violations_in(<<-CODE.strip_heredoc)).to include violation
-            two = 1+1
-          CODE
+          expected_violation = "Surrounding space missing for operator `+`."
+          code = "two = 1+1\n"
+
+          violations = violations_in(code)
+
+          expect(violations).to include expected_violation
         end
       end
 
       context "for comma without trailing space" do
         it "returns violations" do
-          violations = ["Space missing after comma."]
+          expected_violations = ["Space missing after comma."]
+          code = "logger :one,:two\n"
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            logger :one,:two
-          CODE
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for colon without trailing space" do
         it "returns violations" do
-          violations = ["Space missing after colon.",
+          expected_violations = ["Space missing after colon.",
                         "Space inside { missing.",
                         "Space inside } missing."]
+          code = "{one:1}\n"
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            {one:1}
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "for is_* method name" do
+        it "returns violations" do
+          expected_violations = ["Rename `is_something?` to `something?`."]
+          code = <<~CODE
+            def is_something?
+              'something'
+            end
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for semicolon without trailing space" do
         it "returns violations" do
-          violations = ["Do not use semicolons to terminate expressions.",
-                        "Space missing after semicolon."]
+          expected_violations = [
+            "Do not use semicolons to terminate expressions.",
+            "Space missing after semicolon.",
+          ]
+          code = "logger :one;logger :two\n"
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            logger :one;logger :two
-          CODE
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for opening brace without leading space" do
         it "returns violations" do
-          violations = ["Surrounding space missing for operator `=`."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
+          expected_violations = ["Surrounding space missing for operator `=`."]
+          code = <<~CODE
             a ={ one: 1 }
             a
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for opening brace without trailing space" do
         it "returns violations" do
-          violations = ["Space inside { missing."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
+          expected_violations = ["Space inside { missing."]
+          code = <<~CODE
             a = {one: 1 }
             a
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for closing brace without leading space" do
         it "returns violations" do
-          violations = ["Space inside } missing."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
+          expected_violations = ["Space inside } missing."]
+          code = <<~CODE
             a = { one: 1}
             a
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "for method definitions with optional named arguments" do
         it "does not return violations" do
-          expect(violations_in(<<-CODE.strip_heredoc)).to be_empty
+          code = <<~CODE
             def register_email(email:)
               register(email)
             end
           CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq []
         end
       end
 
       context "for argument list spanning multiple lines" do
         context "when each argument is not on its own line" do
           it "returns violations" do
-            code = <<-CODE.strip_heredoc
+            expected_violations = [
+              "Align the parameters of a method call if they span more than " +
+                "one line.",
+            ]
+            code = <<~CODE
               validates :name,
                 presence: true,
                 uniqueness: true
             CODE
 
-            expect(violations_in(code)).to eq [
-              "Align the parameters of a method call if they span more than " +
-                "one line."
-            ]
+            violations = violations_in(code)
+
+            expect(violations).to eq expected_violations
           end
         end
 
         context "when each argument is on its own line" do
           it "returns no violations" do
-            code = <<-CODE.strip_heredoc
+            code = <<~CODE
               validates(
                 :name,
                 presence: true,
@@ -387,7 +380,9 @@ describe Linter::Ruby do
               )
             CODE
 
-            expect(violations_in(code)).to be_empty
+            violations = violations_in(code)
+
+            expect(violations).to eq []
           end
         end
       end
@@ -395,20 +390,26 @@ describe Linter::Ruby do
       context "for required keyword arguments" do
         context "without space after arguments" do
           it "returns no violations" do
-            code = <<-CODE.strip_heredoc
+            code = <<~CODE
               def initialize(name:, age:)
                 @name = name
                 @age = age
               end
             CODE
 
-            expect(violations_in(code)).to be_empty
+            violations = violations_in(code)
+
+            expect(violations).to eq []
           end
         end
 
         context "with spaces after arguments" do
           it "returns violations" do
-            code = <<-CODE.strip_heredoc
+            expected_violations = [
+              "Space found before comma.",
+              "Space inside parentheses detected.",
+            ]
+            code = <<~CODE
               def initialize(name: , age: )
                 @name = name
                 @age = age
@@ -417,16 +418,171 @@ describe Linter::Ruby do
 
             violations = violations_in(code)
 
-            expect(violations).to eq [
-              "Space found before comma.",
-              "Space inside parentheses detected.",
-            ]
+            expect(violations).to eq expected_violations
           end
+        end
+      end
+
+      context "with using block" do
+        it "returns violations" do
+          expected_violations = ["Pass `&:name` as an argument to `map` "\
+                        "instead of a block."]
+          code = <<~CODE
+            users.map do |user|
+              user.name
+            end
+          CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "with calls debugger" do
+        it "returns violations" do
+          expected_violations = ["Remove debugger entry point `binding.pry`."]
+          code = "binding.pry\n"
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "with empty lines around block" do
+        it "returns violations" do
+          expected_violations = [
+            "Extra empty line detected at block body beginning.",
+            "Extra empty line detected at block body end.",
+          ]
+          code = <<~CODE
+            block do |hoge|
+
+              hoge
+
+            end
+          CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "with unnecessary space" do
+        it "returns violations" do
+          expected_violations = [
+            "Unnecessary spacing detected.",
+            "Operator `=` should be surrounded by a single space.",
+          ]
+          code = <<~CODE
+            hoge  = 'https://github.com/bbatsov/rubocop'
+            hoge
+          CODE
+
+          violations = violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+    end
+
+    context "with legacy hound configuration set on owner" do
+      context "for single line conditional" do
+        it "returns no violations" do
+          code = "if signed_in? then redirect_to dashboard_path end\n"
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq []
+        end
+      end
+
+      context "for has_* method name" do
+        it "returns no violations" do
+          code = <<~CODE
+            def has_something?
+              "something"
+            end
+          CODE
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq []
+        end
+      end
+
+      context "when using find" do
+        it "returns violations" do
+          expected_violations = ["Prefer `detect` over `find`."]
+          code = "users.find(&:active?)\n"
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "when using find_all" do
+        it "returns violations" do
+          expected_violations = ["Prefer `select` over `find_all`."]
+          code = "users.find_all(&:active?)\n"
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "when using collect" do
+        it "returns violations" do
+          expected_violations = ["Prefer `map` over `collect`."]
+          code = "users.collect(&:active?)\nusers.collect(&:active?)\n"
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "when using reduce" do
+        it "returns violations" do
+          expected_violations = ["Prefer `inject` over `reduce`."]
+          code = <<~CODE
+            users.reduce(0) do |_, user|
+              user.age
+            end
+          CODE
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "for leading dot used for multi-line method chain" do
+        it "returns violations" do
+          expected_violations = [
+            "Place the . on the previous line, together with the "\
+            "method call receiver.",
+          ]
+          code = <<~CODE
+            one
+              .two
+          CODE
+
+          violations = legacy_violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
       context "when continued lines are not aligned with operand" do
         it "returns violations" do
+          expected_violations = [
+            "Align `limit` with `User.order(:name).` on line 2.",
+          ]
           code = <<-CODE.strip_heredoc
             def user_names
               user = User.order(:name).
@@ -435,136 +591,151 @@ describe Linter::Ruby do
             end
           CODE
 
-          violations = violations_in(code)
+          violations = legacy_violations_in(code)
 
-          expect(violations).to eq [
-            "Align `limit` with `User.order(:name).` on line 2.",
+          expect(violations).to eq expected_violations
+        end
+      end
+    end
+
+    context "with thoughtbot configuration set on owner" do
+      context "when continued lines are aligned with operand" do
+        it "returns violations" do
+          expected_violations = [
+            "Use 2 (not 7) spaces for indenting an expression " +
+              "in an assignment spanning multiple lines.",
           ]
+          code = <<-CODE.strip_heredoc
+            def foo
+              user = User.where(email: "user@example.com").
+                     assign_attributes(name: "User")
+              user.save!
+            end
+          CODE
+
+          violations = thoughtbot_violations_in(code)
+
+          expect(violations).to eq expected_violations
         end
       end
 
-      context "when continued lines are aligned with operand" do
-        context "with thoughtbot repo" do
-          it "returns violations" do
-            code = <<-CODE.strip_heredoc
-              def foo
-                user = User.where(email: "user@example.com").
-                       assign_attributes(name: "User")
-                user.save!
-              end
-            CODE
+      context "when using reduce" do
+        it "returns no violations" do
+          code = <<~CODE
+            users.reduce(0) do |sum, user|
+              sum + user.age
+            end
+          CODE
 
-            violations = violations_in(
-              code,
-              repository_owner_name: "thoughtbot",
-            )
+          violations = thoughtbot_violations_in(code)
 
-            expect(violations).to eq [
-              "Use 2 (not 7) spaces for indenting an expression " +
-                "in an assignment spanning multiple lines."
-            ]
-          end
+          expect(violations).to eq []
+        end
+      end
+
+      context "when using inject" do
+        it "returns violations" do
+          expected_violations = ["Prefer `reduce` over `inject`."]
+          code = <<-CODE.strip_heredoc
+            users.inject(0) do |_, user|
+              user.age
+            end
+          CODE
+
+          violations = thoughtbot_violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "when ommitting trailing commas" do
+        it "returns violations" do
+          expected_violations = [
+            "Put a comma after the last item of a multiline hash.",
+          ]
+          code = <<-CODE.strip_heredoc
+            {
+              a: 1,
+              b: 2
+            }
+          CODE
+
+          violations = thoughtbot_violations_in(code)
+
+          expect(violations).to eq expected_violations
+        end
+      end
+
+      context "when trailing commas are present" do
+        it "returns no violations" do
+          code = <<~CODE
+            {
+              a: 1,
+              b: 2,
+            }
+          CODE
+
+          violations = thoughtbot_violations_in(code)
+
+          expect(violations).to eq []
         end
       end
     end
 
     context "with custom configuration" do
       it "finds only one violation" do
+        expected_violations = ["Use the new Ruby 1.9 hash syntax."]
         config = stub_ruby_config(
           "StringLiterals" => {
-            "EnforcedStyle" => "double_quotes"
-          }
+            "EnforcedStyle" => "double_quotes",
+          },
         )
+        code = <<-CODE.strip_heredoc
+          { :foo => 'hello world' }
+        CODE
 
-        violations = violations_with_config(config: config)
+        violations = violations_in(code, config: config)
 
-        expect(violations).to eq ["Use the new Ruby 1.9 hash syntax."]
+        expect(violations).to eq expected_violations
       end
 
       it "can use custom configuration to display rubocop cop names" do
+        expected_violations = [
+          "Style/HashSyntax: Use the new Ruby 1.9 hash syntax.",
+        ]
         config = stub_ruby_config(
           "AllCops" => { "DisplayCopNames" => "true" },
         )
+        code = <<-CODE.strip_heredoc
+          { :foo => 'hello world' }
+        CODE
 
-        violations = violations_with_config(config)
+        violations = violations_in(code, config: config)
 
-        expect(violations).to eq [
-          "Style/HashSyntax: Use the new Ruby 1.9 hash syntax."
-        ]
+        expect(violations).to eq expected_violations
       end
 
       context "with old-style syntax" do
         it "has one violation" do
+          expected_violations = [
+            "Prefer single-quoted strings when you don't need string "\
+            "interpolation or special symbols.",
+          ]
           config = stub_ruby_config(
-            "StringLiterals" => {
+            "Style/StringLiterals" => {
               "EnforcedStyle" => "single_quotes",
             },
-            "HashSyntax" => {
+            "Style/HashSyntax" => {
               "EnforcedStyle" => "hash_rockets",
             },
           )
-
-          violations = violations_with_config(config)
-
-          expect(violations).to eq [
-            "Prefer single-quoted strings when you don't need string "\
-            "interpolation or special symbols."
-          ]
-        end
-      end
-
-      context "with using block" do
-        it "returns violations" do
-          violations = ["Pass `&:name` as an argument to `map` "\
-                        "instead of a block."]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            users.map do |user|
-              user.name
-            end
+          code = <<~CODE
+            { :foo => "hello world" }
           CODE
-        end
-      end
 
-      context "with calls debugger" do
-        it "returns violations" do
-          violations = ["Remove debugger entry point `binding.pry`."]
+          violations = violations_in(code, config: config)
 
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            binding.pry
-          CODE
-        end
-      end
-
-      context "with empty lines around block" do
-        it "returns violations" do
-          violations = [
-            "Extra empty line detected at block body beginning.",
-            "Extra empty line detected at block body end.",
-          ]
-
-          expect(violations_in(<<-CODE.strip_heredoc)).to eq violations
-            block do |hoge|
-
-              hoge
-
-            end
-          CODE
-        end
-      end
-
-      context "with unnecessary space" do
-        it "returns violations" do
-          code = <<-CODE.strip_heredoc
-            hoge  = "https://github.com/bbatsov/rubocop"
-            hoge
-          CODE
-          violations = [
-            "Unnecessary spacing detected.",
-            "Operator `=` should be surrounded by a single space.",
-          ]
-
-          expect(violations_in(code)).to eq violations
+          expect(violations).to eq expected_violations
         end
       end
     end
@@ -573,7 +744,7 @@ describe Linter::Ruby do
       context "disabling a cop" do
         it "does not return a violation" do
           config = stub_ruby_config(
-            "StringLiterals" => {
+            "Style/StringLiterals" => {
               "EnforcedStyle" => "double_quotes",
             },
           )
@@ -584,142 +755,107 @@ describe Linter::Ruby do
 
           violations = violations_in(code, config: config)
 
-          expect(violations).to be_empty
+          expect(violations).to eq []
         end
       end
     end
+  end
 
-    context "thoughtbot organization PR" do
-      describe "when using reduce" do
-        it "returns no violations" do
-          expect(thoughtbot_violations_in(<<-CODE.strip_heredoc)).to eq []
-            users.reduce(0) do |sum, user|
-              sum + user.age
-            end
-          CODE
-        end
-      end
+  describe "#file_included?" do
+    context "with excluded file" do
+      it "returns false" do
+        stub_ruby_config("AllCops" => { "Exclude" => ["ignore.rb"] })
+        file = double("CommitFile", filename: "ignore.rb")
+        linter = build_linter(build: build_with_stubbed_owner_config(""))
 
-      describe "when using inject" do
-        it "returns violations" do
-          code = <<-CODE.strip_heredoc
-            users.inject(0) do |_, user|
-              user.age
-            end
-          CODE
-
-          violations = ["Prefer `reduce` over `inject`."]
-          expect(thoughtbot_violations_in(code)).to eq violations
-        end
-      end
-
-      describe "when ommitting trailing commas" do
-        it "returns violations" do
-          violations = ["Put a comma after the last item of a multiline hash."]
-          code = <<-CODE.strip_heredoc
-            {
-              a: 1,
-              b: 2
-            }
-          CODE
-
-          expect(thoughtbot_violations_in(code)).to eq violations
-        end
-      end
-
-      describe "when trailing commas are present" do
-        it "returns no violations" do
-          expect(thoughtbot_violations_in(<<-CODE.strip_heredoc)).to eq []
-            {
-              a: 1,
-              b: 2,
-            }
-          CODE
-        end
-      end
-
-      def thoughtbot_violations_in(content)
-        violations_in(content, repository_owner_name: "thoughtbot")
+        expect(linter.file_included?(file)).to eq false
       end
     end
 
-    describe "#file_included?" do
-      context "with excluded file" do
-        it "returns false" do
-          config = stub_ruby_config(
-            "AllCops" => { "Exclude" => ["ignore.rb"] },
-          )
-          file = double("CommitFile", filename: "ignore.rb")
-          linter = build_linter(config: config)
+    context "with included file" do
+      it "returns true" do
+        stub_ruby_config("AllCops" => { "Exclude" => [] })
+        file = double("CommitFile", filename: "app.rb")
+        linter = build_linter(build: build_with_stubbed_owner_config(""))
 
-          expect(linter.file_included?(file)).to eq false
-        end
-      end
-
-      context "with included file" do
-        it "returns true" do
-          config = stub_ruby_config("AllCops" => { "Exclude" => [] })
-          file = double("CommitFile", filename: "app.rb")
-          linter = build_linter(config: config)
-
-          expect(linter.file_included?(file)).to eq true
-        end
+        expect(linter.file_included?(file)).to eq true
       end
     end
+  end
 
-    private
+  private
 
-    def violations_in(
-      content,
-      config: stub_ruby_config,
-      repository_owner_name: "joe"
+  def build_with_stubbed_owner_config(config)
+    stub_commit_on_repo(
+      repo: "organization/style",
+      sha: "HEAD",
+      files: {
+        ".hound.yml" => <<~EOF,
+          ruby:
+            config_file: .rubocop.yml
+        EOF
+        ".rubocop.yml" => config,
+      },
     )
-      hound_config = build_hound_config
-      linter = build_linter(
-        hound_config: hound_config,
-        config: config,
-        repository_owner_name: repository_owner_name,
-      )
-
-      linter.
-        file_review(build_file(content)).
-        violations.
-        flat_map(&:messages)
-    end
-
-    def violations_with_config(config = stub_ruby_config)
-      content = <<-CODE.strip_heredoc
-        { :foo => "hello world" }
-      CODE
-
-      violations_in(content, config: config)
-    end
-
-    def build_linter(
-      hound_config: build_hound_config,
-      config: stub_ruby_config,
-      repository_owner_name: "not_thoughtbot"
+    owner = build(
+      :owner,
+      config_enabled: true,
+      config_repo: "organization/style",
     )
-      Linter::Ruby.new(
-        hound_config: hound_config,
-        build: build(:build),
-        repository_owner_name: repository_owner_name,
-      )
-    end
+    repo = build(:repo, owner: owner)
+    build(:build, repo: repo)
+  end
 
-    def stub_ruby_config(config = {})
-      stubbed_ruby_config = double("RubyConfig", content: config)
-      allow(Config::Ruby).to receive(:new).and_return(stubbed_ruby_config)
+  def violations_in(
+    content,
+    config: "{}"
+  )
+    linter = build_linter(
+      build: build_with_stubbed_owner_config(config),
+    )
 
-      stubbed_ruby_config
-    end
+    linter.
+      file_review(build_file(content)).
+      violations.
+      flat_map(&:messages)
+  end
 
-    def build_hound_config
-      double("HoundConfig", enabled_for?: true, content: "")
-    end
+  def legacy_violations_in(content)
+    config = File.open("spec/support/fixtures/legacy_rubocop_config.yml")
+    violations_in(content, config: config)
+  end
 
-    def build_file(content)
-      build_commit_file(filename: "app/models/user.rb", content: content)
-    end
+  def thoughtbot_violations_in(content)
+    config = File.open("spec/support/fixtures/thoughtbot_rubocop_config.yml")
+    violations_in(content, config: config)
+  end
+
+  def build_linter(
+    build:,
+    hound_config: build_hound_config
+  )
+    Linter::Ruby.new(
+      hound_config: hound_config,
+      build: build,
+    )
+  end
+
+  def stub_ruby_config(config = {})
+    stubbed_ruby_config = double("RubyConfig", content: config)
+    allow(Config::Ruby).to receive(:new).and_return(stubbed_ruby_config)
+
+    stubbed_ruby_config
+  end
+
+  def build_hound_config
+    double(
+      "HoundConfig",
+      enabled_for?: true,
+      content: { "ruby" => { "enabled" => true } },
+    )
+  end
+
+  def build_file(content)
+    build_commit_file(filename: "app/models/user.rb", content: content)
   end
 end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -139,7 +139,10 @@ describe StyleChecker do
   end
 
   def pull_request_violation_messages(pull_request)
-    build = build(:build)
+    build = build(
+      :build,
+      repo: build(:repo, owner: build(:owner, config_enabled: false)),
+    )
     StyleChecker.new(pull_request, build).review_files
 
     build.violations.flat_map(&:messages)

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -4,60 +4,46 @@ require "app/services/ruby_config_builder"
 require "app/models/config/parser"
 
 RSpec.describe RubyConfigBuilder do
-  context "when there is no custom configuration" do
-    it "returns the Hound defaults" do
-      builder = RubyConfigBuilder.new
+  describe "#config" do
+    context "when there is no custom configuration" do
+      it "returns the RuboCop defaults" do
+        builder = RubyConfigBuilder.new
 
-      config = builder.config
+        config = builder.config
 
-      expect(config["Rails/ActionFilter"]).to match enabled_rule
-      expect(config["Style/StringLiterals"]).to match hound_override_rule
-      expect(config["Style/VariableName"]).to match rubocop_default_rule
+        expect(config).to match rubocop_default_config
+      end
     end
-  end
 
-  context "when owner is thoughtbot" do
-    it "returns thoughbot specific configuration" do
-      builder = RubyConfigBuilder.new({}, "thoughtbot")
+    context "when custom configuration is provided" do
+      it "returns merged config" do
+        content = {
+          "AllCops" => {
+            "DisabledByDefault" => true,
+          },
+          "Style/VariableName" => {
+            "EnforcedStyle" => "camel_case",
+          },
+        }
+        builder = RubyConfigBuilder.new(content)
 
-      config = builder.config
+        config = builder.config
 
-      expect(config["Rails/ActionFilter"]).to match disabled_rule
-      expect(config["Style/VariableName"]).to match rubocop_default_rule
+        expect(config["AllCops"]["DisabledByDefault"]).to be true
+        expect(config["Style/Tab"]).to match disabled_rule
+        expect(config["Style/VariableName"]).to match customer_override_rule
+      end
     end
-  end
 
-  context "when custom configuration is provided" do
-    it "returns merged config" do
-      overrides = {
-        "AllCops" => {
-          "DisabledByDefault" => true,
-        },
-        "Style/VariableName" => {
-          "EnforcedStyle" => "camel_case",
-        },
-      }
-      builder = RubyConfigBuilder.new(overrides)
+    context "when the custom configuration returns a type error from rubocop" do
+      it "returns the default config" do
+        content = { "this isn't parsible" => ["foo", "bar"] }
+        builder = RubyConfigBuilder.new(content)
 
-      config = builder.config
+        config = builder.config
 
-      expect(config["AllCops"]["DisabledByDefault"]).to be true
-      expect(config["Style/Tab"]).to match disabled_rule
-      expect(config["Style/StringLiterals"]).to match hound_override_rule
-      expect(config["Style/VariableName"]).to match customer_override_rule
-    end
-  end
-
-  context "when the custom configuration returns a type error from rubocop" do
-    it "returns the default config" do
-      overrides = { "this isn't parsible" => ["foo", "bar"] }
-      builder = RubyConfigBuilder.new(overrides)
-
-      config = builder.config
-
-      expect(config["Rails/ActionFilter"]).to match enabled_rule
-      expect(config["Style/StringLiterals"]).to match hound_override_rule
-      expect(config["Style/VariableName"]).to match rubocop_default_rule
+        expect(config).to match rubocop_default_config
+      end
     end
   end
 
@@ -65,19 +51,11 @@ RSpec.describe RubyConfigBuilder do
     hash_including("EnforcedStyle" => "camel_case", "Enabled" => true)
   end
 
-  def hound_override_rule
-    hash_including("EnforcedStyle" => "double_quotes", "Enabled" => true)
-  end
-
-  def rubocop_default_rule
-    hash_including("EnforcedStyle" => "snake_case", "Enabled" => true)
+  def rubocop_default_config
+    RuboCop::ConfigLoader.merge_with_default(RuboCop::Config.new, "")
   end
 
   def disabled_rule
     hash_including("Enabled" => false)
-  end
-
-  def enabled_rule
-    hash_including("Enabled" => true)
   end
 end

--- a/spec/services/ruby_config_builder_spec.rb
+++ b/spec/services/ruby_config_builder_spec.rb
@@ -47,6 +47,53 @@ RSpec.describe RubyConfigBuilder do
     end
   end
 
+  describe "#merge" do
+    context "when the base and override configurations do not have overlap" do
+      it "returns the contents of both combined" do
+        base = {
+          "AllCops" => {
+            "DisabledByDefault" => true,
+          },
+        }
+        overrides = {
+          "Style/VariableName" => {
+            "Enabled" => true,
+          },
+        }
+        builder = RubyConfigBuilder.new(base)
+
+        merged_config = builder.merge(overrides)
+
+        expect(merged_config["AllCops"]).
+          to match hash_including base["AllCops"]
+        expect(merged_config["Style/VariableName"]).
+          to match hash_including overrides["Style/VariableName"]
+      end
+    end
+
+    context "when the base and override configurations have overlap" do
+      it "returns the contents of the overrides" do
+        base = {
+          "AllCops" => {
+            "DisabledByDefault" => true,
+          },
+          "Style/VariableName" => {
+            "Enabled" => true,
+          },
+        }
+        overrides = {
+          "AllCops" => {
+            "DisabledByDefault" => false,
+          },
+        }
+        builder = RubyConfigBuilder.new(base)
+
+        expect(builder.merge(overrides)["AllCops"]).
+          to match hash_including("DisabledByDefault" => false)
+      end
+    end
+  end
+
   def customer_override_rule
     hash_including("EnforcedStyle" => "camel_case", "Enabled" => true)
   end

--- a/spec/support/fixtures/legacy_rubocop_config.yml
+++ b/spec/support/fixtures/legacy_rubocop_config.yml
@@ -1,0 +1,243 @@
+AllCops:
+  Exclude:
+    - "vendor/**/*"
+    - "db/schema.rb"
+  UseCache: false
+Style/CollectionMethods:
+  Description: Preferred collection methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#map-find-select-reduce-size
+  Enabled: true
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    find: detect
+    find_all: select
+    reduce: inject
+Style/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+Style/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files
+  Enabled: false
+  Exclude: []
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-nested-conditionals
+  Enabled: false
+  MinBodyLength: 1
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
+  Enabled: false
+  MaxLineLength: 80
+Style/OptionHash:
+  Description: Don't use option hashes when you can use keyword arguments.
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-literal-braces
+  Enabled: false
+  PreferredDelimiters:
+    "%": "()"
+    "%i": "()"
+    "%q": "()"
+    "%Q": "()"
+    "%r": "{}"
+    "%s": "()"
+    "%w": "()"
+    "%W": "()"
+    "%x": "()"
+Style/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#bool-methods-qmark
+  Enabled: true
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  NamePrefixBlacklist:
+  - is_
+  Exclude:
+  - spec/**/*
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#exception-class-messages
+  Enabled: false
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#fail-method
+  Enabled: false
+  EnforcedStyle: semantic
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+Style/SingleLineBlockParams:
+  Description: Enforces the names of some block params.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#reduce-blocks
+  Enabled: false
+  Methods:
+  - reduce:
+    - a
+    - e
+  - inject:
+    - a
+    - e
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-single-line-methods
+  Enabled: false
+  AllowIfMethodIsEmpty: true
+Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-string-literals
+  Enabled: true
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/StringLiteralsInInterpolation:
+  Description: Checks if uses of quotes inside expressions in interpolated strings
+    match the configured preference.
+  Enabled: true
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: false
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
+  - no_comma
+Metrics/AbcSize:
+  Description: A calculated magnitude based on number of assignments, branches, and
+    conditions.
+  Enabled: false
+  Max: 15
+Metrics/ClassLength:
+  Description: Avoid classes longer than 100 lines of code.
+  Enabled: false
+  CountComments: false
+  Max: 100
+Metrics/ModuleLength:
+  CountComments: false
+  Max: 100
+  Description: Avoid modules longer than 100 lines of code.
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Description: A complexity metric that is strongly correlated to the number of test
+    cases needed to validate a method.
+  Enabled: false
+  Max: 6
+Metrics/MethodLength:
+  Description: Avoid methods longer than 10 lines of code.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#short-methods
+  Enabled: false
+  CountComments: false
+  Max: 10
+Metrics/ParameterLists:
+  Description: Avoid parameter lists longer than three or four parameters.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#too-many-params
+  Enabled: false
+  Max: 5
+  CountKeywordArgs: true
+Metrics/PerceivedComplexity:
+  Description: A complexity metric geared towards measuring complexity for a human
+    reader.
+  Enabled: false
+  Max: 7
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
+  Enabled: false
+  AllowSafeAssignment: true
+Style/InlineComment:
+  Description: Avoid inline comments.
+  Enabled: false
+Style/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  Enabled: false
+Style/Alias:
+  Description: Use alias_method instead of alias.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
+  Enabled: false
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: false
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-bang-bang
+  Enabled: false
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: false
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#literal-array-hash
+  Enabled: false
+Style/ModuleFunction:
+  Description: Checks for usage of `extend self` in modules.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
+  Enabled: false
+Style/OneLineConditional:
+  Description: Favor the ternary operator(?:) over if/then/else/end constructs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
+  Enabled: false
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
+  Enabled: false
+Style/Send:
+  Description: Prefer `Object#__send__` or `Object#public_send` to `send`, as `send`
+    may overlap with existing methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#prefer-public-send
+  Enabled: false
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
+  Enabled: false
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in
+    strings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#curlies-interpolate
+  Enabled: false
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#one-line-cases
+  Enabled: false
+Lint/EachWithObjectArgument:
+  Description: Check for immutable argument given to each_with_object.
+  Enabled: true
+Lint/HandleExceptions:
+  Description: Don't suppress exception.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
+  Enabled: false
+Lint/LiteralInCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: false
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: false

--- a/spec/support/fixtures/thoughtbot_rubocop_config.yml
+++ b/spec/support/fixtures/thoughtbot_rubocop_config.yml
@@ -1,0 +1,370 @@
+AllCops:
+  Exclude:
+    - db/schema.rb
+
+AccessorMethodName:
+  Enabled: false
+
+ActionFilter:
+  Enabled: false
+
+Alias:
+  Enabled: false
+
+ArrayJoin:
+  Enabled: false
+
+AsciiComments:
+  Enabled: false
+
+AsciiIdentifiers:
+  Enabled: false
+
+Attr:
+  Enabled: false
+
+BlockNesting:
+  Enabled: false
+
+CaseEquality:
+  Enabled: false
+
+CharacterLiteral:
+  Enabled: false
+
+ClassAndModuleChildren:
+  Enabled: true
+  EnforcedStyle: nested
+
+ClassLength:
+  Enabled: false
+
+ModuleLength:
+  Enabled: false
+
+ClassVars:
+  Enabled: false
+
+CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    find: detect
+    inject: reduce
+    collect: map
+    find_all: select
+
+ColonMethodCall:
+  Enabled: false
+
+CommentAnnotation:
+  Enabled: false
+
+CyclomaticComplexity:
+  Enabled: false
+
+Delegate:
+  Enabled: false
+
+DeprecatedHashMethods:
+  Enabled: false
+
+Documentation:
+  Enabled: false
+
+DotPosition:
+  EnforcedStyle: trailing
+
+DoubleNegation:
+  Enabled: false
+
+EachWithObject:
+  Enabled: false
+
+EmptyLiteral:
+  Enabled: false
+
+Encoding:
+  Enabled: false
+
+EvenOdd:
+  Enabled: false
+
+ExtraSpacing:
+  Enabled: true
+
+FileName:
+  Enabled: false
+
+FlipFlop:
+  Enabled: false
+
+FormatString:
+  Enabled: false
+
+GlobalVars:
+  Enabled: false
+
+GuardClause:
+  Enabled: false
+
+IfUnlessModifier:
+  Enabled: false
+
+IfWithSemicolon:
+  Enabled: false
+
+InlineComment:
+  Enabled: false
+
+Lambda:
+  Enabled: false
+
+LambdaCall:
+  Enabled: false
+
+LineEndConcatenation:
+  Enabled: false
+
+LineLength:
+  Max: 80
+
+MethodLength:
+  Enabled: false
+
+ModuleFunction:
+  Enabled: false
+
+Style/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+
+NegatedIf:
+  Enabled: false
+
+NegatedWhile:
+  Enabled: false
+
+Next:
+  Enabled: false
+
+NilComparison:
+  Enabled: false
+
+Not:
+  Enabled: false
+
+NumericLiterals:
+  Enabled: false
+
+OneLineConditional:
+  Enabled: false
+
+OpMethod:
+  Enabled: false
+
+ParameterLists:
+  Enabled: false
+
+PercentLiteralDelimiters:
+  Enabled: false
+
+PerlBackrefs:
+  Enabled: false
+
+PredicateName:
+  NamePrefixBlacklist:
+    - is_
+  Exclude:
+    - spec/**/*
+
+Proc:
+  Enabled: false
+
+RaiseArgs:
+  Enabled: false
+
+RegexpLiteral:
+  Enabled: false
+
+SelfAssignment:
+  Enabled: false
+
+SingleLineBlockParams:
+  Enabled: false
+
+SingleLineMethods:
+  Enabled: false
+
+SignalException:
+  Enabled: false
+
+SpecialGlobalVars:
+  Enabled: false
+
+StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/TrailingCommaInLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInArguments:
+  Enabled: true
+  EnforcedStyleForMultiline: comma
+
+TrivialAccessors:
+  Enabled: false
+
+VariableInterpolation:
+  Enabled: false
+
+WhenThen:
+  Enabled: false
+
+WhileUntilModifier:
+  Enabled: false
+
+WordArray:
+  Enabled: false
+
+# Lint
+
+AmbiguousOperator:
+  Enabled: false
+
+AmbiguousRegexpLiteral:
+  Enabled: false
+
+AssignmentInCondition:
+  Enabled: false
+
+CircularArgumentReference:
+  Enabled: false
+
+ConditionPosition:
+  Enabled: false
+
+DeprecatedClassMethods:
+  Enabled: false
+
+DuplicatedKey:
+  Enabled: false
+
+EachWithObjectArgument:
+  Enabled: false
+
+ElseLayout:
+  Enabled: false
+
+FormatParameterMismatch:
+  Enabled: false
+
+HandleExceptions:
+  Enabled: false
+
+InvalidCharacterLiteral:
+  Enabled: false
+
+InitialIndentation:
+  Enabled: false
+
+LiteralInCondition:
+  Enabled: false
+
+LiteralInInterpolation:
+  Enabled: false
+
+Loop:
+  Enabled: false
+
+NestedMethodDefinition:
+  Enabled: false
+
+NonLocalExitFromIterator:
+  Enabled: false
+
+ParenthesesAsGroupedExpression:
+  Enabled: false
+
+RequireParentheses:
+  Enabled: false
+
+UnderscorePrefixedVariableName:
+  Enabled: false
+
+UnneededDisable:
+  Enabled: false
+
+Void:
+  Enabled: false
+
+# Performance
+
+CaseWhenSplat:
+  Enabled: false
+
+Count:
+  Enabled: false
+
+Detect:
+  Enabled: false
+
+FlatMap:
+  Enabled: false
+
+ReverseEach:
+  Enabled: false
+
+Sample:
+  Enabled: false
+
+Size:
+  Enabled: false
+
+StringReplacement:
+  Enabled: false
+
+# Rails
+
+ActionFilter:
+  Enabled: false
+
+Date:
+  Enabled: false
+
+FindBy:
+  Enabled: false
+
+FindEach:
+  Enabled: false
+
+HasAndBelongsToMany:
+  Enabled: false
+
+Output:
+  Enabled: false
+
+ReadWriteAttribute:
+  Enabled: false
+
+ScopeArgs:
+  Enabled: false
+
+TimeZone:
+  Enabled: false
+
+Validation:
+  Enabled: false
+
+Style/MultilineBlockChain:
+  Description: 'Avoid multi-line chains of blocks.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#single-line-blocks'
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span multiple lines.
+  Enabled: true
+  EnforcedStyle: indented
+
+Metrics/AbcSize:
+  Enabled: false

--- a/spec/support/helpers/linter_helper.rb
+++ b/spec/support/helpers/linter_helper.rb
@@ -64,6 +64,13 @@ module LinterHelper
 
     commit
   end
+
+  def stub_commit_on_repo(repo:, sha:, files:)
+    allow(Commit).
+      to receive(:new).
+      with(repo, sha, anything).
+      and_return(stubbed_commit(files))
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
`RubyConfigBuilder` no longer knows anything about hound defaults or thoughtbot
 defaults, it just acts as a bridge between hashes (what our
 `Config::Ruby` objects produce) and `RuboCop::Config`s.

`Linter::Ruby` configures cops with the results of merging the repo's
configuration into the owner's configuration. Only some of the specs
have been rewritten, there's still more to rewrite on that end, but it does work, I just want to perfect the setup steps and make sure we're testing all scenarios.