### PR TITLE
Fix Style/CollectionMethods to be consistent with linked style guide

### DIFF
--- a/config/style_guides/ruby.yml
+++ b/config/style_guides/ruby.yml
@@ -12,7 +12,7 @@ Style/CollectionMethods:
     collect!: map!
     find: detect
     find_all: select
-    reduce: inject
+    inject: reduce
 Style/DotPosition:
   Description: Checks the position of the dot in multi-line method calls.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains


### PR DESCRIPTION
`#reduce` is preferred over `#inject` as it's a more common name in languages other than SmallTalk.