### PR TITLE
Remove references to old pricing structure

### DIFF
--- a/app/assets/javascripts/components/repo.js.jsx
+++ b/app/assets/javascripts/components/repo.js.jsx
@@ -22,9 +22,6 @@ class Repo extends React.Component {
           "repo-activation-toggle",
           {"repo-activation-toggle--private": showPrivate}
         )}>
-          <span className="repo-private-label">
-            Private - ${repo.price_in_dollars}
-          </span>
           <RepoActivationButton
             repo={repo}
             onRepoClicked={onRepoClicked}

--- a/app/assets/stylesheets/pages/repos/_index.scss
+++ b/app/assets/stylesheets/pages/repos/_index.scss
@@ -82,35 +82,6 @@
 
 .repo-activation-toggle--private {
   min-width: 250px;
-
-  .repo-private-label {
-    display: inline-block;
-  }
-}
-
-.repo-private-label {
-  background: lighten($gold, 50%);
-  border: 1px solid lighten($gold, 3%);
-  border-radius: 3px;
-  color: darken($gold, 5%);
-  display: none;
-  font-size: 0.9em;
-  font-weight: $font-weight-light;
-  letter-spacing: 1px;
-  margin-right: 0.6em;
-  padding: 0.2em 0.6em;
-  text-align: center;
-  vertical-align: middle;
-
-  @include media($small-screen-only) {
-    margin: 0.1em 0 0 0.6em;
-  }
-
-  .fa {
-    color: $gold;
-    display: inline-block;
-    margin-right: 0.2em;
-  }
 }
 
 .repo-toggle {

--- a/app/views/repos/_onboarding.haml
+++ b/app/views/repos/_onboarding.haml
@@ -2,20 +2,17 @@
   .inner-wrapper
     %h1= t("onboarding.title")
     %ol.onboarding-steps
-      - if current_user.has_active_repos?
-        %li.step
+      %li.step
+        - if current_user.has_active_repos?
           %h4= t("onboarding.step_one_alt_title", count: current_user.repos.active.count )
-          %p= t("onboarding.step_one_desc")
-        %li.step.current-step
-          %h4= t("onboarding.step_two_alt_title")
-          %p= t("onboarding.step_two_desc")
-      - else
-        %li.step.current-step
+        - else
           %h4= t("onboarding.step_one_title")
-          %p= t("onboarding.step_one_desc")
-        %li.step
-          %h4= t("onboarding.step_two_title")
-          %p= t("onboarding.step_two_desc")
+        %p
+          = t("onboarding.step_one_desc")
+          = link_to(t("onboarding.step_one_link"), account_path)
+      %li.step.current-step
+        %h4= t("onboarding.step_two_title")
+        %p= t("onboarding.step_two_desc")
       %li.step
         %h4= t("onboarding.step_three_title")
         %p= t("onboarding.step_three_desc")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,9 +34,9 @@ en:
     step_one_alt_title: "Hound is active on %{count} of your repos!"
     step_one_desc:
       "Hound watches for pull requests on all active repos.
-      Activating public repos costs $0; private repos cost $12."
-    step_two_title: "Open a GitHub pull request on the repo."
-    step_two_alt_title: "Open a pull request on an active repo."
+      Activating public repos is free; private repos are priced by tier."
+    step_one_link: "Details"
+    step_two_title: "Open a GitHub pull request on the active repo."
     step_two_desc:
       "Hound will review all GitHub pull requests that are
       opened on an activated repo for violations of your style


### PR DESCRIPTION
Before:
![screen shot 2016-11-23 at 11 31 58 am](https://cloud.githubusercontent.com/assets/1729878/20560294/7e5280c2-b170-11e6-8861-3990a4a651dc.png)

After:
![screen shot 2016-11-23 at 11 32 10 am](https://cloud.githubusercontent.com/assets/1729878/20560296/814a5bce-b170-11e6-8097-67edbce9a03d.png)

The onboarding flash has a reference to the old pricing structure.

Removed the explicit dollar amount, replaced with a link to the account page pricing breakdown

Also removes the price tags next to the 'activate' buttons:

Before:
![screen shot 2016-11-23 at 4 55 55 pm](https://cloud.githubusercontent.com/assets/1729878/20571014/bfbb39dc-b19d-11e6-9982-fe065de56932.png)

After:
![screen shot 2016-11-23 at 4 56 00 pm](https://cloud.githubusercontent.com/assets/1729878/20571019/c47180d0-b19d-11e6-8708-1f6df8039336.png)
