### PR TITLE
Check for conflicting linters + resolve conflicts

### DIFF
--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -3,7 +3,6 @@ class HoundConfig
   BETA_LINTERS = %w(
     eslint
     jscs
-    jshint
     remark
     python
   ).freeze
@@ -12,7 +11,7 @@ class HoundConfig
   attr_reader_initialize :commit
 
   def content
-    @_content ||= default_config.deep_merge(resolved_aliases_config)
+    @_content ||= default_config.deep_merge(resolved_conflicts_config)
   end
 
   def linter_enabled?(name)
@@ -40,6 +39,10 @@ class HoundConfig
 
   def normalized_config
     NormalizeConfig.run(parsed_config)
+  end
+
+  def resolved_conflicts_config
+    ResolveConfigConflicts.run(resolved_aliases_config)
   end
 
   def parsed_config

--- a/app/services/resolve_config_conflicts.rb
+++ b/app/services/resolve_config_conflicts.rb
@@ -1,0 +1,22 @@
+class ResolveConfigConflicts
+  CONFLICTS = { "eslint" => "jshint" }.freeze
+
+  def self.run(config)
+    new(config).run
+  end
+
+  def initialize(config)
+    @config = config
+  end
+
+  def run
+    @config.reduce({}) do |resolved_config, (linter, options)|
+      if CONFLICTS.has_key?(linter) && options["enabled"] == true
+        resolved_config[CONFLICTS[linter]] = { "enabled" => false }
+      else
+        resolved_config[linter] = options
+      end
+      resolved_config
+    end
+  end
+end

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -214,8 +214,6 @@
 
         %code.code-block
           :preserve
-            jshint:
-              enabled: false
             eslint:
               enabled: true
 
@@ -230,8 +228,6 @@
       %p
         %code.code-block
           :preserve
-            jshint:
-              enabled: false
             eslint:
               enabled: true
               config_file: .eslintrc

--- a/spec/services/resolve_config_conflicts_spec.rb
+++ b/spec/services/resolve_config_conflicts_spec.rb
@@ -1,0 +1,15 @@
+require "app/services/resolve_config_conflicts"
+
+describe ResolveConfigConflicts do
+  describe "#run" do
+    context "given a config with conflicting linters" do
+      it "disables the first conflicted linter found" do
+        config = { "eslint" => { "enabled" => true } }
+
+        resolved_config = ResolveConfigConflicts.run(config)
+
+        expect(resolved_config["jshint"]).to eq("enabled" => false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We now have multiple linters which can lint the same file (e.g. `jshint`
and `eslint`). It probably only makes sense to use one of these at a
time, so Hound now checks to see if there are any conflicts between
enabled linters (specifically if eslint is enabled and javascript is not
explicitly disabled) and disables the conflicts explicitly.

Other changes:

 - Turn on `jshint` by default again (because I believe this is the
   expected behavior)