### PR TITLE
Fix customer typo

### DIFF
--- a/lib/migrate_stripe_customers.rb
+++ b/lib/migrate_stripe_customers.rb
@@ -7,7 +7,7 @@ class MigrateStripeCustomers
     customers.each { |customer| migrate_subscriptions_for(customer) }
 
     while customers.has_more
-      customers = Stripe::Customers.all(
+      customers = Stripe::Customer.all(
         limit: 100,
         starting_after: customers.data.last.id,
       )


### PR DESCRIPTION
Previously, were were calling `all` on `Stripe::Customers`, which is a class that does not exist. Update the "migrate Stripe customers" to use the correct, `Stripe::Customer`, class.