### PR TITLE
WIP: Add new pricing plans to account page

### DIFF
--- a/app/assets/stylesheets/components/_components.scss
+++ b/app/assets/stylesheets/components/_components.scss
@@ -4,3 +4,4 @@
 @import "inline-flash";
 @import "toggle_switch";
 @import "pricing";
+@import "current-plan";

--- a/app/assets/stylesheets/components/_current-plan.scss
+++ b/app/assets/stylesheets/components/_current-plan.scss
@@ -1,0 +1,11 @@
+.current-plan {
+  background: lighten($gold, 50%);
+  border: 1px solid lighten($gold, 3%);
+  border-radius: 100px;
+  color: darken($gold, 10%);
+  display: inline-block;
+  font-size: 0.8em;
+  margin-bottom: $small-spacing;
+  padding: 0 1em;
+  text-transform: uppercase;
+}

--- a/app/assets/stylesheets/components/_pricing.scss
+++ b/app/assets/stylesheets/components/_pricing.scss
@@ -92,3 +92,40 @@
     color: $base-font-color;
   }
 }
+
+.plan-vertical {
+  @include border-width(0 0 1px 0);
+  border-bottom: 1px dotted;
+  border-color: $light-font-color;
+  border-radius: 0;
+  margin-left: 0.5em;
+  padding-left: 0;
+  padding-top: 0;
+  position: static;
+  width: 100%;
+
+  &.current {
+    .plan-price {
+      color: $base-accent-color;
+    }
+  }
+
+  .plan-divider {
+    float: left;
+  }
+
+  .plan-title,
+  .plan-allowance {
+    font-size: 1.2em;
+  }
+
+  .plan-allowance {
+    margin-bottom: 0;
+  }
+
+  .plan-price {
+    color: $base-font-color;
+    float: right;
+    font-size: 1.8em;
+  }
+}

--- a/app/assets/stylesheets/pages/accounts/_show.scss
+++ b/app/assets/stylesheets/pages/accounts/_show.scss
@@ -1,6 +1,8 @@
 .account-section {
   @extend %content-frame;
   display: table;
+  position: relative;
+  width: 100%;
 }
 
 .account-content {
@@ -21,6 +23,7 @@
     background: lighten($gold, 50%);
     border: 1px solid lighten($gold, 3%);
     border-radius: 3px;
+    clear: both;
     color: darken($gold, 10%);
     padding: 1em;
   }
@@ -92,5 +95,11 @@
     float: right;
     margin-top: 1.5em;
     text-align: right;
+  }
+}
+
+.active-private-repos {
+  .repo {
+    display: table-row;
   }
 }

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -2,6 +2,12 @@
 <%= render "settings" %>
 <section class="account-section">
   <aside class="account-nav">
+    <h3>Plans</h3>
+
+    <%= render "shared/plan_vertical", current: true, name: "Chihuahua", allowance: "4", price: "$49" %>
+    <%= render "shared/plan_vertical", current: false, name: "Labrador", allowance: "10", price: "$99" %>
+    <%= render "shared/plan_vertical", current: false, name: "Great Dane", allowance: "30", price: "$249" %>
+
     <p class="message">
       <%= t(
         "account.bulk_pricing",

--- a/app/views/shared/_plan_vertical.html.erb
+++ b/app/views/shared/_plan_vertical.html.erb
@@ -1,0 +1,18 @@
+<% if current %>
+  <span class="current-plan">Current Plan</span>
+<% end %>
+
+<div class="plan plan-vertical <%= current ? 'current' : '' %>">
+  <div class="plan-divider">
+    <h5 class="plan-title"><%= name %></h5>
+    <div class="plan-allowance">
+      Up to
+      <strong><%= allowance %></strong>
+      Repos
+    </div>
+  </div>
+  <div class="plan-price">
+    <%= price %>
+    <small>month</small>
+  </div>
+</div>


### PR DESCRIPTION
<img width="1265" alt="screen shot 2016-10-20 at 4 49 25 pm" src="https://cloud.githubusercontent.com/assets/1729878/19567334/2fdfa94c-96e5-11e6-9575-8797a5abe6fe.png">

This is mostly styling of static markup (hence WIP). Needs to be integrated with pricing implementation once that's finished, also many need converting to react components.

**Notes:**

- The `.current-plan` `<span>` tag is added to the current plan.
- The `.current` class is applied to the current plan.

**Todo:**
- [ ] Replace 'Base cost' and 'quantity' columns with 'Repos active' and 'Repos remaining'

**Depends on #1231 so rebase from there.**