### PR TITLE
Separate public/private repo activated events

### DIFF
--- a/app/assets/javascripts/directives/repo.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo.js.coffee.erb
@@ -88,12 +88,15 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
         createSubscription()
 
     track_repo_activated = (repo) ->
-      window.analytics.track(
-        "Repo Activated",
-        properties: {
-          name: repo.full_github_name,
-          private: repo.private,
-          revenue: repo.price_in_dollars
-        }
-      )
+      if repo.private
+        eventName = "Private Repo Activated"
+        price = repo.price_in_dollars
+      else
+        eventName = "Public Repo Activated"
+        price = 0.0
+
+      window.analytics.track eventName,
+        properties:
+          name: repo.full_github_name
+          revenue: price
 ]


### PR DESCRIPTION
We're over-reporting our "Repo Activated" events to Twitter, et. al.
because Segment maps pixels at the event level,
can't take advantage of the nice properties we were sending.

Separating the events should improve the accuracy of the measurements
on our paid marketing growth experiments.

https://trello.com/c/BANVIQKY