### PR TITLE
Clear working workers count in Resque

### DIFF
--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -14,6 +14,8 @@ namespace :resque do
       if time_running > max_time_running
         w.unregister_worker
       end
+
+      Resque.workers.each { |w| w.unregister_worker unless w.working? }
     end
   end
 


### PR DESCRIPTION
Resque will show something like "2 of 356 Workers Working" which is
clearly false. This will clear that count, back to sane numbers.