### PR TITLE
WIP: Add basic allowance indicator

### DIFF
--- a/app/assets/stylesheets/components/_allowance.scss
+++ b/app/assets/stylesheets/components/_allowance.scss
@@ -1,0 +1,23 @@
+.allowance {
+  border: 2px solid $base-accent-color;
+  border-radius: 100px;
+  color: $base-accent-color;
+  line-height: 40px;
+  padding: 0 $small-spacing;
+
+  strong {
+    border-left: 1px dotted $base-accent-color;
+    margin-left: $small-spacing;
+    padding-left: $small-spacing;
+  }
+
+  &.stressed {
+     color: $red;
+  }
+
+  &.large {
+    display: inline-block;
+    font-size: 1.3em;
+    line-height: 60px;
+  }
+}

--- a/app/assets/stylesheets/components/_components.scss
+++ b/app/assets/stylesheets/components/_components.scss
@@ -5,3 +5,4 @@
 @import "toggle_switch";
 @import "pricing";
 @import "current-plan";
+@import "allowance";

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -19,6 +19,12 @@
   <ul class="pull-right">
     <% if signed_in? %>
       <li>
+        <div class="allowance">
+          Private Repos
+          <strong>5/5</strong>
+        </div>
+      </li>
+      <li>
         <%= link_to account_path, class: "account" do %>
           <% if current_user.email.present? %>
             <div class="avatar" style="background-image: url('<%= avatar_url(current_user) %>')"></div>


### PR DESCRIPTION
<img width="1252" alt="screen shot 2016-10-20 at 5 12 31 pm" src="https://cloud.githubusercontent.com/assets/1729878/19568172/68bf29ec-96e8-11e6-82bd-24eccb0c97e8.png">

This is mostly styling of static markup (hence WIP). Needs to be integrated with pricing implementation once that's finished, also many need converting to react components.

**Notes:**

- The `.allowance` needs to display the current repo allowance e.g. 4/5
- The `.stressed` class should be applied when the user has no repos remaining, i.e. the next repos they activate will display the tier change page. 

**Todo:**
- [ ] Make this more advanced with a 'sticky' header functionality

**Depends on #1232  so rebase from there.**