### PR TITLE
Go, Don't Go

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -341,7 +341,7 @@
         %code.code-block
           :preserve
             go:
-              enabled: true
+              enabled: false
 
     %article#python
       %h3 Python (beta)


### PR DESCRIPTION
The section about Go in the docs ought to read:

## Go

To disable Go style checking, add the following to your `.hound.yml`

```
go:
  enabled: false
```