### PR TITLE
Use owner configuration for SCSS linting

### DIFF
--- a/app/models/config/scss.rb
+++ b/app/models/config/scss.rb
@@ -1,10 +1,25 @@
 module Config
   class Scss < Base
+    def initialize(hound_config, owner: MissingOwner.new)
+      super(hound_config)
+      @owner = owner
+    end
+
+    def content
+      owner_config.deep_merge(super)
+    end
+
     def serialize(data = content)
       Serializer.yaml(data)
     end
 
     private
+
+    attr_reader :owner
+
+    def owner_config
+      owner.hound_config
+    end
 
     def parse(file_content)
       Parser.yaml(file_content)

--- a/spec/models/config/scss_spec.rb
+++ b/spec/models/config/scss_spec.rb
@@ -3,21 +3,81 @@ require "app/models/config/base"
 require "app/models/config/scss"
 require "app/models/config/parser"
 require "app/models/config/serializer"
+require "app/models/missing_owner"
+require "app/services/build_owner_hound_config"
 
 describe Config::Scss do
   describe "#content" do
-    it "parses the configuration using YAML" do
-      raw_config = <<-EOS.strip_heredoc
-        linters:
-          BangFormat:
-            enabled: true
-            space_before_bang: true
-            space_after_bang: false
-      EOS
-      commit = stubbed_commit("config/scss.yml" => raw_config)
-      config = build_config(commit)
+    context "when an owner is provided" do
+      it "merges the configuration into the owner's configuration" do
+        owner = instance_double(
+          "Owner",
+          hound_config: {
+            "linters" => {
+              "BemDepth" => {
+                "enabled" => false,
+                "max_elements" => 1,
+              },
+            },
+          },
+        )
+        raw_owner_config = <<~EOS
+          linters:
+            BemDepth:
+              enabled: false
+              max_elements: 1
+        EOS
+        owner_commit = stubbed_commit("config/scss.yml" => raw_owner_config)
+        owner_config = build_config(owner_commit)
+        raw_config = <<~EOS
+          linters:
+            BangFormat:
+              enabled: true
+              space_before_bang: true
+              space_after_bang: false
+        EOS
+        commit = stubbed_commit("config/scss.yml" => raw_config)
+        config = build_config(commit, owner)
+        allow(BuildOwnerHoundConfig).to receive(:run).and_return(owner_config)
 
-      expect(config.content).to eq Config::Parser.yaml(raw_config)
+        expect(config.content).to eq(
+          "linters" => {
+            "BangFormat" => {
+              "enabled" => true,
+              "space_after_bang" => false,
+              "space_before_bang" => true,
+            },
+            "BemDepth" => {
+              "enabled" => false,
+              "max_elements" => 1,
+            },
+          },
+        )
+      end
+    end
+
+    context "when there is no owner" do
+      it "parses the configuration using YAML" do
+        raw_config = <<~EOS
+          linters:
+            BangFormat:
+              enabled: true
+              space_before_bang: true
+              space_after_bang: false
+        EOS
+        commit = stubbed_commit("config/scss.yml" => raw_config)
+        config = build_config(commit)
+
+        expect(config.content).to eq(
+          "linters" => {
+            "BangFormat" => {
+              "enabled" => true,
+              "space_after_bang" => false,
+              "space_before_bang" => true,
+            },
+          },
+        )
+      end
     end
   end
 
@@ -44,7 +104,7 @@ describe Config::Scss do
     end
   end
 
-  def build_config(commit)
+  def build_config(commit, owner = MissingOwner.new)
     hound_config = double(
       "HoundConfig",
       commit: commit,
@@ -53,6 +113,6 @@ describe Config::Scss do
       },
     )
 
-    Config::Scss.new(hound_config)
+    Config::Scss.new(hound_config, owner: owner)
   end
 end


### PR DESCRIPTION
Before, the SCSS linting always used Hound's default or the repository's own configuration. This meant we had to specify organisation-wide configurations in each individual repository. Updated the SCSS configuration to allow configuration at an organisational level.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/l0MYu5JMpCfiyKRFe.gif)