### PR TITLE
Hooking webpack's build step before asset precompilation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,6 +10,8 @@ task(:default).clear
 # Run webpack:build before :spec
 task default: ["webpack:build", :spec]
 
+task "assets:precompile" => "webpack:build"
+
 if defined? RSpec
   task(:spec).clear
   RSpec::Core::RakeTask.new(:spec) do |t|

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Houndapp::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = false
+  config.public_file_server.enabled = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true

--- a/lib/redirect_to_configuration.rb
+++ b/lib/redirect_to_configuration.rb
@@ -1,5 +1,5 @@
 class RedirectToConfiguration
-  CONFIG_REGEX = %r{^/configuration.}
+  CONFIG_REGEX = %r{^/configuration.} unless defined?(CONFIG_REGEX)
 
   def initialize(app)
     @app = app


### PR DESCRIPTION
To fix Heroku deployment. Also - getting rid of some deprecations and warnings.