### PR TITLE
Move configuration owner into base

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -1,6 +1,9 @@
 module Config
   class Base
-    attr_reader_initialize :hound_config
+    def initialize(hound_config, owner: MissingOwner.new)
+      @hound_config = hound_config
+      @owner = owner
+    end
 
     def content
       @content ||= ensure_correct_type(safe_parse(load_content))
@@ -16,7 +19,12 @@ module Config
 
     private
 
+    attr_reader :hound_config, :owner
     attr_implement :parse, [:file_content]
+
+    def owner_config
+      owner.hound_config
+    end
 
     def safe_parse(content)
       parse(content)

--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -1,12 +1,7 @@
 module Config
   class CoffeeScript < Base
-    def initialize(hound_config, owner: nil)
-      super(hound_config)
-      @owner = owner
-    end
-
     def content
-      owner_config_content.deep_merge(super)
+      owner_config.deep_merge(super)
     end
 
     def serialize(data = content)
@@ -17,18 +12,6 @@ module Config
 
     def parse(file_content)
       Parser.json(file_content)
-    end
-
-    def owner_config_content
-      if @owner.present?
-        Config::CoffeeScript.new(owner_hound_config).content
-      else
-        {}
-      end
-    end
-
-    def owner_hound_config
-      BuildOwnerHoundConfig.run(@owner)
     end
   end
 end

--- a/app/models/config/haml.rb
+++ b/app/models/config/haml.rb
@@ -1,10 +1,5 @@
 module Config
   class Haml < Base
-    def initialize(hound_config, owner: MissingOwner.new)
-      super(hound_config)
-      @owner = owner
-    end
-
     def content
       owner_config.deep_merge(super)
     end
@@ -14,12 +9,6 @@ module Config
     end
 
     private
-
-    attr_reader :owner
-
-    def owner_config
-      owner.hound_config
-    end
 
     def parse(file_content)
       Parser.yaml(file_content)

--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -1,15 +1,10 @@
 module Config
   class Ruby < Base
-    def initialize(hound_config, owner: nil)
-      super(hound_config)
-      @owner = owner
-    end
-
     def content
       if legacy?
         hound_config.content
       else
-        owner_config_content.deep_merge(parse_inherit_from(super))
+        owner_config.deep_merge(parse_inherit_from(super))
       end
     end
 
@@ -21,18 +16,6 @@ module Config
 
     def parse(file_content)
       Parser.yaml(file_content)
-    end
-
-    def owner_config_content
-      if @owner.present?
-        Config::Ruby.new(owner_hound_config).content
-      else
-        {}
-      end
-    end
-
-    def owner_hound_config
-      BuildOwnerHoundConfig.run(@owner)
     end
 
     def parse_inherit_from(config)

--- a/app/models/config/scss.rb
+++ b/app/models/config/scss.rb
@@ -1,10 +1,5 @@
 module Config
   class Scss < Base
-    def initialize(hound_config, owner: MissingOwner.new)
-      super(hound_config)
-      @owner = owner
-    end
-
     def content
       owner_config.deep_merge(super)
     end
@@ -14,12 +9,6 @@ module Config
     end
 
     private
-
-    attr_reader :owner
-
-    def owner_config
-      owner.hound_config
-    end
 
     def parse(file_content)
       Parser.yaml(file_content)

--- a/app/models/config/tslint.rb
+++ b/app/models/config/tslint.rb
@@ -1,12 +1,7 @@
 module Config
   class Tslint < Base
-    def initialize(hound_config, owner: nil)
-      super(hound_config)
-      @owner = owner
-    end
-
     def content
-      owner_config_content.deep_merge(super)
+      owner_config.deep_merge(super)
     end
 
     def serialize(data = content)
@@ -19,18 +14,6 @@ module Config
       json_with_comments = JsonWithComments.new(file_content)
       content_without_comments = json_with_comments.without_comments
       Parser.yaml(content_without_comments)
-    end
-
-    def owner_config_content
-      if @owner.present?
-        Config::TsLint.new(owner_hound_config).content
-      else
-        {}
-      end
-    end
-
-    def owner_hound_config
-      BuildOwnerHoundConfig.run(@owner)
     end
   end
 end

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -63,6 +63,10 @@ module Linter
       job_name.constantize
     end
 
+    def owner
+      build.repo.owner || MissingOwner.new
+    end
+
     def config
       @config ||= ConfigBuilder.for(hound_config, name)
     end

--- a/app/models/linter/coffee_script.rb
+++ b/app/models/linter/coffee_script.rb
@@ -7,7 +7,7 @@ module Linter
     private
 
     def config
-      Config::CoffeeScript.new(hound_config, owner: build.repo.owner)
+      Config::CoffeeScript.new(hound_config, owner: owner)
     end
 
     def job_name

--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -5,7 +5,7 @@ module Linter
     private
 
     def config
-      Config::Ruby.new(hound_config, owner: build.repo.owner)
+      Config::Ruby.new(hound_config, owner: owner)
     end
 
     def job_name

--- a/spec/models/config/base_spec.rb
+++ b/spec/models/config/base_spec.rb
@@ -1,6 +1,7 @@
 require "spec_helper"
 require "app/models/config/base"
 require "app/models/config/parser_error"
+require "app/models/missing_owner"
 require "faraday"
 require "yaml"
 

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -3,6 +3,7 @@ require "app/models/config/base"
 require "app/models/config/coffee_script"
 require "app/models/config/parser"
 require "app/models/config/parser_error"
+require "app/models/missing_owner"
 
 describe Config::CoffeeScript do
   describe "#content" do

--- a/spec/models/config/ruby_spec.rb
+++ b/spec/models/config/ruby_spec.rb
@@ -4,6 +4,7 @@ require "app/models/config/ruby"
 require "app/models/hound_config"
 require "app/models/config/parser"
 require "app/models/config/parser_error"
+require "app/models/missing_owner"
 require "app/services/build_owner_hound_config"
 
 describe Config::Ruby do
@@ -32,17 +33,18 @@ describe Config::Ruby do
 
       context "and an owner is present" do
         it "returns the config merged with the owner's config as a hash" do
-          owner = double("Owner")
-          owner_commit = stubbed_commit(
-            "config/rubocop.yml" => '{ "Metrics/ClassLength": { "Max": 100 } }',
+          owner = instance_double(
+            "Owner",
+            hound_config: {
+              "Metrics/ClassLength" => {
+                "Max" => 100,
+              },
+            },
           )
-          owner_config = build_config(owner_commit)
           repo_commit = stubbed_commit(
             "config/rubocop.yml" => '{ "LineLength": { "Max": 90 } }',
           )
           config = build_config(repo_commit, owner)
-          allow(BuildOwnerHoundConfig).to receive(:run).with(owner).
-            and_return(owner_config)
 
           expect(config.content).to eq(
             "LineLength" => { "Max" => 90 },
@@ -170,7 +172,7 @@ describe Config::Ruby do
     end
   end
 
-  def build_config(commit, owner = nil)
+  def build_config(commit, owner = MissingOwner.new)
     hound_config = double(
       "HoundConfig",
       commit: commit,

--- a/spec/models/config/tslint_spec.rb
+++ b/spec/models/config/tslint_spec.rb
@@ -5,6 +5,7 @@ require "app/models/config/parser"
 require "app/models/config/parser_error"
 require "app/models/config/serializer"
 require "app/models/config/json_with_comments"
+require "app/models/missing_owner"
 
 describe Config::Tslint do
   describe "#content" do


### PR DESCRIPTION
Before, we were overriding the constructor in every child class, which was a waste of time. Updated the base class to now take an optional owner argument.

https://trello.com/c/HY2hoTdq