### PR TITLE
Bind `this` to email update event

### DIFF
--- a/app/assets/javascripts/components/update_account_email.js.jsx
+++ b/app/assets/javascripts/components/update_account_email.js.jsx
@@ -40,6 +40,7 @@ class UpdateAccountEmail extends React.Component {
           <div className="form-group">
             <label>Email address for receipts</label>
             <input
+              id="email_address"
               type="email"
               placeholder={placeholder}
               onChange={ event => this.setState({
@@ -52,7 +53,10 @@ class UpdateAccountEmail extends React.Component {
             />
           </div>
           <div className="form-actions">
-            <button className="button-small" onClick={this.onUpdateEmail}>
+            <button
+              className="button-small"
+              onClick={this.onUpdateEmail.bind(this)}
+            >
               Update Email
             </button>
           </div>

--- a/app/assets/javascripts/components/update_account_email_message.js.jsx
+++ b/app/assets/javascripts/components/update_account_email_message.js.jsx
@@ -4,7 +4,7 @@ class UpdateAccountEmailMessage extends React.Component {
       return null;
     } else if (this.props.addressChanged === true) {
       return (
-        <p className="inline-flash inline-flash--success">
+        <p className="inline-flash inline-flash--success" data-role="flash">
           <i className="fa fa-check">
             Email address updated!
           </i>

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -135,12 +135,30 @@ feature "Account" do
     expect(find("td.violations-caught")).to have_text("5")
   end
 
+  scenario "user updates their email address", :js do
+    email_address = "somebody.else@example.com"
+    stub_customer_find_request
+    stub_customer_update_request(email: email_address)
+    stub_repos_requests("letmein")
+
+    sign_in_as(create(:user, :stripe))
+    visit account_path
+    user = user_on_page
+    user.update(email_address)
+
+    expect(user).to be_updated
+  end
+
   private
 
   def stub_customer_find_request_with_subscriptions(customer_id, subscriptions)
     stub_request(:get, "#{stripe_base_url}/#{customer_id}").
       with(headers: { "Authorization" => "Bearer #{ENV['STRIPE_API_KEY']}" }).
       to_return(status: 200, body: merge_customer_subscriptions(subscriptions))
+  end
+
+  def user_on_page
+    UserOnPage.new
   end
 
   def generate_subscriptions_response(subscriptions)

--- a/spec/support/user_on_page.rb
+++ b/spec/support/user_on_page.rb
@@ -1,0 +1,20 @@
+require "capybara/dsl"
+
+class UserOnPage
+  include Capybara::DSL
+
+  def update(email_address)
+    fill_in "email_address", with: email_address
+    click_on "Update Email"
+  end
+
+  def updated?
+    flash_element.has_text? "Email address updated!"
+  end
+
+  private
+
+  def flash_element
+    find("[data-role='flash']")
+  end
+end


### PR DESCRIPTION
Previously, `this` was not bound to the email update event, which meant the resulting function was called in the correct context and users could not update their email address. Bound `this` to the email update.

https://trello.com/c/FjeiUk41

![](http://i.giphy.com/3o6ZsTnUnwh0mDYMgg.gif)