### PR TITLE
Store violations count when file review completes

### DIFF
--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -7,17 +7,11 @@ class Violation < ActiveRecord::Base
   delegate :count, to: :messages, prefix: true
   delegate :filename, to: :file_review
 
-  after_create :increment_build_violations_count
-
   def add_message(message)
     self[:messages] << message
   end
 
   def messages
     self[:messages].uniq
-  end
-
-  def increment_build_violations_count
-    file_review.build.increment!(:violations_count, messages_count)
   end
 end

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -29,6 +29,10 @@ class CompleteFileReview
 
     file_review.complete
     file_review.save!
+    file_review.build.increment!(
+      :violations_count,
+      file_review.violations.map(&:messages_count).sum,
+    )
   end
 
   def pull_request

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -77,26 +77,20 @@ feature "Account" do
   scenario "user sees paid repo usage" do
     user = create(:user)
     paid_repo = create(:repo, users: [user])
-    create_failed_build(paid_repo)
-    create_failed_build(paid_repo)
     create(:build, repo: paid_repo)
+    create(:build, repo: paid_repo, violations_count: 3)
+    create(:build, repo: paid_repo, violations_count: 2)
     create(:subscription, repo: paid_repo, user: user)
 
     sign_in_as(user)
 
     visit account_path
 
-    expect(find('td.reviews-given')).to have_text("3");
-    expect(find('td.violations-caught')).to have_text("2");
+    expect(find("td.reviews-given")).to have_text("3")
+    expect(find("td.violations-caught")).to have_text("5")
   end
 
   private
-
-  def create_failed_build(repo)
-    build = create(:build, repo: repo)
-    file_review = create(:file_review, build: build)
-    create(:violation, file_review: file_review)
-  end
 
   def stub_customer_find_request_with_subscriptions(customer_id, subscriptions)
     stub_request(:get, "#{stripe_base_url}/#{customer_id}").

--- a/spec/models/violation_spec.rb
+++ b/spec/models/violation_spec.rb
@@ -34,15 +34,4 @@ describe Violation do
       expect(violation.messages_count).to eq 2
     end
   end
-
-  describe "after create callbacks" do
-    it "increments the build's violations count by the number of messages" do
-      violation = build(:violation, messages: ["foo", "bar"])
-
-      violation.save
-
-      violation.reload
-      expect(violation.file_review.build.violations_count).to eq 2
-    end
-  end
 end

--- a/spec/services/complete_file_review_spec.rb
+++ b/spec/services/complete_file_review_spec.rb
@@ -12,7 +12,8 @@ describe CompleteFileReview do
 
       file_review.reload
       expect(file_review).to be_completed
-      expect(file_review.violations).to be_present
+      expect(file_review.violations.size).to eq 1
+      expect(file_review.build.violations_count).to eq 1
     end
 
     it "runs Build Report" do


### PR DESCRIPTION
Rather than updating `build.violations_count` after each violation,
do it once after the file review is complete.

This should alleviate the DEADLOCK error, like:
```
PG::TRDeadlockDetected: ERROR: deadlock detected DETAIL: Process 2333
waits for ShareLock on transaction 19601816; blocked by process 2430.
Process 2430 waits for ExclusiveLock on tuple (223360,8) of relation
16407 of database 16385; blocked by process 2333. HINT: See server log
for query details. : UPDATE "builds" SET "violations_count" = $1,
"updated_at" = $2 WHERE "builds"."id" = $3
```
Since we'll be updating that model less frequently during the build.