### PR TITLE
Make nav on repos index sticky

### DIFF
--- a/app/assets/javascripts/sticky-header.js
+++ b/app/assets/javascripts/sticky-header.js
@@ -1,0 +1,5 @@
+$( document ).ready(function() {
+  $(window).on("scroll touchmove", function () {
+    $('.global-header.repo-index').toggleClass('shrunk', $(document).scrollTop() > 0);
+  });
+});

--- a/app/assets/stylesheets/base/_helpers.scss
+++ b/app/assets/stylesheets/base/_helpers.scss
@@ -19,6 +19,10 @@
 
 .content {
   @include outer-container;
+
+  &.repo-index {
+    padding-top: 10em;
+  }
 }
 
 .inner-wrapper {

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -59,3 +59,6 @@ $font-weight-normal: 400;
 $base-transition-timing: 0.2s;
 $base-easing: cubic-bezier(0.39, 0.575, 0.565, 1);
 $base-transition: all $base-transition-timing $base-easing;
+
+// Z-Indices
+$z-index-front: 100;

--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -1,8 +1,40 @@
 $medium-screen-header: new-breakpoint(max-width em(850) 4);
 
 .global-header {
-  @include outer-container;
+  @include transition(height 0.2s ease-in-out);
+  background-color: $white;
   height: 120px;
+  width: 100%;
+
+  @include media($medium-screen-header) {
+    height: auto;
+    padding: 1em 2em;
+    text-align: center;
+  }
+
+  &.repo-index {
+    position: fixed;
+    z-index: $z-index-front;
+  }
+
+  &.shrunk {
+    border-bottom: 2px solid $base-accent-color;
+    height: 80px;
+
+    @include media($medium-screen-header) {
+      height: auto;
+      padding: 0;
+    }
+
+    @include media($small-screen) {
+      padding: 0.5em;
+    }
+  }
+}
+
+.global-header-wrapper {
+  @include outer-container;
+  height: 100%;
   padding: 0 0.5em;
 
   &.home-header {
@@ -17,12 +49,6 @@ $medium-screen-header: new-breakpoint(max-width em(850) 4);
       height: 40px;
       width: 174px;
     }
-  }
-
-  @include media($medium-screen-header) {
-    height: auto;
-    padding: 2em 1em;
-    text-align: center;
   }
 
   .logo {
@@ -91,8 +117,8 @@ $medium-screen-header: new-breakpoint(max-width em(850) 4);
 
     li {
       display: table-cell;
-      vertical-align: middle;
       text-align: center;
+      vertical-align: middle;
 
       @include media($medium-screen-header) {
         display: inline-block;

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,56 +1,58 @@
-<header class="<%= content_for(:header_class) %> global-header">
-  <div class="logo pull-left">
-    <div class="va-cell">
-      <%= link_to repos_path, class: "logo-link" do %>
-        <h1>
-          Hound
-        </h1>
-      <% end %>
+<div class="global-header <%= content_for(:header_class) %>">
+  <header class="global-header-wrapper <%= content_for(:header_class) %>">
+    <div class="logo pull-left">
+      <div class="va-cell">
+        <%= link_to repos_path, class: "logo-link" do %>
+          <h1>
+            Hound
+          </h1>
+        <% end %>
+      </div>
     </div>
-  </div>
-  <ul class="pull-left">
-    <li>
-      <%= link_to "Docs", configuration_path, class: "docs" %>
-    </li>
-    <li>
-      <%= link_to "FAQ", faq_path, class: "faq" %>
-    </li>
-  </ul>
-  <ul class="pull-right">
-    <% if signed_in? %>
-      <% if current_user.subscriptions.count > 0 %>
+    <ul class="pull-left">
+      <li>
+        <%= link_to "Docs", configuration_path, class: "docs" %>
+      </li>
+      <li>
+        <%= link_to "FAQ", faq_path, class: "faq" %>
+      </li>
+    </ul>
+    <ul class="pull-right">
+      <% if signed_in? %>
+        <% if current_user.subscriptions.count > 0 %>
+          <li>
+            <div class="allowance">
+              Private Repos
+              <strong><%= current_user.subscribed_repos.count%>/<%= current_user.tier_max %></strong>
+            </div>
+          </li>
+        <% end %>
         <li>
-          <div class="allowance">
-            Private Repos
-            <strong><%= current_user.subscribed_repos.count%>/<%= current_user.tier_max %></strong>
-          </div>
+          <%= link_to account_path, class: "account" do %>
+            <% if current_user.email.present? %>
+              <div class="avatar" style="background-image: url('<%= avatar_url(current_user) %>')"></div>
+            <% end %>
+            <span>
+              <%= current_user.username %>
+            </span>
+          <% end %>
+        </li>
+        <li>
+          <%= link_to t("sign_out"), sign_out_path, class: "sign-out" %>
+        </li>
+      <% else %>
+        <li>
+          <%= link_to "Pricing", root_path(anchor: "pricing"), class: "pricing" %>
+        </li>
+        <li>
+          <%= link_to "https://twitter.com/houndci", target: "_blank", class: "tweet-us" do %>
+            <span>@houndci</span>
+          <% end %>
+        </li>
+        <li class="auth-container">
+          <%= render "application/auth_button" %>
         </li>
       <% end %>
-      <li>
-        <%= link_to account_path, class: "account" do %>
-          <% if current_user.email.present? %>
-            <div class="avatar" style="background-image: url('<%= avatar_url(current_user) %>')"></div>
-          <% end %>
-          <span>
-            <%= current_user.username %>
-          </span>
-        <% end %>
-      </li>
-      <li>
-        <%= link_to t("sign_out"), sign_out_path, class: "sign-out" %>
-      </li>
-    <% else %>
-      <li>
-        <%= link_to "Pricing", root_path(anchor: "pricing"), class: "pricing" %>
-      </li>
-      <li>
-        <%= link_to "https://twitter.com/houndci", target: "_blank", class: "tweet-us" do %>
-          <span>@houndci</span>
-        <% end %>
-      </li>
-      <li class="auth-container">
-        <%= render "application/auth_button" %>
-      </li>
-    <% end %>
-  </ul>
-</header>
+    </ul>
+  </header>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
         <%= value %>
       </div>
     <% end %>
-    <div class="content">
+    <div class="content <%= content_for(:container_class) %>">
       <%= yield %>
     </div>
     <%= render "application/footer" %>

--- a/app/views/repos/index.html.erb
+++ b/app/views/repos/index.html.erb
@@ -1,4 +1,6 @@
 <% content_for :page_title, "Your Repos" %>
+<% content_for :header_class, "repo-index" %>
+<% content_for :container_class, "repo-index" %>
 <%= render "settings" %>
 <% if display_onboarding? %>
   <%= render "onboarding" %>


### PR DESCRIPTION
![hound](https://cloud.githubusercontent.com/assets/1729878/19805805/7b56b1e8-9d0e-11e6-8e15-773afa725b2d.gif)

When the user has many repos they cannot see the allowance indicator at the top of the page when scrolled, this solves by 'sticking' the nav to the screen top on scroll.
