### PR TITLE
Update base linter config

### DIFF
--- a/app/models/config_builder.rb
+++ b/app/models/config_builder.rb
@@ -1,20 +1,21 @@
 class ConfigBuilder
-  def self.for(hound_config, name)
-    new(hound_config, name).config
+  def self.for(hound_config:, name:, owner:)
+    new(hound_config: hound_config, name: name, owner: owner).config
   end
 
-  def initialize(hound_config, name)
+  def initialize(hound_config:, name:, owner:)
     @hound_config = hound_config
     @name = name
+    @owner = owner
   end
 
   def config
-    config_class.new(hound_config)
+    config_class.new(hound_config, owner: owner)
   end
 
   private
 
-  attr_reader :hound_config, :name
+  attr_reader :hound_config, :name, :owner
 
   def config_class
     "Config::#{name.classify}".constantize

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -68,7 +68,11 @@ module Linter
     end
 
     def config
-      @config ||= ConfigBuilder.for(hound_config, name)
+      @_config ||= ConfigBuilder.for(
+        hound_config: hound_config,
+        name: name,
+        owner: owner,
+      )
     end
   end
 end

--- a/app/models/linter/coffee_script.rb
+++ b/app/models/linter/coffee_script.rb
@@ -6,10 +6,6 @@ module Linter
 
     private
 
-    def config
-      Config::CoffeeScript.new(hound_config, owner: owner)
-    end
-
     def job_name
       "CoffeelintReviewJob"
     end

--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -9,10 +9,6 @@ module Linter
 
     private
 
-    def config
-      Config::Eslint.new(hound_config, owner: owner)
-    end
-
     def jsignore
       @jsignore ||= JsIgnore.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/app/models/linter/haml.rb
+++ b/app/models/linter/haml.rb
@@ -1,11 +1,5 @@
 module Linter
   class Haml < Base
     FILE_REGEXP = /.+\.haml\z/
-
-    private
-
-    def config
-      Config::Haml.new(hound_config, owner: owner)
-    end
   end
 end

--- a/app/models/linter/ruby.rb
+++ b/app/models/linter/ruby.rb
@@ -4,10 +4,6 @@ module Linter
 
     private
 
-    def config
-      Config::Ruby.new(hound_config, owner: owner)
-    end
-
     def job_name
       "RubocopReviewJob"
     end

--- a/app/models/linter/scss.rb
+++ b/app/models/linter/scss.rb
@@ -1,11 +1,5 @@
 module Linter
   class Scss < Base
     FILE_REGEXP = /.+\.scss\z/
-
-    private
-
-    def config
-      Config::Scss.new(hound_config, owner: owner)
-    end
   end
 end

--- a/app/models/linter/swift.rb
+++ b/app/models/linter/swift.rb
@@ -1,11 +1,5 @@
 module Linter
   class Swift < Base
     FILE_REGEXP = /.+\.swift\z/
-
-    private
-
-    def config
-      Config::Swift.new(hound_config, owner: owner)
-    end
   end
 end

--- a/app/models/linter/tslint.rb
+++ b/app/models/linter/tslint.rb
@@ -2,10 +2,4 @@ module Linter
   class Tslint < Base
     FILE_REGEXP = /.+\.ts\z/
   end
-
-  private
-
-  def config
-    Config::TsLint.new(hound_config, owner: build.repo.owner)
-  end
 end

--- a/spec/models/config_builder_spec.rb
+++ b/spec/models/config_builder_spec.rb
@@ -3,12 +3,17 @@ require "app/models/config_builder"
 require "app/models/config/base"
 require "app/models/config/ruby"
 require "app/models/config/unsupported"
+require "app/models/missing_owner"
 
 describe ConfigBuilder do
   describe ".for" do
     context "when there is matching config class for the given name" do
       it "returns the matching config" do
-        config = ConfigBuilder.for(double, "ruby")
+        config = ConfigBuilder.for(
+          hound_config: double,
+          name: "ruby",
+          owner: instance_double("Owner"),
+        )
 
         expect(config).to be_a(Config::Ruby)
       end
@@ -16,7 +21,11 @@ describe ConfigBuilder do
 
     context "when there is not matching config class for the given name" do
       it "returns the unsupported config" do
-        config = ConfigBuilder.for(double, "non-existent-config")
+        config = ConfigBuilder.for(
+          hound_config: double,
+          name: "non-existent-config",
+          owner: instance_double("Owner"),
+        )
 
         expect(config).to be_a(Config::Unsupported)
       end


### PR DESCRIPTION
Before, we had started to pass the owner through to the individual configurations. This meant we were overriding the base class with similar methods in the children. Updated the configuration builder to accept an owner and updated the base lint to pass an owner.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/26FL3Jl2PF7MWyN5S.gif)