### PR TITLE
Support blacklisting pull requests

### DIFF
--- a/app/controllers/admin/blacklisted_pull_requests_controller.rb
+++ b/app/controllers/admin/blacklisted_pull_requests_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class BlacklistedPullRequestsController < Admin::ApplicationController
+  end
+end

--- a/app/dashboards/blacklisted_pull_request_dashboard.rb
+++ b/app/dashboards/blacklisted_pull_request_dashboard.rb
@@ -1,0 +1,23 @@
+require "administrate/base_dashboard"
+
+class BlacklistedPullRequestDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    full_repo_name: Field::String,
+    pull_request_number: Field::Number,
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = [
+    :full_repo_name,
+    :pull_request_number,
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = [
+    :full_repo_name,
+    :pull_request_number,
+  ].freeze
+
+  FORM_ATTRIBUTES = [
+    :full_repo_name,
+    :pull_request_number,
+  ].freeze
+end

--- a/app/dashboards/dashboard_manifest.rb
+++ b/app/dashboards/dashboard_manifest.rb
@@ -1,5 +1,6 @@
 class DashboardManifest
   DASHBOARDS = [
+    :blacklisted_pull_requests,
     :bulk_customers,
     :job_failures,
   ]

--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -2,14 +2,25 @@ module Buildable
   def perform(payload_data)
     payload = Payload.new(payload_data)
 
-    UpdateRepoStatus.new(payload).run
-    build_runner = BuildRunner.new(payload)
-    build_runner.run
+    unless blacklisted?(payload)
+      UpdateRepoStatus.new(payload).run
+      build_runner = BuildRunner.new(payload)
+      build_runner.run
+    end
   end
 
   def after_retry_exhausted
     payload = Payload.new(*arguments)
     build_runner = BuildRunner.new(payload)
     build_runner.set_internal_error
+  end
+
+  private
+
+  def blacklisted?(payload)
+    BlacklistedPullRequest.where(
+      full_repo_name: payload.full_repo_name,
+      pull_request_number: payload.pull_request_number,
+    ).any?
   end
 end

--- a/app/models/blacklisted_pull_request.rb
+++ b/app/models/blacklisted_pull_request.rb
@@ -1,0 +1,2 @@
+class BlacklistedPullRequest < ActiveRecord::Base
+end

--- a/db/migrate/20160712203443_create_blacklisted_pull_requests.rb
+++ b/db/migrate/20160712203443_create_blacklisted_pull_requests.rb
@@ -1,0 +1,10 @@
+class CreateBlacklistedPullRequests < ActiveRecord::Migration
+  def change
+    create_table :blacklisted_pull_requests do |t|
+      t.string :full_repo_name, null: false
+      t.integer :pull_request_number, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,11 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160624165658) do
+ActiveRecord::Schema.define(version: 20160712203443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "pg_stat_statements"
+
+  create_table "blacklisted_pull_requests", force: :cascade do |t|
+    t.string   "full_repo_name",      null: false
+    t.integer  "pull_request_number", null: false
+    t.datetime "created_at",          null: false
+    t.datetime "updated_at",          null: false
+  end
 
   create_table "builds", force: :cascade do |t|
     t.text     "violations_archive"

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -2,6 +2,11 @@ FactoryGirl.define do
   sequence(:github_id)
   sequence(:github_name) { |n| "github_name#{n}" }
 
+  factory :blacklisted_pull_request do
+    sequence(:full_repo_name) { |n| "user/repo#{n}" }
+    sequence(:pull_request_number)
+  end
+
   factory :build do
     commit_sha "somesha"
     repo


### PR DESCRIPTION
* Adds `blacklisted_pull_requests` table
* Updates `Buildable` to check if a pull request has been blacklisted
  before changing the PR status or running the build. If a PR is
  blacklisted, nothing will happen on the PR.
* Adds an admin dashboard to manage blacklisted pull requests