### PR TITLE
Add lib to eagerload paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(:default, Rails.env)
 module Houndapp
   class Application < Rails::Application
     config.autoload_paths += %W(#{config.root}/lib)
+    config.eager_load_paths += %W(#{config.root}/lib)
     config.encoding = "utf-8"
     config.filter_parameters += [:password]
     config.active_support.escape_html_entities_in_json = true


### PR DESCRIPTION
This fixes lib files not being available in Rails 5 production without
explicitly requiring them.

This comes with the caveat that everything in lib will be loaded when the
application boots, but in our case that's just a few rake tasks so we aren't too
concerned about it for the convenience this provides.