### PR TITLE
Use owner configuration for Swift linting

### DIFF
--- a/app/models/config/swift.rb
+++ b/app/models/config/swift.rb
@@ -1,5 +1,9 @@
 module Config
   class Swift < Base
+    def content
+      owner_config.deep_merge(super)
+    end
+
     def serialize(data = content)
       Serializer.yaml(data)
     end

--- a/app/models/linter/swift.rb
+++ b/app/models/linter/swift.rb
@@ -1,5 +1,11 @@
 module Linter
   class Swift < Base
     FILE_REGEXP = /.+\.swift\z/
+
+    private
+
+    def config
+      Config::Swift.new(hound_config, owner: owner)
+    end
   end
 end


### PR DESCRIPTION
Before, the Swift linting always used Hound's default or the repository's own configuration. This meant we had to specify organisation-wide configurations in each individual repository. Updated the Swift configuration to allow configuration at an organisational level.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/l4Jz4sz2yTLhxzquY.gif)