### PR TITLE
Delay CompleteFileReviewJob on Resque::TermException

### DIFF
--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -10,9 +10,7 @@ class CompletedFileReviewJob
   #   [{ line: 123, message: "WAT" }]
   def self.perform(attributes)
     CompleteFileReview.run(attributes)
-  rescue ActiveRecord::RecordNotFound
+  rescue ActiveRecord::RecordNotFound, Resque::TermException
     Resque.enqueue_in(30, self, attributes)
-  rescue Resque::TermException
-    Resque.enqueue(self, attributes)
   end
 end


### PR DESCRIPTION
This could be causing our double commenting issue.

If we encounter an error, we likely want to delay for a bit.