### PR TITLE
Use owner configuration for JavaScript linting

### DIFF
--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -1,10 +1,25 @@
 module Config
   class Eslint < Base
+    def initialize(hound_config, owner: MissingOwner.new)
+      super(hound_config)
+      @owner = owner
+    end
+
+    def content
+      owner_config.deep_merge(super)
+    end
+
     def serialize(data = content)
       Serializer.json(data)
     end
 
     private
+
+    attr_reader :owner
+
+    def owner_config
+      owner.hound_config
+    end
 
     def parse(file_content)
       json_with_comments = JsonWithComments.new(file_content)


### PR DESCRIPTION
Before, the JavaScript linting always used Hound's default or the repository's own configuration. This meant we had to specify organisation-wide configurations in each individual repository. Updated the JavaScript configuration to allow configuration at an organisational level.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/3o6ZteutxAmQ1cFcD6.gif)