### PR TITLE
Disable Rubocop HTTP positional arguments check

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -573,6 +573,8 @@ Rails/HasAndBelongsToMany:
   Enabled: true
   Include:
   - app/models/**/*.rb
+Rails/HttpPositionalArguments:
+  Enabled: false
 Rails/Output:
   Description: Checks for calls to puts, print, etc.
   Enabled: true


### PR DESCRIPTION
Before, we were using the default Rubocop Ruby styles, which included rules for Rails 5. This was causing Hound to throw a warning because the app is only on Rails 4. Disabled the rule until the app we upgrade the app.