### PR TITLE
Move loading of content into base config

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -6,7 +6,9 @@ module Config
     end
 
     def content
-      @content ||= ensure_correct_type(safe_parse(load_content))
+      @content ||= owner_config.deep_merge(load)
+    rescue ConfigContent::ContentError => exception
+      raise_parse_error(exception.message)
     end
 
     def serialize(data = content)
@@ -20,58 +22,21 @@ module Config
     private
 
     attr_reader :hound_config, :owner
-    attr_implement :parse, [:file_content]
+
+    def load
+      ConfigContent.new(
+        commit: commit,
+        file_path: file_path,
+        parser: ->(content) { parse(content) },
+      ).load
+    end
 
     def owner_config
       owner.hound_config
     end
 
-    def safe_parse(content)
-      parse(content)
-    rescue JSON::ParserError, Psych::Exception => exception
-      raise_parse_error(exception.message)
-    end
-
-    def ensure_correct_type(config)
-      if config.is_a? Hash
-        config
-      else
-        raise_type_error
-      end
-    end
-
-    def raise_type_error
-      raise_parse_error(%{"#{file_path}" must be a Hash})
-    end
-
-    def load_content
-      if file_path
-        if url?
-          fetch_url
-        else
-          commit.file_content(file_path)
-        end
-      else
-        default_content
-      end
-    end
-
-    def fetch_url
-      response = Faraday.new.get(file_path)
-
-      if response.success?
-        response.body
-      else
-        raise_parse_error("#{response.status} #{response.body}")
-      end
-    end
-
-    def url?
-      URI::regexp(%w(http https)).match(file_path)
-    end
-
-    def default_content
-      "{}"
+    def parse(content)
+      Parser.yaml(content)
     end
 
     def raise_parse_error(message)

--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -1,17 +1,7 @@
 module Config
   class CoffeeScript < Base
-    def content
-      owner_config.deep_merge(super)
-    end
-
     def serialize(data = content)
       Serializer.json(data)
-    end
-
-    private
-
-    def parse(file_content)
-      Parser.json(file_content)
     end
   end
 end

--- a/app/models/config/credo.rb
+++ b/app/models/config/credo.rb
@@ -7,5 +7,15 @@ module Config
     def default_content
       ""
     end
+
+    private
+
+    def load_content
+      if file_path
+        commit.file_content(file_path)
+      else
+        default_content
+      end
+    end
   end
 end

--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -1,30 +1,15 @@
 module Config
   class Eslint < Base
-    def initialize(hound_config, owner: MissingOwner.new)
-      super(hound_config)
-      @owner = owner
-    end
-
-    def content
-      owner_config.deep_merge(super)
-    end
-
     def serialize(data = content)
       Serializer.json(data)
     end
 
     private
 
-    attr_reader :owner
-
-    def owner_config
-      owner.hound_config
-    end
-
     def parse(file_content)
       json_with_comments = JsonWithComments.new(file_content)
       content_without_comments = json_with_comments.without_comments
-      Parser.yaml(content_without_comments)
+      super(content_without_comments)
     end
   end
 end

--- a/app/models/config/haml.rb
+++ b/app/models/config/haml.rb
@@ -1,17 +1,7 @@
 module Config
   class Haml < Base
-    def content
-      owner_config.deep_merge(super)
-    end
-
     def serialize(data = content)
       Serializer.yaml(data)
-    end
-
-    private
-
-    def parse(file_content)
-      Parser.yaml(file_content)
     end
   end
 end

--- a/app/models/config/jshint.rb
+++ b/app/models/config/jshint.rb
@@ -18,8 +18,22 @@ module Config
 
     private
 
+    def ensure_correct_type(config)
+      if config.is_a? Hash
+        config
+      else
+        raise_type_error
+      end
+    end
+
     def parse(file_content = raw_content)
-      Parser.json(file_content)
+      super(file_content)
+    end
+
+    def safe_parse(content)
+      parse(content)
+    rescue JSON::ParserError, Psych::Exception => exception
+      raise_parse_error(exception.message)
     end
   end
 end

--- a/app/models/config/python.rb
+++ b/app/models/config/python.rb
@@ -1,9 +1,5 @@
 module Config
   class Python < Base
-    def content
-      @content ||= owner_config.deep_merge(super.presence || default_content)
-    end
-
     def serialize(data = content)
       Serializer.ini(data)
     end
@@ -12,10 +8,6 @@ module Config
 
     def parse(file_content)
       Parser.ini(file_content)
-    end
-
-    def default_content
-      {}
     end
   end
 end

--- a/app/models/config/remark.rb
+++ b/app/models/config/remark.rb
@@ -3,11 +3,5 @@ module Config
     def serialize(data = content)
       Serializer.json(data)
     end
-
-    private
-
-    def parse(file_content)
-      Parser.json(file_content)
-    end
   end
 end

--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -4,7 +4,7 @@ module Config
       if legacy?
         hound_config.content
       else
-        owner_config.deep_merge(parse_inherit_from(super))
+        parse_inherit_from(super)
       end
     end
 
@@ -13,10 +13,6 @@ module Config
     end
 
     private
-
-    def parse(file_content)
-      Parser.yaml(file_content)
-    end
 
     def parse_inherit_from(config)
       inherit_from = Array(config.fetch("inherit_from", []))
@@ -28,6 +24,12 @@ module Config
       end
 
       inherited_config.merge(config.except("inherit_from"))
+    end
+
+    def safe_parse(content)
+      parse(content)
+    rescue Psych::Exception => exception
+      raise_parse_error(exception.message)
     end
 
     def legacy?

--- a/app/models/config/scss.rb
+++ b/app/models/config/scss.rb
@@ -1,17 +1,7 @@
 module Config
   class Scss < Base
-    def content
-      owner_config.deep_merge(super)
-    end
-
     def serialize(data = content)
       Serializer.yaml(data)
-    end
-
-    private
-
-    def parse(file_content)
-      Parser.yaml(file_content)
     end
   end
 end

--- a/app/models/config/swift.rb
+++ b/app/models/config/swift.rb
@@ -1,17 +1,7 @@
 module Config
   class Swift < Base
-    def content
-      owner_config.deep_merge(super)
-    end
-
     def serialize(data = content)
       Serializer.yaml(data)
-    end
-
-    private
-
-    def parse(file_content)
-      Parser.yaml(file_content)
     end
   end
 end

--- a/app/models/config/tslint.rb
+++ b/app/models/config/tslint.rb
@@ -1,9 +1,5 @@
 module Config
   class Tslint < Base
-    def content
-      owner_config.deep_merge(super)
-    end
-
     def serialize(data = content)
       Serializer.json(data)
     end
@@ -13,7 +9,7 @@ module Config
     def parse(file_content)
       json_with_comments = JsonWithComments.new(file_content)
       content_without_comments = json_with_comments.without_comments
-      Parser.yaml(content_without_comments)
+      super(content_without_comments)
     end
   end
 end

--- a/app/models/config_content.rb
+++ b/app/models/config_content.rb
@@ -1,0 +1,59 @@
+class ConfigContent
+  ContentError = Class.new(StandardError)
+
+  def initialize(commit:, file_path: nil, parser:)
+    @commit = commit
+    @file_path = file_path
+    @parser = parser
+  end
+
+  def load
+    if file_path
+      parse
+    else
+      {}
+    end
+  end
+
+  private
+
+  attr_reader :commit, :file_path, :parser
+
+  def content
+    if url?
+      remote_content.load
+    else
+      commit.file_content(file_path)
+    end
+  end
+
+  def incorrect_format?
+    !parsed_content.is_a? Hash
+  end
+
+  def parse
+    if incorrect_format?
+      raise_error %{"#{file_path}" must be a Hash}
+    else
+      parsed_content
+    end
+  end
+
+  def parsed_content
+    @_parsed_content ||= parser.call(content)
+  rescue Psych::Exception => exception
+    raise_error exception.message
+  end
+
+  def raise_error(message)
+    raise ContentError, message
+  end
+
+  def remote_content
+    Remote.new(file_path)
+  end
+
+  def url?
+    URI::regexp(%w(http https)).match(file_path)
+  end
+end

--- a/app/models/config_content/remote.rb
+++ b/app/models/config_content/remote.rb
@@ -1,0 +1,31 @@
+class ConfigContent
+  class Remote
+    extend Forwardable
+
+    def_delegators :response, :body, :status, :success?
+
+    def initialize(url)
+      @url = url
+    end
+
+    def load
+      if success?
+        body
+      else
+        raise ContentError, "#{status} #{body}"
+      end
+    end
+
+    private
+
+    attr_reader :url
+
+    def connection
+      Faraday.new
+    end
+
+    def response
+      connection.get(url)
+    end
+  end
+end

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -3,6 +3,7 @@ require "app/models/config/base"
 require "app/models/config/coffee_script"
 require "app/models/config/parser"
 require "app/models/config/parser_error"
+require "app/models/config_content"
 require "app/models/missing_owner"
 
 describe Config::CoffeeScript do
@@ -45,15 +46,12 @@ describe Config::CoffeeScript do
       it "raises an exception" do
         commit = stubbed_commit(
           "config/coffeescript.json" => <<-EOS.strip_heredoc
-            invalid_json
+            { invalid_json: [ }
           EOS
         )
         config = build_config(commit)
 
-        expect { config.content }.to raise_error(
-          Config::ParserError,
-          /unexpected token at 'invalid_json\n'/,
-        )
+        expect { config.content }.to raise_error(Config::ParserError)
       end
     end
   end

--- a/spec/models/config/python_spec.rb
+++ b/spec/models/config/python_spec.rb
@@ -4,6 +4,7 @@ require "app/models/config/parser"
 require "app/models/config/parser_error"
 require "app/models/config/python"
 require "app/models/config/serializer"
+require "app/models/config_content"
 require "app/models/missing_owner"
 require "inifile"
 

--- a/spec/models/config_content/remote_spec.rb
+++ b/spec/models/config_content/remote_spec.rb
@@ -1,0 +1,40 @@
+require "spec_helper"
+require "app/models/config_content"
+require "app/models/config_content/remote"
+require "faraday"
+
+class ConfigContent
+  RSpec.describe Remote do
+    describe "#load" do
+      context "successfully" do
+        it "is a hash of the remote config file" do
+          url = "https://example.com/rubocop.yml"
+          response = <<~EOS
+            LineLength:
+              Max: 90
+          EOS
+          stub_request(:get, url).to_return(status: 200, body: response)
+
+          expect(Remote.new(url).load). to eq(response)
+        end
+      end
+
+      context "when there is an issue with the remote config file" do
+        it "raises an exception" do
+          url = "https://example.com/rubocop.yml"
+          stub_request(:get, url).to_return(
+            status: 404,
+            body: "Could not find resource",
+          )
+
+          expect do
+            Remote.new(url).load
+          end.to raise_error(
+            ConfigContent::ContentError,
+            "404 Could not find resource",
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/config_content_spec.rb
+++ b/spec/models/config_content_spec.rb
@@ -1,0 +1,107 @@
+require "spec_helper"
+require "app/models/config_content"
+require "app/models/config_content/remote"
+require "app/models/config/parser"
+require "faraday"
+require "json"
+
+RSpec.describe ConfigContent do
+  describe "#load" do
+    context "when the file path exists" do
+      it "is a hash of the config file's contents" do
+        file_path = "config-file.txt"
+        parser = ->(_raw_content) { { "LineLength" => { "Max" => 90 } } }
+        raw_content = <<~EOS
+          LineLength:
+            Max: 90
+        EOS
+        commit = instance_double("Commit", file_content: raw_content)
+
+        expect(ConfigContent.new(
+          commit: commit,
+          file_path: file_path,
+          parser: parser,
+        ).load).to eq("LineLength" => { "Max" => 90 })
+      end
+    end
+
+    context "when the file path is a URL" do
+      it "is a hash of the remote config file's contents" do
+        commit = instance_double("Commit")
+        file_path = "https://example.com/rubocop.yml"
+        parser = ->(_raw_content) { { "LineLength" => { "Max" => 90 } } }
+        raw_content = <<~EOS
+          LineLength:
+            Max: 90
+        EOS
+        remote = instance_double("ConfigContent::Remote", load: raw_content)
+        allow(ConfigContent::Remote).to receive(:new).and_return(remote)
+
+        expect(ConfigContent.new(
+          commit: commit,
+          file_path: file_path,
+          parser: parser,
+        ).load).to eq("LineLength" => { "Max" => 90 })
+      end
+    end
+
+    context "when there is no file path" do
+      it "is an empty hash" do
+        commit = instance_double("Commit")
+        parser = ->(_) {}
+
+        expect(ConfigContent.new(commit: commit, parser: parser).load).to eq({})
+      end
+    end
+
+    context "when the config is invalid" do
+      it "raises an exception" do
+        file_path = "config-file.txt"
+        parser = ->(content) { Config::Parser.yaml(content) }
+        raw_content = <<~EOS
+          foo: bar
+            baz: qux
+        EOS
+        commit = instance_double("Commit", file_content: raw_content)
+        allow(Config::Parser).to receive(:yaml).and_raise(
+          Psych::SyntaxError.new(
+            nil,
+            2,
+            6,
+            0,
+            "mapping values are not allowed in this context",
+            nil,
+          ),
+        )
+
+        expect do
+          ConfigContent.new(
+            commit: commit,
+            file_path: file_path,
+            parser: parser,
+          ).load
+        end.to raise_error(ConfigContent::ContentError)
+      end
+    end
+
+    context "when the parsed config is not a hash" do
+      it "raises an exception" do
+        file_path = "config-file.txt"
+        parser = ->(_raw_content) { "" }
+        raw_content = ""
+        commit = instance_double("Commit", file_content: raw_content)
+
+        expect do
+          ConfigContent.new(
+            commit: commit,
+            file_path: file_path,
+            parser: parser,
+          ).load
+        end.to raise_error(
+          ConfigContent::ContentError,
+          %{"config-file.txt" must be a Hash},
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before, we had started to override the loading of config content in each of the child classes. This meant there had become some divergence from the base definition. Created a config content loader and moved the loading and merging into the parent class.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/l1IYi090aR06OeNAk.gif)