### PR TITLE
Use owner configuration for Haml linting

### DIFF
--- a/app/models/config/haml.rb
+++ b/app/models/config/haml.rb
@@ -1,10 +1,25 @@
 module Config
   class Haml < Base
+    def initialize(hound_config, owner: MissingOwner.new)
+      super(hound_config)
+      @owner = owner
+    end
+
+    def content
+      owner_config.deep_merge(super)
+    end
+
     def serialize(data = content)
       Serializer.yaml(data)
     end
 
     private
+
+    attr_reader :owner
+
+    def owner_config
+      owner.hound_config
+    end
 
     def parse(file_content)
       Parser.yaml(file_content)

--- a/app/models/missing_owner.rb
+++ b/app/models/missing_owner.rb
@@ -1,0 +1,5 @@
+class MissingOwner
+  def hound_config
+    {}
+  end
+end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -12,4 +12,14 @@ class Owner < ApplicationRecord
   def has_config_repo?
     config_enabled? && config_repo.present?
   end
+
+  def hound_config
+    build_config.content
+  end
+
+  private
+
+  def build_config
+    BuildOwnerHoundConfig.run(self)
+  end
 end

--- a/spec/models/missing_owner_spec.rb
+++ b/spec/models/missing_owner_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+require "app/models/missing_owner"
+
+RSpec.describe MissingOwner do
+  describe "#hound_config" do
+    it "is an empty hash" do
+      expect(MissingOwner.new.hound_config).to eq({})
+    end
+  end
+end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -62,4 +62,19 @@ describe Owner do
       end
     end
   end
+
+  describe "#hound_config" do
+    it "is the content of the owner's Hound configuration" do
+      config = instance_double(
+        "HoundConfig",
+        content: {
+          "LineLength" => { "Max" => 90 },
+        },
+      )
+      owner = create(:owner)
+      allow(BuildOwnerHoundConfig).to receive(:run).and_return(config)
+
+      expect(owner.hound_config).to eq("LineLength" => { "Max" => 90 })
+    end
+  end
 end


### PR DESCRIPTION
Before, the Haml linting always used Hound's default or the repository's own configuration. This meant we had to specify organisation-wide configurations in each individual repository. Updated the Haml configuration to allow configuration at an organisational level.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/9u9oc820eAF0s.gif)