### PR TITLE
Use owner configuration for Python linting

### DIFF
--- a/app/models/config/python.rb
+++ b/app/models/config/python.rb
@@ -1,7 +1,7 @@
 module Config
   class Python < Base
     def content
-      @content ||= super.presence || default_content
+      @content ||= owner_config.deep_merge(super.presence || default_content)
     end
 
     def serialize(data = content)
@@ -15,7 +15,7 @@ module Config
     end
 
     def default_content
-      ""
+      {}
     end
   end
 end

--- a/app/models/linter/python.rb
+++ b/app/models/linter/python.rb
@@ -4,6 +4,10 @@ module Linter
 
     private
 
+    def config
+      Config::Python.new(hound_config, owner: owner)
+    end
+
     def enqueue_job(attributes)
       Resque.push(
         "python_review",


### PR DESCRIPTION
Before, the Python linting always used Hound's default or the repository's own configuration. This meant we had to specify organisation-wide configurations in each individual repository. Updated the Python configuration to allow configuration at an organisational level.

https://trello.com/c/HY2hoTdq

![](http://i.giphy.com/l0HlSGY5N6p8bM5iw.gif)