### PR TITLE
Thoughtbot should use thoughtbot config

### DIFF
--- a/db/migrate/20160624165658_update_thoughtbot_owner_configs.rb
+++ b/db/migrate/20160624165658_update_thoughtbot_owner_configs.rb
@@ -1,0 +1,23 @@
+class UpdateThoughtbotOwnerConfigs < ActiveRecord::Migration
+  def up
+    execute <<~SQL
+      UPDATE
+        owners
+      SET
+        config_repo = 'thoughtbot/guides'
+      WHERE
+        owners.name in ('houndci', 'thoughtbot')
+    SQL
+  end
+
+  def down
+    execute <<~SQL
+      UPDATE
+        owners
+      SET
+        config_repo = 'houndci/legacy-config'
+      WHERE
+        owners.name in ('houndci', 'thoughtbot')
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160608183021) do
+ActiveRecord::Schema.define(version: 20160624165658) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Migrate thoughtbot owner to use the guides as its owner level config.