### PR TITLE
Give the config builder an appropriate name

### DIFF
--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -68,7 +68,7 @@ module Linter
     end
 
     def config
-      @_config ||= ConfigBuilder.for(
+      @_config ||= BuildConfig.for(
         hound_config: hound_config,
         name: name,
         owner: owner,

--- a/app/services/build_config.rb
+++ b/app/services/build_config.rb
@@ -1,4 +1,4 @@
-class ConfigBuilder
+class BuildConfig
   def self.for(hound_config:, name:, owner:)
     new(hound_config: hound_config, name: name, owner: owner).config
   end

--- a/spec/models/linter/base_spec.rb
+++ b/spec/models/linter/base_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 require "app/models/linter/base"
-require "app/models/config_builder"
 require "app/models/config/base"
 require "app/models/config/unsupported"
+require "app/services/build_config"
 
 module Linter
   class Test < Base

--- a/spec/services/build_config_spec.rb
+++ b/spec/services/build_config_spec.rb
@@ -1,15 +1,15 @@
 require "spec_helper"
-require "app/models/config_builder"
 require "app/models/config/base"
 require "app/models/config/ruby"
 require "app/models/config/unsupported"
 require "app/models/missing_owner"
+require "app/services/build_config"
 
-describe ConfigBuilder do
+describe BuildConfig do
   describe ".for" do
     context "when there is matching config class for the given name" do
       it "returns the matching config" do
-        config = ConfigBuilder.for(
+        config = BuildConfig.for(
           hound_config: double,
           name: "ruby",
           owner: instance_double("Owner"),
@@ -21,7 +21,7 @@ describe ConfigBuilder do
 
     context "when there is not matching config class for the given name" do
       it "returns the unsupported config" do
-        config = ConfigBuilder.for(
+        config = BuildConfig.for(
           hound_config: double,
           name: "non-existent-config",
           owner: instance_double("Owner"),


### PR DESCRIPTION
Before, the config builder was a model and the name implied that it return an instance of a config builder. The config builder actually returned an instance of a specific config. Moved the class into the `services` directory and gave it a more appropriate name.

![](http://i.giphy.com/l3vR1DhIGPsp7E4i4.gif)