### PR TITLE
Initialize Jshint config with content

### DIFF
--- a/app/models/config/jshint.rb
+++ b/app/models/config/jshint.rb
@@ -1,12 +1,24 @@
 module Config
   class Jshint < Base
+    pattr_initialize :raw_content
+
     def serialize(data = content)
       Serializer.json(data)
     end
 
+    def content
+      @_content ||= ensure_correct_type(safe_parse(raw_content))
+    end
+
+    def merge(raw_overrides)
+      parsed_overrides = parse(raw_overrides)
+      merged_content = content.deep_merge(parsed_overrides)
+      Config::Jshint.new(serialize(merged_content))
+    end
+
     private
 
-    def parse(file_content)
+    def parse(file_content = raw_content)
       Parser.json(file_content)
     end
   end

--- a/app/models/jshint_config_builder.rb
+++ b/app/models/jshint_config_builder.rb
@@ -1,0 +1,51 @@
+class JshintConfigBuilder
+  pattr_initialize :hound_config
+
+  def self.for(hound_config)
+    new(hound_config).config
+  end
+
+  def config
+    Config::Jshint.new(load_content)
+  end
+
+  private
+
+  def load_content
+    if file_path
+      if url?
+        fetch_url
+      else
+        commit.file_content(file_path)
+      end
+    else
+      "{}"
+    end
+  end
+
+  def fetch_url
+    response = Faraday.new.get(file_path)
+
+    if response.success?
+      response.body
+    else
+      raise_parse_error("#{response.status} #{response.body}")
+    end
+  end
+
+  def url?
+    URI::regexp(%w(http https)).match(file_path)
+  end
+
+  def file_path
+    linter_config && linter_config["config_file"]
+  end
+
+  def linter_config
+    hound_config.content.slice("jshint").values.first
+  end
+
+  def commit
+    hound_config.commit
+  end
+end

--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -9,6 +9,10 @@ module Linter
 
     private
 
+    def config
+      @_config ||= JshintConfigBuilder.for(hound_config)
+    end
+
     def jsignore
       @jsignore ||= JsIgnore.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/spec/models/config/jshint_spec.rb
+++ b/spec/models/config/jshint_spec.rb
@@ -8,13 +8,12 @@ require "app/models/config/serializer"
 describe Config::Jshint do
   describe "#content" do
     it "parses the configuration using JSON" do
-      raw_config = <<-EOS.strip_heredoc
+      raw_config = <<~EOS
         {
           "maxlen": 80
         }
       EOS
-      commit = stubbed_commit("config/jshint.json" => raw_config)
-      config = build_config(commit)
+      config = Config::Jshint.new(raw_config)
 
       expect(config.content).to eq("maxlen" => 80)
     end
@@ -22,32 +21,36 @@ describe Config::Jshint do
 
   describe "#serialize" do
     it "serializes the parsed content into JSON" do
-      raw_config = <<-EOS.strip_heredoc
+      raw_config = <<~EOS
         {
           "maxlen": 80
         }
       EOS
-      commit = stubbed_commit("config/jshint.json" => raw_config)
-      config = build_config(commit)
+      config = Config::Jshint.new(raw_config)
 
       expect(config.serialize).to eq "{\"maxlen\":80}"
     end
   end
 
-  def build_config(commit)
-    Config::Jshint.new(stubbed_hound_config(commit))
-  end
+  describe "#merge" do
+    it "overrides the config values with the supplied config" do
+      raw_config = <<~EOS
+        {
+          "maxlen": 80,
+          "some_other_value": "foo"
+        }
+      EOS
+      raw_overrides = <<~EOS
+        {
+          "maxlen": 60
+        }
+      EOS
+      config = Config::Jshint.new(raw_config)
+      merged_config = config.merge(raw_overrides)
 
-  def stubbed_hound_config(commit)
-    double(
-      "HoundConfig",
-      commit: commit,
-      content: {
-        "jshint" => {
-          "enabled" => true,
-          "config_file" => "config/jshint.json",
-        },
-      },
-    )
+      expect(merged_config.serialize).to eq(
+        "{\"maxlen\":60,\"some_other_value\":\"foo\"}",
+      )
+    end
   end
 end

--- a/spec/models/jshint_config_builder_spec.rb
+++ b/spec/models/jshint_config_builder_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+require "app/models/config/base"
+require "app/models/config/parser"
+require "app/models/config/jshint"
+require "app/models/jshint_config_builder"
+
+describe JshintConfigBuilder do
+  describe ".for" do
+    context "when there is a jshint configuration" do
+      it "takes a hound config and returns a jshint config with content" do
+        commit = stubbed_commit(".jshintrc" => <<~CON)
+          {
+            "undef": true,
+            "unused": true,
+            "predef": [ "MY_GLOBAL" ]
+          }
+        CON
+        hound_config = double(
+          "HoundConfig",
+          commit: commit,
+          content: { "jshint" => { "config_file" => ".jshintrc" } },
+        )
+
+        config = JshintConfigBuilder.for(hound_config)
+
+        expect(config).to be_a(Config::Jshint)
+        expect(config.content).to eq(
+          "undef" => true,
+          "unused" => true,
+          "predef" => ["MY_GLOBAL"],
+        )
+      end
+    end
+
+    context "when there is not a jshint configuration" do
+      it "returns a jshint with default config" do
+        hound_config = double(
+          "HoundConfig",
+          content: {},
+        )
+
+        config = JshintConfigBuilder.for(hound_config)
+
+        expect(config).to be_a(Config::Jshint)
+        expect(config.content).to eq({})
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Context

Most of our configs are initialized by passing in a `hound_config`. In a
lot of cases this makes sense, but it makes it difficult to do things
like merge configs, which is a crucial part of enabling owner level
configurations.

# Changes

- Make Config::Jshint initialize with a string of content
- Allow `parse` to take other arguments, but default to the`raw_content` that the object was initialized with (similar to how `serialize` works already)

# Future Development

Right now the `JshintConfigBuilder` is overly specialized. I'd like to start expanding this to other linters, slowly making `JshintConfigBuilder` more generic, and then ultimately remove what is the `ConfigBuilder` right now with the generic version of `JshintConfigBuilder`