### PR TITLE
Pass the owner through to the configuration

### DIFF
--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -9,6 +9,10 @@ module Linter
 
     private
 
+    def config
+      Config::Eslint.new(hound_config, owner: owner)
+    end
+
     def jsignore
       @jsignore ||= JsIgnore.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/app/models/linter/haml.rb
+++ b/app/models/linter/haml.rb
@@ -1,5 +1,11 @@
 module Linter
   class Haml < Base
     FILE_REGEXP = /.+\.haml\z/
+
+    private
+
+    def config
+      Config::Haml.new(hound_config, owner: owner)
+    end
   end
 end

--- a/app/models/linter/scss.rb
+++ b/app/models/linter/scss.rb
@@ -1,5 +1,11 @@
 module Linter
   class Scss < Base
     FILE_REGEXP = /.+\.scss\z/
+
+    private
+
+    def config
+      Config::Scss.new(hound_config, owner: owner)
+    end
   end
 end


### PR DESCRIPTION
Before, we set up several configurations to accept an owner. This was all well and good, but we did not actually pass an owner through. Updated the SCSS, ESLint, and Haml linters to provide an owner to their configurations.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/l0MYzq6Tf7w8gY29G.gif)