### PR TITLE
Rename a few fields on repos and users

### DIFF
--- a/app/assets/javascripts/directives/repo.js.coffee.erb
+++ b/app/assets/javascripts/directives/repo.js.coffee.erb
@@ -49,7 +49,7 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
       subscription = new Subscription(
         repo_id: scope.repo.id
         card_token: stripeToken.id
-        email_address: stripeToken.email
+        email: stripeToken.email
       )
       saveSubscription(subscription)
 
@@ -97,6 +97,6 @@ App.directive 'repo', ['Subscription', 'StripeCheckout', 'User', (Subscription, 
 
       window.analytics.track eventName,
         properties:
-          name: repo.full_github_name
+          name: repo.name
           revenue: price
 ]

--- a/app/controllers/accounts_controller.rb
+++ b/app/controllers/accounts_controller.rb
@@ -37,6 +37,6 @@ class AccountsController < ApplicationController
   end
 
   def find_subscribed_repos
-    current_user.subscribed_repos.order(:full_github_name)
+    current_user.subscribed_repos.order(:name)
   end
 end

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -12,7 +12,7 @@ module Admin
 
     def github_admin?
       current_user &&
-        Hound::ADMIN_GITHUB_USERNAMES.include?(current_user.github_username)
+        Hound::ADMIN_GITHUB_USERNAMES.include?(current_user.username)
     end
 
     def current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -25,7 +25,7 @@ class SessionsController < ApplicationController
   end
 
   def find_user
-    if user = User.where(github_username: github_username).first
+    if user = User.where(username: username).first
       Analytics.new(user).track_signed_in
     end
 
@@ -34,8 +34,8 @@ class SessionsController < ApplicationController
 
   def create_user
     user = User.create!(
-      github_username: github_username,
-      email_address: github_email_address,
+      username: username,
+      email: github_email,
       utm_source: session[:campaign_params].try(:[], :utm_source),
     )
     flash[:signed_up] = true
@@ -54,11 +54,11 @@ class SessionsController < ApplicationController
     GithubApi.new(github_token)
   end
 
-  def github_username
+  def username
     request.env["omniauth.auth"]["info"]["nickname"]
   end
 
-  def github_email_address
+  def github_email
     request.env["omniauth.auth"]["info"]["email"]
   end
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,7 +2,7 @@ class SubscriptionsController < ApplicationController
   class FailedToActivate < StandardError; end
 
   before_action :check_subscription_presence, only: :destroy
-  before_action :update_email_address
+  before_action :update_email
 
   def create
     if activator.activate && create_subscription
@@ -56,9 +56,9 @@ class SubscriptionsController < ApplicationController
     end
   end
 
-  def update_email_address
-    if current_user.email_address.blank?
-      current_user.update(email_address: params[:email_address])
+  def update_email
+    if current_user.email.blank?
+      current_user.update(email: params[:email])
     end
   end
 end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -6,8 +6,8 @@ module AnalyticsHelper
   def identify_hash(user = current_user)
     {
       created: user.created_at,
-      email: user.email_address,
-      username: user.github_username,
+      email: user.email,
+      username: user.username,
       user_id: user.id,
       active_repo_ids: user.active_repos.ids,
     }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def avatar_url(user)
-    gravatar_id = Digest::MD5::hexdigest(user.email_address.downcase)
+    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
     "https://www.gravatar.com/avatar/#{gravatar_id}"
   end
 

--- a/app/models/analytics.rb
+++ b/app/models/analytics.rb
@@ -14,7 +14,7 @@ class Analytics
     track(
       event: "Repo Activation Failed",
       properties: {
-        name: repo.full_github_name,
+        name: repo.name,
         private: repo.private
       }
     )
@@ -24,7 +24,7 @@ class Analytics
     track(
       event: "Repo Deactivated",
       properties: {
-        name: repo.full_github_name,
+        name: repo.name,
         private: repo.private,
         revenue: -repo.plan_price,
       }
@@ -35,7 +35,7 @@ class Analytics
     track(
       event: "Build Started",
       properties: {
-        name: repo.full_github_name,
+        name: repo.name,
         private: repo.private,
       }
     )
@@ -45,7 +45,7 @@ class Analytics
     track(
       event: "Build Completed",
       properties: {
-        name: repo.full_github_name,
+        name: repo.name,
         private: repo.private,
       }
     )

--- a/app/models/bulk_customer.rb
+++ b/app/models/bulk_customer.rb
@@ -5,13 +5,13 @@ class BulkCustomer < ActiveRecord::Base
       includes(:subscription).
       where(subscriptions: { repo_id: nil }).
       where(private: true).
-      where("full_github_name !~* ?", "(#{bulk_orgs.join('|')})").
+      where("name !~* ?", "(#{bulk_orgs.join('|')})").
       active
   end
 
   def update_current_repos
     repo_count = Repo.
-      where("full_github_name ILIKE ?", "#{org}/%").
+      where("name ILIKE ?", "#{org}/%").
       where(private: true).
       active.
       count

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -5,8 +5,6 @@ class Repo < ActiveRecord::Base
   has_one :subscription
   has_many :users, through: :memberships
 
-  alias_attribute :name, :full_github_name
-
   delegate :type, :price, to: :plan, prefix: true
   delegate :price, to: :subscription, prefix: true
 
@@ -18,7 +16,7 @@ class Repo < ActiveRecord::Base
 
   def self.find_or_create_with(attributes)
     repo = find_by(github_id: attributes[:github_id]) ||
-      find_by(full_github_name: attributes[:full_github_name]) ||
+      find_by(name: attributes[:name]) ||
       Repo.new
 
     begin
@@ -67,9 +65,7 @@ class Repo < ActiveRecord::Base
   private
 
   def organization
-    if full_github_name
-      full_github_name.split("/").first
-    end
+    name && name.split("/").first
   end
 
   def self.report_update_failure(error, attributes)
@@ -77,7 +73,7 @@ class Repo < ActiveRecord::Base
       error,
       extra: {
         github_id: attributes[:github_id],
-        full_github_name: attributes[:full_github_name],
+        name: attributes[:name],
       }
     )
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,12 +7,12 @@ class User < ActiveRecord::Base
   has_many :subscribed_repos, through: :subscriptions, source: :repo
   has_many :subscriptions
 
-  validates :github_username, presence: true
+  validates :username, presence: true
 
   before_create :generate_remember_token
 
   def to_s
-    github_username
+    username
   end
 
   def active_repos
@@ -59,7 +59,7 @@ class User < ActiveRecord::Base
     repos.
       order("memberships.admin DESC").
       order(active: :desc).
-      order("LOWER(full_github_name) ASC")
+      order("LOWER(name) ASC")
   end
 
   private

--- a/app/serializers/repo_serializer.rb
+++ b/app/serializers/repo_serializer.rb
@@ -2,7 +2,7 @@ class RepoSerializer < ActiveModel::Serializer
   attributes(
     :admin,
     :active,
-    :full_github_name,
+    :name,
     :full_plan_name,
     :github_id,
     :id,

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,5 +1,5 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :github_username, :card_exists, :refreshing_repos
+  attributes :id, :username, :card_exists, :refreshing_repos
 
   def card_exists
     object.stripe_customer_id.present?

--- a/app/services/build_owner_hound_config.rb
+++ b/app/services/build_owner_hound_config.rb
@@ -12,7 +12,7 @@ class BuildOwnerHoundConfig
 
   def run
     if owner.has_config_repo? && config_repo_reachable?
-      commit = Commit.new(config_repo.full_github_name, LATEST_SHA, github)
+      commit = Commit.new(config_repo.name, LATEST_SHA, github)
       HoundConfig.new(commit)
     else
       HoundConfig.new(EmptyCommit.new)
@@ -32,13 +32,12 @@ class BuildOwnerHoundConfig
   end
 
   def config_repo_reachable?
-    !!github.repo(config_repo.full_github_name)
+    !!github.repo(config_repo.name)
   rescue Octokit::InvalidRepository, Octokit::NotFound
     false
   end
 
   def config_repo
-    Repo.find_by(full_github_name: owner.config_repo) ||
-      Repo.new(full_github_name: owner.config_repo)
+    Repo.find_or_initialize_by(name: owner.config_repo)
   end
 end

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -56,11 +56,11 @@ class RepoActivator
   end
 
   def remove_hound_from_repo
-    github.remove_collaborator(repo.full_github_name, Hound::GITHUB_USERNAME)
+    github.remove_collaborator(repo.name, Hound::GITHUB_USERNAME)
   end
 
   def add_hound_to_repo
-    github.add_collaborator(repo.full_github_name, Hound::GITHUB_USERNAME)
+    github.add_collaborator(repo.name, Hound::GITHUB_USERNAME)
   end
 
   def github
@@ -68,13 +68,13 @@ class RepoActivator
   end
 
   def create_webhook
-    github.create_hook(repo.full_github_name, builds_url) do |hook|
+    github.create_hook(repo.name, builds_url) do |hook|
       repo.update(hook_id: hook.id)
     end
   end
 
   def delete_webhook
-    github.remove_hook(repo.full_github_name, repo.hook_id) do
+    github.remove_hook(repo.name, repo.hook_id) do
       repo.update(hook_id: nil)
     end
   end

--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -69,7 +69,7 @@ class RepoSubscriber
 
   def create_stripe_customer
     stripe_customer = Stripe::Customer.create(
-      email: user.email_address,
+      email: user.email,
       metadata: { user_id: user.id },
       card: card_token
     )

--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -30,7 +30,7 @@ class RepoSynchronization
     {
       private: attributes[:private],
       github_id: attributes[:id],
-      full_github_name: attributes[:full_name],
+      name: attributes[:full_name],
       in_organization: attributes[:owner][:type] == GithubApi::ORGANIZATION_TYPE,
       owner: owner,
     }

--- a/app/services/update_repo_status.rb
+++ b/app/services/update_repo_status.rb
@@ -15,7 +15,7 @@ class UpdateRepoStatus
 
   def repo_attributes
     {
-      full_github_name: payload.full_repo_name,
+      name: payload.full_repo_name,
       private: payload.private_repo?,
     }
   end

--- a/app/views/accounts/show.haml
+++ b/app/views/accounts/show.haml
@@ -73,7 +73,7 @@
               %tr.repo
                 %td
                   %span.repo-name
-                    = repo.full_github_name
+                    = repo.name
                 %td.reviews-given
                   = repo.builds.count
                 %td.violations-caught

--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -13,9 +13,9 @@
     - if signed_in?
       %li
         = link_to account_path, class: "account" do
-          - if current_user.email_address.present?
+          - if current_user.email.present?
             .avatar(style="background-image: url('#{avatar_url(current_user)}')")
-          %span #{current_user.github_username}
+          %span= current_user.username
       %li
         = link_to t("sign_out"), sign_out_path, class: "sign-out"
     - else

--- a/app/views/application/_settings.haml
+++ b/app/views/application/_settings.haml
@@ -2,5 +2,5 @@
   Namespaced.declare("Hound.settings");
   Hound.settings = {
     stripePublishableKey: "#{Hound::STRIPE_PUBLISHABLE_KEY}",
-    userEmailAddress: "#{current_user.email_address}",
+    userEmailAddress: "#{current_user.email}",
   };

--- a/app/views/builds/index.html.haml
+++ b/app/views/builds/index.html.haml
@@ -6,7 +6,7 @@
       .build
         .build-meta
           %h2.build-org-repo
-            = build.repo.full_github_name
+            = build.repo.name
           %h4.build-time
             %span
               = time_ago_in_words(build.created_at)

--- a/app/views/templates/organization_list.haml
+++ b/app/views/templates/organization_list.haml
@@ -2,7 +2,7 @@
   .repo-tools-search
     %input.repo-search-tools-input{ 'type' => 'text',
       'placeholder' => t('search_placeholder'),
-      'ng-model' => 'search.full_github_name' }
+      'ng-model' => 'search.name' }
   - unless current_user.has_access_to_private_repos?
     .repo-tools-private
       = button_to '/auth/github?access=full',

--- a/app/views/templates/repo.haml
+++ b/app/views/templates/repo.haml
@@ -1,5 +1,5 @@
 .repo-name
-  {{ repo.full_github_name }}
+  {{ repo.name }}
 .repo-activation-toggle{ "ng-class": "{ 'repo-activation-toggle--private': repo.private }" }
   %span.repo-private-label Private - $12
   %button.repo-toggle{ "ng-click": "toggle()",

--- a/db/migrate/20161021231021_rename_columns_on_repos_and_users.rb
+++ b/db/migrate/20161021231021_rename_columns_on_repos_and_users.rb
@@ -1,0 +1,8 @@
+class RenameColumnsOnReposAndUsers < ActiveRecord::Migration
+  def change
+    rename_column :repos, :full_github_name, :name
+
+    rename_column :users, :email_address, :email
+    rename_column :users, :github_username, :username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161021212135) do
+ActiveRecord::Schema.define(version: 20161021231021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,20 +90,20 @@ ActiveRecord::Schema.define(version: 20161021212135) do
   add_index "owners", ["name"], name: "index_owners_on_name", unique: true, using: :btree
 
   create_table "repos", force: :cascade do |t|
-    t.integer  "github_id",                                    null: false
-    t.boolean  "active",                       default: false, null: false
+    t.integer  "github_id",                                   null: false
+    t.boolean  "active",                      default: false, null: false
     t.integer  "hook_id"
-    t.string   "full_github_name", limit: 255,                 null: false
-    t.datetime "created_at",                                   null: false
-    t.datetime "updated_at",                                   null: false
+    t.string   "name",            limit: 255,                 null: false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
     t.boolean  "private"
     t.boolean  "in_organization"
     t.integer  "owner_id"
   end
 
   add_index "repos", ["active"], name: "index_repos_on_active", using: :btree
-  add_index "repos", ["full_github_name"], name: "index_repos_on_full_github_name", using: :btree
   add_index "repos", ["github_id"], name: "index_repos_on_github_id", unique: true, using: :btree
+  add_index "repos", ["name"], name: "index_repos_on_name", using: :btree
   add_index "repos", ["owner_id"], name: "index_repos_on_owner_id", using: :btree
 
   create_table "subscriptions", force: :cascade do |t|
@@ -122,10 +122,10 @@ ActiveRecord::Schema.define(version: 20161021212135) do
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",                                     null: false
     t.datetime "updated_at",                                     null: false
-    t.string   "github_username",    limit: 255,                 null: false
+    t.string   "username",           limit: 255,                 null: false
     t.string   "remember_token",     limit: 255,                 null: false
     t.boolean  "refreshing_repos",               default: false
-    t.string   "email_address",      limit: 255
+    t.string   "email",              limit: 255
     t.string   "stripe_customer_id", limit: 255
     t.string   "token"
     t.string   "utm_source"

--- a/spec/controllers/activations_controller_spec.rb
+++ b/spec/controllers/activations_controller_spec.rb
@@ -66,7 +66,7 @@ describe ActivationsController, "#create" do
         for_user(membership.user).
         with(
           properties: {
-            name: repo.full_github_name,
+            name: repo.name,
             private: false
           }
         )

--- a/spec/controllers/deactivations_controller_spec.rb
+++ b/spec/controllers/deactivations_controller_spec.rb
@@ -25,7 +25,7 @@ describe DeactivationsController, "#create" do
         for_user(membership.user).
         with(
           properties: {
-            name: repo.full_github_name,
+            name: repo.name,
             private: false,
             revenue: 0,
           }

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -13,8 +13,8 @@ describe SessionsController do
 
         expect { post :create }.to change { User.count }.by(1)
         user = User.last
-        expect(user.github_username).to eq "jimtom"
-        expect(user.email_address).to eq "jimtom@example.com"
+        expect(user.username).to eq "jimtom"
+        expect(user.email).to eq "jimtom@example.com"
         expect(user.token).to eq "letmein"
       end
     end
@@ -23,11 +23,9 @@ describe SessionsController do
       it "raises and does not save user" do
         request.env["omniauth.auth"] = stub_oauth(username: nil)
 
-        expect do
-          post :create
-        end.to raise_error(
+        expect { post :create }.to raise_error(
           ActiveRecord::RecordInvalid,
-          "Validation failed: Github username can't be blank",
+          "Validation failed: Username can't be blank",
         )
         expect(User.count).to be_zero
       end

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -14,7 +14,7 @@ describe SubscriptionsController, "#create" do
         :create,
         repo_id: repo.id,
         card_token: "cardtoken",
-        email_address: "jimtom@example.com",
+        email: "jimtom@example.com",
         format: :json
       )
 
@@ -26,7 +26,7 @@ describe SubscriptionsController, "#create" do
     end
 
     it "updates the current user's email address" do
-      user = create(:user, email_address: nil)
+      user = create(:user, email: nil)
       repo = create(:repo)
       user.repos << repo
       activator = double(:repo_activator, activate: true)
@@ -38,11 +38,11 @@ describe SubscriptionsController, "#create" do
         :create,
         repo_id: repo.id,
         card_token: "cardtoken",
-        email_address: "jimtom@example.com",
+        email: "jimtom@example.com",
         format: :json
       )
 
-      expect(user.reload.email_address).to eq "jimtom@example.com"
+      expect(user.reload.email).to eq "jimtom@example.com"
     end
   end
 

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,7 +11,7 @@ describe UsersController do
       expect(response.body).to eq(
         {
           id: user.id,
-          github_username: user.github_username,
+          username: user.username,
           card_exists: false,
           refreshing_repos: user.refreshing_repos
         }.to_json

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -33,14 +33,14 @@ FactoryGirl.define do
       private true
     end
 
-    sequence(:full_github_name) { |n| "user/repo#{n}" }
+    sequence(:name) { |n| "user/repo#{n}" }
     github_id
     private false
     in_organization false
   end
 
   factory :user do
-    github_username { generate(:github_name) }
+    username { generate(:github_name) }
   end
 
   factory :membership do

--- a/spec/features/admin_authorization_spec.rb
+++ b/spec/features/admin_authorization_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 feature "Admin authorization" do
   scenario "admin accesses dashboard" do
     stub_repos_requests(token)
-    stub_admin_github_usernames(["admin_user", "other_admin_user"])
-    admin = create(:user, github_username: "admin_user")
+    stub_admin_usernames(["admin_user", "other_admin_user"])
+    admin = create(:user, username: "admin_user")
 
     sign_in_as(admin, token)
     visit admin_bulk_customers_path
@@ -14,8 +14,8 @@ feature "Admin authorization" do
 
   scenario "non-admin cannot access dashboard" do
     stub_repos_requests(token)
-    stub_admin_github_usernames(["admin_user", "other_admin_user"])
-    non_admin = create(:user, github_username: "not_admin_user")
+    stub_admin_usernames(["admin_user", "other_admin_user"])
+    non_admin = create(:user, username: "not_admin_user")
 
     sign_in_as(non_admin, token)
     visit admin_bulk_customers_path
@@ -23,7 +23,7 @@ feature "Admin authorization" do
     expect(page).not_to have_admin_bulk_customers_header
   end
 
-  def stub_admin_github_usernames(usernames)
+  def stub_admin_usernames(usernames)
     stub_const("Hound::ADMIN_GITHUB_USERNAMES", usernames)
   end
 

--- a/spec/features/job_failures_spec.rb
+++ b/spec/features/job_failures_spec.rb
@@ -16,7 +16,7 @@ feature "Job failures" do
 
   scenario "Admin views all failures" do
     stub_const("Hound::ADMIN_GITHUB_USERNAMES", ["foo-user"])
-    user = create(:user, github_username: "foo-user")
+    user = create(:user, username: "foo-user")
     populate_failures(["Foo error", "Bar error", "Foo error"])
 
     sign_in_as(user)
@@ -39,7 +39,7 @@ feature "Job failures" do
 
   scenario "Admin removes job failures" do
     stub_const("Hound::ADMIN_GITHUB_USERNAMES", ["foo-user"])
-    user = create(:user, github_username: "foo-user")
+    user = create(:user, username: "foo-user")
     populate_failures(["Foo error", "Bar error", "Foo error"])
 
     sign_in_as(user)

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -6,29 +6,29 @@ feature "Repo list", js: true do
 
   scenario "user views list of repos" do
     user = create(:user, token_scopes: "public_repo,user:email")
-    restricted_repo = create(:repo, full_github_name: "inaccessible-repo")
-    activatable_repo = create(:repo, full_github_name: "thoughtbot/my-repo")
+    restricted_repo = create(:repo, name: "inaccessible-repo")
+    activatable_repo = create(:repo, name: "thoughtbot/my-repo")
     create(:membership, repo: activatable_repo, user: user, admin: true)
     create(:membership, repo: restricted_repo, user: user, admin: false)
 
     sign_in_as(user)
 
     within ".repo:nth-of-type(1)" do
-      expect(page).to have_text activatable_repo.full_github_name
+      expect(page).to have_text activatable_repo.name
       expect(page).to have_css ".repo-toggle"
     end
     within ".repo:nth-of-type(2)" do
-      expect(page).to have_text restricted_repo.full_github_name
+      expect(page).to have_text restricted_repo.name
       expect(page).to have_text I18n.t("cannot_activate_repo")
       expect(page).not_to have_css ".repo-toggle"
     end
   end
 
   scenario "signed out user views repo list" do
-    repo = create(:repo, full_github_name: "thoughtbot/my-repo")
+    repo = create(:repo, name: "thoughtbot/my-repo")
     repo.users << user
 
-    expect(page).not_to have_content repo.full_github_name
+    expect(page).not_to have_content repo.name
   end
 
   scenario "user sees onboarding" do
@@ -50,29 +50,29 @@ feature "Repo list", js: true do
   end
 
   scenario "user filters list" do
-    repo1 = create_repo(full_github_name: "foo")
-    repo2 = create_repo(full_github_name: "bar")
+    repo1 = create_repo(name: "foo")
+    repo2 = create_repo(name: "bar")
 
     sign_in_as(user)
     find(".repo-search-tools-input").set("fo")
 
-    expect(page).to have_text repo1.full_github_name
-    expect(page).not_to have_text repo2.full_github_name
+    expect(page).to have_text repo1.name
+    expect(page).not_to have_text repo2.name
   end
 
   scenario "user syncs repos" do
     token = "letmein"
-    repo = create_repo(full_github_name: "user1/test-repo")
+    repo = create_repo(name: "user1/test-repo")
     stub_repos_requests(token)
 
     sign_in_as(user, token)
 
-    expect(page).to have_content(repo.full_github_name)
+    expect(page).to have_content(repo.name)
 
     click_button I18n.t("sync_repos")
 
     expect(page).to have_text("jimtom/My-Private-Repo")
-    expect(page).not_to have_text(repo.full_github_name)
+    expect(page).not_to have_text(repo.name)
   end
 
   scenario "user signs up" do
@@ -88,9 +88,9 @@ feature "Repo list", js: true do
     token = "letmein"
     repo = create_repo(private: false)
     hook_url = "http://#{ENV["HOST"]}/builds"
-    stub_repo_request(repo.full_github_name, token)
-    stub_add_collaborator_request(username, repo.full_github_name, token)
-    stub_hook_creation_request(repo.full_github_name, hook_url, token)
+    stub_repo_request(repo.name, token)
+    stub_add_collaborator_request(username, repo.name, token)
+    stub_hook_creation_request(repo.name, hook_url, token)
 
     sign_in_as(user, token)
     find(".repo .repo-toggle").click
@@ -106,10 +106,10 @@ feature "Repo list", js: true do
 
   scenario "user with admin access activates organization repo" do
     token = "letmein"
-    repo = create_repo(private: false, full_github_name: "testing/repo")
+    repo = create_repo(private: false, name: "testing/repo")
     hook_url = "http://#{ENV["HOST"]}/builds"
-    stub_repo_with_org_request(repo.full_github_name, token)
-    stub_hook_creation_request(repo.full_github_name, hook_url, token)
+    stub_repo_with_org_request(repo.name, token)
+    stub_hook_creation_request(repo.name, hook_url, token)
 
     sign_in_as(user, token)
     find(".repos .repo-toggle").click
@@ -126,9 +126,9 @@ feature "Repo list", js: true do
   scenario "user deactivates repo" do
     token = "letmein"
     repo = create_repo(:active)
-    stub_repo_request(repo.full_github_name, token)
-    stub_hook_removal_request(repo.full_github_name, repo.hook_id)
-    stub_remove_collaborator_request(username, repo.full_github_name, token)
+    stub_repo_request(repo.name, token)
+    stub_hook_removal_request(repo.name, repo.hook_id)
+    stub_remove_collaborator_request(username, repo.name, token)
 
     sign_in_as(user, token)
     find(".repos .repo-toggle").click
@@ -145,9 +145,9 @@ feature "Repo list", js: true do
   scenario "user deactivates private repo without subscription" do
     token = "letmein"
     repo = create_repo(:active, private: true)
-    stub_repo_request(repo.full_github_name, token)
-    stub_hook_removal_request(repo.full_github_name, repo.hook_id)
-    stub_remove_collaborator_request(username, repo.full_github_name, token)
+    stub_repo_request(repo.name, token)
+    stub_hook_removal_request(repo.name, repo.hook_id)
+    stub_remove_collaborator_request(username, repo.name, token)
 
     sign_in_as(user, token)
     find(".repos .repo-toggle").click

--- a/spec/features/user_authentication_spec.rb
+++ b/spec/features/user_authentication_spec.rb
@@ -8,19 +8,19 @@ feature 'User authentication' do
 
     sign_in_as(user, token)
 
-    expect(page).to have_content user.github_username
+    expect(page).to have_content user.username
     expect(analytics).to have_tracked("Signed In").for_user(user)
   end
 
   scenario "new user signs in" do
     token = "usergithubtoken"
-    github_username = "croaky"
-    user = build(:user, github_username: github_username)
+    username = "croaky"
+    user = build(:user, username: username)
     stub_repos_requests(token)
 
     sign_in_as(user, token)
 
-    expect(page).to have_content(github_username)
+    expect(page).to have_content(username)
   end
 
   scenario 'user signs out' do
@@ -31,6 +31,6 @@ feature 'User authentication' do
     sign_in_as(user, token)
     find('a[href="/sign_out"]').click
 
-    expect(page).not_to have_content user.github_username
+    expect(page).not_to have_content user.username
   end
 end

--- a/spec/helpers/analytics_helper_spec.rb
+++ b/spec/helpers/analytics_helper_spec.rb
@@ -28,8 +28,8 @@ describe AnalyticsHelper do
 
       expect(identify_hash).to eq(
         created: user.created_at,
-        email: user.email_address,
-        username: user.github_username,
+        email: user.email,
+        username: user.username,
         user_id: user.id,
         active_repo_ids: [repo.id],
       )

--- a/spec/models/repo_spec.rb
+++ b/spec/models/repo_spec.rb
@@ -17,7 +17,7 @@ describe Repo do
     context "when repo is bulk" do
       it "returns true" do
         create(:bulk_customer, org: "thoughtbot")
-        repo = Repo.new(full_github_name: "thoughtbot/hub")
+        repo = Repo.new(name: "thoughtbot/hub")
 
         expect(repo).to be_bulk
       end
@@ -25,15 +25,15 @@ describe Repo do
 
     context "when repo is not bulk" do
       it "returns false" do
-        repo = Repo.new(full_github_name: "jimbob/hound")
+        repo = Repo.new(name: "jimbob/hound")
 
         expect(repo).not_to be_bulk
       end
     end
 
-    context "without full_github_name" do
+    context "without name" do
       it "returns false" do
-        repo = Repo.new(full_github_name: nil)
+        repo = Repo.new(name: nil)
 
         expect(repo).not_to be_bulk
       end
@@ -101,28 +101,28 @@ describe Repo do
     context "with existing github name" do
       it "updates attributes" do
         repo = create(:repo, github_id: 1)
-        new_attributes = { github_id: 2, full_github_name: repo.name }
+        new_attributes = { github_id: 2, name: repo.name }
 
         Repo.find_or_create_with(new_attributes)
         repo.reload
 
         expect(Repo.count).to eq 1
-        expect(repo.name).to eq new_attributes[:full_github_name]
+        expect(repo.name).to eq new_attributes[:name]
         expect(repo.github_id).to eq new_attributes[:github_id]
       end
     end
 
     context "with existing github id" do
       it "updates attributes" do
-        repo = create(:repo, full_github_name: "foo")
-        new_attributes = { github_id: repo.github_id, full_github_name: "bar" }
+        repo = create(:repo, name: "foo")
+        new_attributes = { github_id: repo.github_id, name: "bar" }
 
         Repo.find_or_create_with(new_attributes)
         repo.reload
 
         expect(Repo.count).to eq 1
         expect(repo.github_id).to eq new_attributes[:github_id]
-        expect(repo.name).to eq new_attributes[:full_github_name]
+        expect(repo.name).to eq new_attributes[:name]
       end
     end
 
@@ -140,8 +140,8 @@ describe Repo do
         github_name = "foo/bar"
         github_id = 40023
         repo_with_id = create(:repo, github_id: github_id)
-        _repo_with_name = create(:repo, full_github_name: github_name)
-        new_attributes = { github_id: github_id, full_github_name: github_name }
+        _repo_with_name = create(:repo, name: github_name)
+        new_attributes = { github_id: github_id, name: github_name }
 
         Repo.find_or_create_with(new_attributes)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe User do
   it { should have_many(:repos).through(:memberships) }
   it { should have_many(:subscribed_repos).through(:subscriptions) }
-  it { should validate_presence_of :github_username }
+  it { should validate_presence_of :username }
   it { should have_many(:memberships).dependent(:destroy) }
 
   describe "#subscribed_repos" do
@@ -74,7 +74,7 @@ describe User do
 
       user_string = user.to_s
 
-      expect(user_string).to eq user.github_username
+      expect(user_string).to eq user.username
     end
   end
 

--- a/spec/requests/builds_spec.rb
+++ b/spec/requests/builds_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "POST /builds" do
       comment_id_from_fixture = 12195842
       commit_id_from_fixture = "498b81cd038f8a3ac02f035a8537b7ddcff38a81"
       violations = [existing_comment_violation, new_violation]
-      create(:repo, :active, github_id: repo_id, full_github_name: repo_name)
+      create(:repo, :active, github_id: repo_id, name: repo_name)
       stub_github_requests_with_violations(filename: filename)
       stub_commit_request(repo_name, pr_sha)
       stub_pull_request_comments_request(
@@ -46,7 +46,7 @@ RSpec.describe "POST /builds" do
 
   context "without violations" do
     it "does not make a comment" do
-      create(:repo, github_id: repo_id, full_github_name: repo_name)
+      create(:repo, github_id: repo_id, name: repo_name)
       stub_github_requests_with_no_violations
       comment_request = stub_new_comment_request
 

--- a/spec/services/build_report_spec.rb
+++ b/spec/services/build_report_spec.rb
@@ -121,7 +121,7 @@ describe BuildReport do
 
         expect(analytics).to have_tracked("Build Completed").
           for_user(repo.subscription.user).
-          with(properties: { name: repo.full_github_name, private: true })
+          with(properties: { name: repo.name, private: true })
       end
     end
 

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -142,7 +142,7 @@ describe BuildRunner do
 
         expect(analytics).to have_tracked("Build Started").
           for_user(repo.subscription.user).
-          with(properties: { name: repo.full_github_name, private: true })
+          with(properties: { name: repo.name, private: true })
       end
     end
 

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -78,7 +78,7 @@ describe RepoActivator do
           activator.activate
 
           expect(api).to have_received(:add_collaborator).
-            with(repo.full_github_name, Hound::GITHUB_USERNAME)
+            with(repo.name, Hound::GITHUB_USERNAME)
         end
 
         it "marks repo as active" do
@@ -147,7 +147,7 @@ describe RepoActivator do
           end
 
           expect(github).to have_received(:create_hook).with(
-            repo.full_github_name,
+            repo.name,
             URI.join("https://#{ENV["HOST"]}", "builds").to_s
           )
         end
@@ -162,7 +162,7 @@ describe RepoActivator do
           activator.activate
 
           expect(github).to have_received(:create_hook).with(
-            repo.full_github_name,
+            repo.name,
             URI.join("http://#{ENV["HOST"]}", "builds").to_s
           )
         end
@@ -254,7 +254,7 @@ describe RepoActivator do
         activator.deactivate
 
         expect(api).to have_received(:remove_collaborator).
-          with(repo.full_github_name, Hound::GITHUB_USERNAME)
+          with(repo.name, Hound::GITHUB_USERNAME)
       end
 
       context "when the subscribed user does not have a membership" do

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -64,7 +64,7 @@ describe RepoSynchronization do
 
       user.reload
       expect(user.repos.size).to eq(1)
-      expect(user.repos.first.full_github_name).to eq "user/newrepo"
+      expect(user.repos.first.name).to eq "user/newrepo"
       expect(user.repos.first.github_id).to eq 456
     end
 

--- a/spec/services/update_repo_status_spec.rb
+++ b/spec/services/update_repo_status_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe UpdateRepoStatus do
   describe "#run" do
-    it "updates the repo full_github_name" do
+    it "updates the repo name" do
       expected_repo_name = "foo/bar"
       repo = create(:repo, :active)
       payload = double(
@@ -15,7 +15,7 @@ describe UpdateRepoStatus do
       UpdateRepoStatus.new(payload).run
 
       repo.reload
-      expect(repo.full_github_name).to eq(expected_repo_name)
+      expect(repo.name).to eq(expected_repo_name)
     end
 
     it "updates the private flag for repo" do
@@ -24,7 +24,7 @@ describe UpdateRepoStatus do
       payload = double(
         "Payload",
         github_repo_id: repo.github_id,
-        full_repo_name: repo.full_github_name,
+        full_repo_name: repo.name,
         private_repo?: expected_status,
       )
 

--- a/spec/support/helpers/authentication_helper.rb
+++ b/spec/support/helpers/authentication_helper.rb
@@ -5,11 +5,7 @@ module AuthenticationHelper
   end
 
   def sign_in_as(user, token = "letmein")
-    stub_oauth(
-      username: user.github_username,
-      email: user.email_address,
-      token: token
-    )
+    stub_oauth(username: user.username, email: user.email, token: token)
     stub_scopes_request(token: token)
     visit root_path(SPLIT_DISABLE: "true")
     click_link(I18n.t('authenticate'), match: :first)

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -201,10 +201,10 @@ module GithubApiHelper
   def stub_pull_request_comments_request(
     full_repo_name,
     pull_request_number,
-    github_username
+    username
   )
     comments_body = read_fixture("pull_request_comments.json").
-      gsub("the_hound_user", github_username)
+      gsub("the_hound_user", username)
     url = "https://api.github.com/repos/#{full_repo_name}/pulls/" +
       "#{pull_request_number}/comments"
     headers = { "Content-Type" => "application/json; charset=utf-8" }


### PR DESCRIPTION
I've been meaning to rename these, as the longer versions are always a
pain to type (when dealing with customer support, and debugging).

There shouldn't be any confusion using these new, shorter names.

* `full_github_name` -> `name`
* `email_address` -> `email`
* `github_username` -> `username`