### PR TITLE
Speed Improvements for CommitFile and Patch models. Closes #1223

### DIFF
--- a/app/models/commit_file.rb
+++ b/app/models/commit_file.rb
@@ -12,8 +12,7 @@ class CommitFile
   end
 
   def line_at(line_number)
-    changed_lines.detect { |line| line.number == line_number } ||
-      UnchangedLine.new
+    changed_lines[line_number] || UnchangedLine.new
   end
 
   private

--- a/app/models/patch.rb
+++ b/app/models/patch.rb
@@ -9,8 +9,9 @@ class Patch
 
   def changed_lines
     line_number = 0
-
-    lines.each_with_index.inject([]) do |lines, (content, patch_position)|
+    lines.
+      each_with_object({}).
+      each_with_index do |(content, hash), patch_position|
       case content
       when RANGE_INFORMATION_LINE
         line_number = Regexp.last_match[:line_number].to_i
@@ -20,19 +21,17 @@ class Patch
           number: line_number,
           patch_position: patch_position
         )
-        lines << line
+        hash[line_number] = line
         line_number += 1
       when NOT_REMOVED_LINE
         line_number += 1
       end
-
-      lines
     end
   end
 
   private
 
   def lines
-    @body.lines
+    @body.each_line
   end
 end

--- a/spec/models/commit_file_spec.rb
+++ b/spec/models/commit_file_spec.rb
@@ -7,10 +7,10 @@ require "app/models/unchanged_line"
 
 describe CommitFile do
   describe "#line_at" do
-    let(:line) { double("Line", number: 1) }
-    let(:patch) { double("Patch", changed_lines: { 1 => line }) }
     context "with a changed line" do
       it "returns a line at the given line number" do
+        line = double("Line", number: 1)
+        patch = double("Patch", changed_lines: { 1 => line })
         allow(Patch).to receive(:new).and_return(patch)
 
         expect(commit_file.line_at(1)).to eq line
@@ -19,6 +19,8 @@ describe CommitFile do
 
     context "without a changed line" do
       it "returns nil" do
+        line = double("Line", number: 1)
+        patch = double("Patch", changed_lines: { 1 => line })
         allow(Patch).to receive(:new).and_return(patch)
 
         expect(commit_file.line_at(2)).to be_an UnchangedLine

--- a/spec/models/commit_file_spec.rb
+++ b/spec/models/commit_file_spec.rb
@@ -7,10 +7,10 @@ require "app/models/unchanged_line"
 
 describe CommitFile do
   describe "#line_at" do
+    let(:line) { double("Line", number: 1) }
+    let(:patch) { double("Patch", changed_lines: { 1 => line }) }
     context "with a changed line" do
       it "returns a line at the given line number" do
-        line = double("Line", number: 1)
-        patch = double("Patch", changed_lines: [line])
         allow(Patch).to receive(:new).and_return(patch)
 
         expect(commit_file.line_at(1)).to eq line
@@ -19,8 +19,6 @@ describe CommitFile do
 
     context "without a changed line" do
       it "returns nil" do
-        line = double("Line", number: 1)
-        patch = double("Patch", changed_lines: [line])
         allow(Patch).to receive(:new).and_return(patch)
 
         expect(commit_file.line_at(2)).to be_an UnchangedLine

--- a/spec/models/patch_spec.rb
+++ b/spec/models/patch_spec.rb
@@ -6,11 +6,12 @@ describe Patch do
   describe "#changed_lines" do
     it 'returns lines that were modified' do
       patch_text = File.read('spec/support/fixtures/patch.diff')
-      patch = Patch.new(patch_text)
+      changed_lines =
+        Patch.new(patch_text).changed_lines.each_value
 
-      expect(patch.changed_lines.size).to eq(3)
-      expect(patch.changed_lines.map(&:number)).to eq [14, 22, 54]
-      expect(patch.changed_lines.map(&:patch_position)).to eq [5, 13, 37]
+      expect(changed_lines.size).to eq(3)
+      expect(changed_lines.map(&:number)).to match_array [14, 22, 54]
+      expect(changed_lines.map(&:patch_position)).to match_array [5, 13, 37]
     end
 
     context 'when body is nil' do

--- a/spec/models/patch_spec.rb
+++ b/spec/models/patch_spec.rb
@@ -6,8 +6,7 @@ describe Patch do
   describe "#changed_lines" do
     it 'returns lines that were modified' do
       patch_text = File.read('spec/support/fixtures/patch.diff')
-      changed_lines =
-        Patch.new(patch_text).changed_lines.each_value
+      changed_lines = Patch.new(patch_text).changed_lines.each_value
 
       expect(changed_lines.size).to eq(3)
       expect(changed_lines.map(&:number)).to match_array [14, 22, 54]


### PR DESCRIPTION
`CommitFile.line_at` has a point of improvements changing the way
we create and access the data structure, from an array to hash, this
means an improvement from O(n) to O(1).

In order to get this improvement we need to change how
`Patch.changed_lines` construct their data structure.