### PR TITLE
Add markup for open source on account page

### DIFF
--- a/app/assets/stylesheets/components/_pricing.scss
+++ b/app/assets/stylesheets/components/_pricing.scss
@@ -98,7 +98,6 @@
   border-bottom: 1px dotted;
   border-color: $light-font-color;
   border-radius: 0;
-  margin-left: 0.5em;
   padding-left: 0;
   padding-top: 0;
   position: static;

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -4,9 +4,37 @@
   <aside class="account-nav">
     <h3>Plans</h3>
 
-    <%= render "shared/plan_vertical", new: false, current: true, name: "Chihuahua", allowance: "4", price: "$49" %>
-    <%= render "shared/plan_vertical", new: false,  current: false, name: "Labrador", allowance: "10", price: "$99" %>
-    <%= render "shared/plan_vertical", new: false,  current: false, name: "Great Dane", allowance: "30", price: "$249" %>
+    <%= render "shared/plan_vertical",
+      new: false,
+      current: false,
+      open_source: true,
+      name: "Hound",
+      allowance: "Unlimited",
+      price: "$0" %>
+
+    <%= render "shared/plan_vertical",
+      new: false,
+      current: true,
+      open_source: false,
+      name: "Chihuahua",
+      allowance: "4",
+      price: "$49" %>
+
+    <%= render "shared/plan_vertical",
+      new: false,
+      current: false,
+      open_source: false,
+      name: "Labrador",
+      allowance: "10",
+      price: "$99" %>
+
+    <%= render "shared/plan_vertical",
+      new: false,
+      current: false,
+      open_source: false,
+      name: "Great Dane",
+      allowance: "30",
+      price: "$249" %>
 
     <p class="message">
       <%= t(
@@ -25,8 +53,8 @@
         <thead>
           <tr>
             <th>Plan</th>
-            <th>Base Cost</th>
-            <th>Quantity</th>
+            <th>Allowance</th>
+            <th>Remaining</th>
             <th>Subtotal</th>
           </tr>
         </thead>

--- a/app/views/shared/_plan_vertical.html.erb
+++ b/app/views/shared/_plan_vertical.html.erb
@@ -12,9 +12,13 @@
   <div class="plan-divider">
     <h5 class="plan-title"><%= name %></h5>
     <div class="plan-allowance">
-      Up to
-      <strong><%= allowance %></strong>
-      Repos
+      <% if open_source %>
+        Unlimited
+      <% else %>
+        Up to
+        <strong><%= allowance %></strong>
+        Repos
+      <% end %>
     </div>
   </div>
   <div class="plan-price">


### PR DESCRIPTION
![screen shot 2016-10-28 at 2 43 07 pm](https://cloud.githubusercontent.com/assets/1729878/19808455/dd5417e2-9d1c-11e6-9507-8017f5f7fccc.png)

This page previously had no mockup for the open-source plan.

There may be a better way to implement the partials than the clunky looking way I am doing it now. Looking for feedback on that.
