### PR TITLE
Typo on configuration page fixed

### DIFF
--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -104,7 +104,7 @@
         = succeed "." do
           = link_to "default RuboCop config", rubocop_config_url, target: :blank
         To change the way RuboCop is configured, add a
-        %em.code-inline .rucobop.yml
+        %em.code-inline .rubocop.yml
         file to your project, configure it as desired
         (see the
         = succeed ")," do


### PR DESCRIPTION
(.rucobop.yml -> .rubocop.yml)