### PR TITLE
Loop through Stripe elements

### DIFF
--- a/lib/migrate_stripe_customers.rb
+++ b/lib/migrate_stripe_customers.rb
@@ -7,7 +7,12 @@ class MigrateStripeCustomers
     customers.each { |customer| migrate_subscriptions_for(customer) }
 
     while customers.has_more
-      run
+      customers = Stripe::Customers.all(
+        limit: 100,
+        starting_after: customers.data.last.id,
+      )
+
+      run(customers)
     end
   end
 

--- a/lib/migrate_stripe_subscription.rb
+++ b/lib/migrate_stripe_subscription.rb
@@ -34,6 +34,11 @@ class MigrateStripeSubscription
 
   def delete_stripe_subscriptions(subscriptions)
     while subscriptions.has_more
+      subscriptions = customer.subscriptions.all(
+        limit: 100,
+        starting_after: subscriptions.data.last.id,
+      )
+
       subscriptions.each(&:delete)
     end
   end


### PR DESCRIPTION
Previously, the Rake task to migrate Stripe customers onto the new payment plans only looped through the first 100 customers, which meant we never updated the other 800+ customers and the script got stuck in an infinite loop. Update the Rake tasks to pagination through the rest of the Stripe elements.