### PR TITLE
Return empty HoundConfig when owner has no config

### DIFF
--- a/app/models/empty_commit.rb
+++ b/app/models/empty_commit.rb
@@ -1,0 +1,8 @@
+class EmptyCommit < Commit
+  def initialize
+  end
+
+  def file_content(_filename)
+    ""
+  end
+end

--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -50,13 +50,8 @@ module Linter
     end
 
     def merged_config
-      @merged_config ||=
-        if build.repo.owner.has_config_repo?
-          rubocop_config_builder(owner_config.content).
-            merge(repo_config.content)
-        else
-          rubocop_config_builder(repo_config.content).config
-        end
+      @merged_config ||= rubocop_config_builder(owner_config.content).
+        merge(repo_config.content)
     end
 
     def rubocop_config_builder(content)

--- a/app/services/build_owner_hound_config.rb
+++ b/app/services/build_owner_hound_config.rb
@@ -11,10 +11,11 @@ class BuildOwnerHoundConfig
   end
 
   def run
-    if owner.has_config_repo?
-      github = GithubApi.new(user_token)
+    if owner.has_config_repo? && config_repo_reachable?
       commit = Commit.new(config_repo.full_github_name, LATEST_SHA, github)
       HoundConfig.new(commit)
+    else
+      HoundConfig.new(EmptyCommit.new)
     end
   end
 
@@ -22,11 +23,22 @@ class BuildOwnerHoundConfig
 
   attr_reader :owner
 
+  def github
+    @_github ||= GithubApi.new(user_token)
+  end
+
   def user_token
     UserToken.new(config_repo).token
   end
 
+  def config_repo_reachable?
+    !!github.repo(config_repo.full_github_name)
+  rescue Octokit::InvalidRepository, Octokit::NotFound
+    false
+  end
+
   def config_repo
-    Repo.find_or_create_with(full_github_name: owner.config_repo)
+    Repo.find_by(full_github_name: owner.config_repo) ||
+      Repo.new(full_github_name: owner.config_repo)
   end
 end

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -797,6 +797,7 @@ describe Linter::Ruby do
         ".rubocop.yml" => config,
       },
     )
+    stub_repo_request("organization/style", ENV["HOUND_GITHUB_TOKEN"])
     owner = build(
       :owner,
       config_enabled: true,


### PR DESCRIPTION
We've been getting some errors on staging when I set non-sensical values for config repos (things that either can't be parsed by the GitHub API or don't exist). This changes the way `BuildOwnerHoundConfig` works to allow for inputs like that. It also changes all behavior where `BuildOwnerHoundConfig` would previously return nil and instead returns a default `HoundConfig` (this allows us to merge into it without worrying about whether or not it's the correct type). Lastly, instead of trying to save config repos (which were getting validation errors because we don't have their GitHub ID) it just discards the config repo after grabbing the default Hound GitHub token from it.