### PR TITLE
Use merged config in jshint linter

### DIFF
--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -10,7 +10,19 @@ module Linter
     private
 
     def config
+      owner_config.merge(local_config.serialize)
+    end
+
+    def local_config
       @_config ||= JshintConfigBuilder.for(hound_config)
+    end
+
+    def owner_config
+      @_owner_config ||= JshintConfigBuilder.for(owner_hound_config)
+    end
+
+    def owner_hound_config
+      BuildOwnerHoundConfig.run(build.repo.owner)
     end
 
     def jsignore


### PR DESCRIPTION
Background

This builds on work done in https://github.com/houndci/hound/pull/1191 to allow owner level configurations for the `jshint` linter.

Changes

- Add a `owner_config` and `owner_hound_config` methods to `Linter::Jshint`
- Move `config` to `local_config`
- Change `config` to be the merged result of the `owner_config` and the `local_config`