### PR TITLE
Silence 404 errors when setting status

### DIFF
--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -139,5 +139,7 @@ class GithubApi
       description: description,
       target_url: target_url
     )
+  rescue Octokit::NotFound
+    # noop
   end
 end

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -220,16 +220,20 @@ describe GithubApi do
   describe "#create_pending_status" do
     it "makes request to GitHub for creating a pending status" do
       api = GithubApi.new(Hound::GITHUB_TOKEN)
-      request = stub_status_request(
-        "test/repo",
-        "sha",
-        "pending",
-        "description"
-      )
+      request = stub_status_request("test/repo", "sha", "pending", "foo bar")
 
-      api.create_pending_status("test/repo", "sha", "description")
+      api.create_pending_status("test/repo", "sha", "foo bar")
 
       expect(request).to have_been_requested
+    end
+
+    it "does not raise when a status cannot be set" do
+      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      url = "https://api.github.com/repos/test/repo/statuses/sha"
+      stub_request(:post, url).to_return(status: 404)
+
+      expect { api.create_pending_status("test/repo", "sha", "foo bar") }.
+        not_to raise_error
     end
   end
 


### PR DESCRIPTION
Sometimes users will change `houndci-bot`'s permissions so that it
cannot set the status of the GitHub PR. This generates a lot of
failure noise in our job queues.

This actually doesn't affect the functionality of Hound that much,
since it will still review the PR and make comments when violations are
found. The PR status just won't be set/updated.