### PR TITLE
Include original config options after transform

### DIFF
--- a/app/services/resolve_config_conflicts.rb
+++ b/app/services/resolve_config_conflicts.rb
@@ -13,9 +13,8 @@ class ResolveConfigConflicts
     @config.reduce({}) do |resolved_config, (linter, options)|
       if CONFLICTS.has_key?(linter) && options["enabled"] == true
         resolved_config[CONFLICTS[linter]] = { "enabled" => false }
-      else
-        resolved_config[linter] = options
       end
+      resolved_config[linter] = options
       resolved_config
     end
   end

--- a/spec/models/hound_config_spec.rb
+++ b/spec/models/hound_config_spec.rb
@@ -91,6 +91,7 @@ describe HoundConfig do
         hound_config = HoundConfig.new(commit)
 
         expect(hound_config).not_to be_enabled_for("jshint")
+        expect(hound_config).to be_enabled_for("eslint")
       end
     end
 

--- a/spec/services/resolve_config_conflicts_spec.rb
+++ b/spec/services/resolve_config_conflicts_spec.rb
@@ -9,6 +9,7 @@ describe ResolveConfigConflicts do
         resolved_config = ResolveConfigConflicts.run(config)
 
         expect(resolved_config["jshint"]).to eq("enabled" => false)
+        expect(resolved_config["eslint"]).to eq("enabled" => true)
       end
     end
   end


### PR DESCRIPTION
The ResolveConfigConflicts object was working in the sense that it
disables linters which conflict with configured and enabled linters.
However, it was not correctly including the config options for the
configured and enabled linter. An example:

A .hound.yml of:

    eslint:
        enabled: true

would accurately disable `jshint`. However, it would not enable `eslint`.
This change allows it to do both.