### PR TITLE
Rename BuildReport to CompleteBuild

### DIFF
--- a/app/services/complete_build.rb
+++ b/app/services/complete_build.rb
@@ -1,4 +1,4 @@
-class BuildReport
+class CompleteBuild
   def self.run(pull_request:, build:, token:)
     new(pull_request: pull_request, build: build, token: token).run
   end

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -10,7 +10,7 @@ class CompleteFileReview
   def run
     create_violations!
 
-    BuildReport.run(
+    CompleteBuild.run(
       pull_request: pull_request,
       build: build,
       token: build.user_token,

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe BuildReport do
+describe CompleteBuild do
   describe ".run" do
     context "when build has violations" do
       context "when the build is complete" do
@@ -153,7 +153,11 @@ describe BuildReport do
     def run_service(build)
       head_commit = double("Commit", file_content: "")
       pull_request = double("PullRequest", head_commit: head_commit)
-      BuildReport.run(pull_request: pull_request, build: build, token: "abc123")
+      CompleteBuild.run(
+        pull_request: pull_request,
+        build: build,
+        token: "abc123",
+      )
     end
   end
 end

--- a/spec/services/complete_file_review_spec.rb
+++ b/spec/services/complete_file_review_spec.rb
@@ -25,7 +25,7 @@ describe CompleteFileReview do
 
       CompleteFileReview.run(attributes)
 
-      expect(BuildReport).to have_received(:run).with(
+      expect(CompleteBuild).to have_received(:run).with(
         pull_request: pull_request,
         build: build,
         token: Hound::GITHUB_TOKEN,
@@ -54,7 +54,7 @@ describe CompleteFileReview do
 
         CompleteFileReview.run(attributes)
 
-        expect(BuildReport).to have_received(:run).with(
+        expect(CompleteBuild).to have_received(:run).with(
           pull_request: pull_request,
           build: correct_build,
           token: Hound::GITHUB_TOKEN,
@@ -83,7 +83,7 @@ describe CompleteFileReview do
   end
 
   def stub_build_report_run
-    allow(BuildReport).to receive(:run)
+    allow(CompleteBuild).to receive(:run)
   end
 
   def stub_pull_request


### PR DESCRIPTION
`BuildReport` was confusing due to us having a `Build` model.
Does it mean it's a noun "the build report", or an action of
"building a report"?

We already have `CompleteFileReview`, so for parity with that it makes
sense to rename this to `CompleteBuild` to avoid ambiguity.