### PR TITLE
Update and cleanup configuration

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -11,12 +11,8 @@ module ConfigurationHelper
     config_url("houndci/jshint", "config/.jshintrc")
   end
 
-  def javascript_ignore_url
-    config_url("houndci/hound", "config/style_guides/.jshintignore")
-  end
-
   def eslint_config_url
-    config_url("houndci/eslint", "config/.eslintrc")
+    config_url("houndci/linters", "config/eslintrc")
   end
 
   def scss_config_url

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -8,11 +8,9 @@
       %li
         = link_to "Ruby", "#ruby"
       %li
-        = link_to "Coffeescript", "#coffeescript"
+        = link_to "CoffeeScript", "#coffeescript"
       %li
-        = link_to "Javascript", "#javascript"
-      %li
-        = link_to "ESLint", "#eslint"
+        = link_to "JavaScript", "#javascript"
       %li
         = link_to "SCSS", "#scss"
       %li
@@ -20,9 +18,11 @@
       %li
         = link_to "Go", "#go"
       %li
-        = link_to "Python", "#python"
-      %li
         = link_to "Swift", "#swift"
+      %li
+        = link_to "ESLint (beta)", "#eslint"
+      %li
+        = link_to "Python (beta)", "#python"
 
   %section.doc-content
     %article
@@ -30,29 +30,34 @@
       %p
         Want to modify style rules to better suit your preferences?
         Below you will find documentation on configuring style rules for each
-        language we support.
+        linter that we support.
 
       %p
         If this page doesn't help you find what you are looking for,
         please tweet at us
-        #{link_to "@houndci", "https://twitter.com/houndci", target: :blank}
+        = link_to "@houndci", "https://twitter.com/houndci", target: :blank
         or email us at #{mail_to "hound@thoughtbot.com"}
         and we will help you out.
 
     %article#configuration
       %h3 Hound Configuration
-      %p
-        With a
-        %em.code .hound.yml
-        file you can tell Hound which languages not to review
-        (all supported, non-beta languages are reviewed by default)
-        and specify paths to custom style rules and an ignore file
-        for JavaScript.
 
       %p
-        Put your
+        All supported linters, except the ones in beta, are enabled by default.
+
+      %p
+        Hound will look for a custom configuration file named
         %em.code .hound.yml
-        file in the root directory of your project. Here is an example:
+        in the root directory of your project.
+
+      %p
+        Using
+        %em.code .hound.yml
+        you can tell Hound which linters to enable or disable,
+        specify paths to files that provide custom style rules,
+        and determine which files/directories to ignore.
+
+        Here is an example:
 
       %code.code-block
         :preserve
@@ -60,25 +65,26 @@
             enabled: false
 
           ruby:
-            config_file: .ruby-style.yml
+            config_file: .rubocop.yml
 
-          javascript:
-            ignore_file: .javascript_ignore
+          jshint:
+            ignore_file: .jshintignore
 
       %p
-        In this example, review of SCSS is deactivated (:sad face:) and we are
-        pointing Hound to a custom config file for Ruby style checking and
-        an ignore file for JavaScript.
+        In this example,
+        review of SCSS is deactivated,
+        custom RuboCop configuration is provided for Ruby files,
+        and an ignore file is given that tells which files/directories JSHint
+        should not review.
 
       %p
         Hound can be configured to use
         = link_to "GitHub's Status API",
           "https://github.com/blog/1935-see-results-from-all-pull-request-status-checks",
           target: :blank
-        to mark a pull request as failed if any violations are found. To do so,
-        add the following to your
+        to mark a pull request as failed if any violations are found.
+        To do so, add the following to your
         %em.code .hound.yml
-        file:
 
       %code.code-block
         :preserve
@@ -88,26 +94,27 @@
       %h3 Ruby
       %p
         Hound uses
-        #{link_to "RuboCop", "https://github.com/bbatsov/rubocop", target: :blank}
+        = link_to "RuboCop",
+          "https://github.com/bbatsov/rubocop",
+          target: :blank
         with this
-        #{link_to "config", ruby_config_url, target: :blank}
+        = link_to "config", ruby_config_url, target: :blank
         by default.
 
       %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", ruby_config_url, target: :blank}
+        To change the way RuboCop is configured, copy the
+        = link_to "default config file", ruby_config_url, target: :blank
         into your project, make changes and reference the file in your
         %em.code .hound.yml
 
         %code.code-block
           :preserve
             ruby:
-              config_file: .ruby-style.yml
+              config_file: .rubocop.yml
 
       %p
-        Add the following code to your
+        To disable Ruby style checking, add the following to your
         %em.code .hound.yml
-        to disable Ruby style checking.
 
         %code.code-block
           :preserve
@@ -119,25 +126,25 @@
 
       %p
         Hound uses
-        #{link_to "CoffeeLint", "http://www.coffeelint.org", target: :blank}
+        = link_to "CoffeeLint", "http://www.coffeelint.org", target: :blank
         with this
-        #{link_to "config", coffeescript_config_url, target: :blank}.
+        = link_to "config", coffeescript_config_url, target: :blank
+        by default.
 
       %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", coffeescript_config_url, target: :blank}.
+        To change the way CoffeeLint is configured, copy the
+        = link_to "default config file", coffeescript_config_url, target: :blank
         into your project, make changes and reference the file in your
         %em.code .hound.yml
 
         %code.code-block
           :preserve
             coffeescript:
-              config_file: .coffeescript-style.json
+              config_file: coffeelint.json
 
       %p
-        Add the following code to your
+        To disable CoffeeScript style checking, add the following to your
         %em.code .hound.yml
-        to disable CoffeeScript style checking.
 
         %code.code-block
           :preserve
@@ -149,97 +156,125 @@
 
       %p
         Hound uses
-        #{link_to "JSHint", "https://github.com/jshint/jshint", target: :blank}
+        = link_to "JSHint", "https://github.com/jshint/jshint", target: :blank
         with this
-        #{link_to "config", javascript_config_url, target: :blank}.
+        = link_to "config", javascript_config_url, target: :blank
+        by default.
 
       %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", javascript_config_url, target: :blank}.
+        To change the way JSHint is configured, copy the
+        = link_to "default config file", javascript_config_url, target: :blank
         into your project, make changes and reference the file in your
         %em.code .hound.yml
 
       %p
         %code.code-block
           :preserve
-            javascript:
-              config_file: .javascript-style.json
+            jshint:
+              config_file: .jshintrc
 
       %p
-        If you would like to ignore certain JavaScript files, simply copy the
-        #{link_to "default config", javascript_ignore_url, target: :blank}
-        into your project, make changes and reference the file in your
+        To ignore certain files and directories, add
+        %em.code .jshintignore
+        file to your project,
+        include in it path patterns for files/directories that you want ignored,
+        and reference the ignore file in your
         %em.code .hound.yml
+        \. See
+        = link_to "linter docs", "http://jshint.com/docs/cli/", target: :blank
+        for more info ("Ignoring Files" section).
 
         %code.code-block
           :preserve
-            javascript:
+            jshint:
               ignore_file: .javascript_ignore
 
       %p
-        Add the following code to your
+        To disable JavaScript style checking, add the following to your
         %em.code .hound.yml
-        to disable JavaScript style checking.
 
         %code.code-block
           :preserve
-            javascript:
+            jshint:
               enabled: false
 
     %article#eslint
       %h3 ESLint (beta)
 
       %p
-        Add the following code to your
+        Hound uses
+        = link_to "ESLint", "http://eslint.org/", target: :blank
+        with this
+        = link_to "config", eslint_config_url, target: :blank
+        by default.
+
+      %p
+        To enable ESLint style checking, add the following to your
         %em.code .hound.yml
-        to enable ESLint style checking.
 
         %code.code-block
           :preserve
-            javascript:
+            jshint:
               enabled: false
             eslint:
               enabled: true
 
       %p
-        Hound uses
-        = link_to "ESLint", "http://eslint.org/", target: :blank
-        with this
-        = link_to "config", eslint_config_url, target: :blank
-
-      %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", eslint_config_url, target: :blank}.
-        into your project, make changes and reference the file in your
+        To change the way ESLint is configured, add
+        %em.code .eslintrc
+        file to your project,
+        specify your desired configuration
+        and reference the file in your
         %em.code .hound.yml
 
       %p
         %code.code-block
           :preserve
+            jshint:
+              enabled: false
             eslint:
               enabled: true
               config_file: .eslintrc
 
       %p
-        For more information on the available rules in your
-        %em.code config_file
-        , you can read about them on the
+        For more information on configuring ESLint rules, see the
         = link_to "ESLint Rules Documentation",
           "http://eslint.org/docs/rules/",
           target: :blank
+
+      %p
+        To ignore certain files and directories, add
+        %em.code .eslintignore
+        file to your project,
+        include in it path patterns for files/directories that you want ignored,
+        and reference the ignore file in your
+        %em.code .hound.yml
+        \. See
+        = link_to "linter docs",
+          "http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories",
+          target: :blank
+        for more info.
+
+        %code.code-block
+          :preserve
+            eslint:
+              ignore_file: .eslintignore
 
     %article#scss
       %h3 SCSS
 
       %p
         Hound uses
-        #{link_to "SCSS-Lint", "https://github.com/causes/scss-lint", target: :blank}
+        = link_to "scss-lint",
+          "https://github.com/causes/scss-lint",
+          target: :blank
         with this
-        #{link_to "config", scss_config_url, target: :blank}.
+        = link_to "config", scss_config_url, target: :blank
+        by default.
 
       %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", scss_config_url, target: :blank}.
+        To change the way scss-lint is configured, simply copy the
+        = link_to "default config file", scss_config_url, target: :blank
         into your project, make changes and reference the file in your
         %em.code .hound.yml
 
@@ -247,14 +282,14 @@
         %code.code-block
           :preserve
             scss:
-              config_file: .scss-style.yml
+              config_file: .scss-lint.yml
 
       %p
-        If you would like to ignore certain SCSS files, add
+        To ignore certain SCSS files, add
         %em.code exclude:
-        to your
-        %em.code .scss-style.yml
-        to exclude scss files from being linted.
+        directive to your
+        %em.code .scss-lint.yml
+        file, like:
 
         %code.code-block
           :preserve
@@ -262,9 +297,8 @@
               - "app/assets/stylesheets/plugins/**"
 
       %p
-        Add the following code to your
+        To disable SCSS style checking, add the following to your
         %em.code .hound.yml
-        to disable SCSS style checking.
 
         %code.code-block
           :preserve
@@ -275,24 +309,17 @@
       %h3 Haml
 
       %p
-        Add the following code to your
-        %em.code .hound.yml
-        to enable Haml style checking.
-
-        %code.code-block
-          :preserve
-            haml:
-              enabled: true
-
-      %p
         Hound uses
-        #{link_to "haml-lint", "https://github.com/brigade/haml-lint", target: :blank}
+        = link_to "haml-lint",
+          "https://github.com/brigade/haml-lint",
+          target: :blank
         with this
-        #{link_to "config", haml_config_url, target: :blank}.
+        = link_to "config", haml_config_url, target: :blank
+        by default.
 
       %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", haml_config_url, target: :blank}
+        To change the way haml-lint is configured, simply copy the
+        = link_to "default config file", haml_config_url, target: :blank
         into your project, make changes and reference the file in your
         %em.code .hound.yml
 
@@ -300,15 +327,23 @@
         %code.code-block
           :preserve
             haml:
-              config_file: .haml-style.yml
+              config_file: .haml-lint.yml
+
+      %p
+        To disable Haml style checking, add the following to your
+        %em.code .hound.yml
+
+        %code.code-block
+          :preserve
+            haml:
+              enabled: false
 
     %article#go
       %h3 Go
 
       %p
-        Add the following code to your
+        To disable Go style checking, add the following to your
         %em.code .hound.yml
-        to enable Go style checking.
 
         %code.code-block
           :preserve
@@ -319,9 +354,19 @@
       %h3 Python (beta)
 
       %p
-        Add the following code to your
+        Hound uses
+        = link_to "Flake8",
+          "http://flake8.readthedocs.org/en/latest/",
+          target: :blank
+        with this
+        = link_to "default config",
+          "http://flake8.readthedocs.org/en/latest/config.html#default",
+          target: :blank
+        by default.
+
+      %p
+        To enable Python style checking, add the following to your
         %em.code .hound.yml
-        to enable Python style checking.
 
         %code.code-block
           :preserve
@@ -329,18 +374,7 @@
               enabled: true
 
       %p
-        Hound uses
-        = link_to "Flake8",
-          "http://flake8.readthedocs.org/en/latest/",
-          target: :blank
-        with its
-        = link_to "default config",
-          "http://flake8.readthedocs.org/en/latest/config.html#default",
-          target: :blank
-        \.
-
-      %p
-        If you need to change the way Hound is configured, create a
+        To change the way Flake8 is configured, create a
         = link_to ".ini file",
           "http://flake8.readthedocs.org/en/latest/config.html#per-project",
           target: :blank
@@ -364,10 +398,11 @@
           target: :blank
         with this
         = link_to "config", swift_config_url, target: :blank
+        by default.
 
       %p
-        If you need to change the way Hound is configured, simply copy the
-        #{link_to "default config", swift_config_url, target: :blank}.
+        To change the way SwiftLint is configured, copy the
+        = link_to "default config file", swift_config_url, target: :blank
         into your project, make changes and reference the file in your
         %em.code .hound.yml
 
@@ -378,8 +413,7 @@
               config_file: .swiftlint.yml
 
       %p
-        If you would like to disable Swift style checking,
-        add the following code to your
+        To disable Swift style checking, add the following to your
         %em.code .hound.yml
         file.
 
@@ -401,6 +435,6 @@
 
       %p
         Please tweet at us
-        #{link_to "@houndci", "https://twitter.com/houndci", target: :blank}
+        = link_to "@houndci", "https://twitter.com/houndci", target: :blank
         or email us at #{mail_to "hound@thoughtbot.com"}
         and we will help you out.

--- a/config/style_guides/.jshintignore
+++ b/config/style_guides/.jshintignore
@@ -1,2 +1,0 @@
-node_modules/*
-vendor/*

--- a/lib/js_ignore.rb
+++ b/lib/js_ignore.rb
@@ -1,5 +1,8 @@
 class JsIgnore
-  DEFAULT_EXCLUDED_PATHS = %w(vendor/*).freeze
+  DEFAULT_EXCLUDED_PATHS = %w(
+    vendor/*
+    node_modules/*
+  ).freeze
 
   attr_private_initialize :linter_name, :hound_config, :default_filename
 
@@ -12,7 +15,7 @@ class JsIgnore
   private
 
   def excluded_paths
-    ignored_paths.presence || DEFAULT_EXCLUDED_PATHS
+    DEFAULT_EXCLUDED_PATHS + ignored_paths
   end
 
   def ignored_paths


### PR DESCRIPTION
Update, rephrase, standardize and cleanup the content of the docs.

This also will now always ignore `vendor/*` and `node_modules/*`.