### PR TITLE
Build owner config

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -32,7 +32,11 @@ module Config
     end
 
     def owner_config
-      owner.hound_config
+      BuildConfig.for(
+        hound_config: owner.hound_config,
+        name: linter_name,
+        owner: MissingOwner.new,
+      ).content
     end
 
     def parse(content)

--- a/app/models/missing_owner.rb
+++ b/app/models/missing_owner.rb
@@ -1,5 +1,7 @@
 class MissingOwner
+  MissingHoundConfig = Struct.new(:content)
+
   def hound_config
-    {}
+    MissingHoundConfig.new({})
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -14,12 +14,6 @@ class Owner < ApplicationRecord
   end
 
   def hound_config
-    build_config.content
-  end
-
-  private
-
-  def build_config
     BuildOwnerHoundConfig.run(self)
   end
 end

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -5,6 +5,7 @@ require "app/models/config/parser"
 require "app/models/config/parser_error"
 require "app/models/config_content"
 require "app/models/missing_owner"
+require "app/services/build_config"
 
 describe Config::CoffeeScript do
   describe "#content" do
@@ -16,6 +17,8 @@ describe Config::CoffeeScript do
           EOS
         )
         config = build_config(commit)
+        owner_config = instance_double("Config::CoffeeScript", content: {})
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         result = config.content
 
@@ -33,6 +36,8 @@ describe Config::CoffeeScript do
           EOS
         )
         config = build_config(commit)
+        owner_config = instance_double("Config::CoffeeScript", content: {})
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         result = config.content
 
@@ -50,6 +55,8 @@ describe Config::CoffeeScript do
           EOS
         )
         config = build_config(commit)
+        owner_config = instance_double("Config::CoffeeScript", content: {})
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect { config.content }.to raise_error(Config::ParserError)
       end

--- a/spec/models/config/remark_spec.rb
+++ b/spec/models/config/remark_spec.rb
@@ -3,6 +3,9 @@ require "app/models/config/base"
 require "app/models/config/remark"
 require "app/models/config/parser"
 require "app/models/config/serializer"
+require "app/models/config_content"
+require "app/models/missing_owner"
+require "app/services/build_config"
 
 describe Config::Remark do
   describe "#content" do
@@ -14,6 +17,8 @@ describe Config::Remark do
       EOS
       commit = stubbed_commit("config/.remarkrc" => raw_config)
       config = build_config(commit)
+      owner_config = instance_double("Config::Remark", content: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.content).to eq Config::Parser.json(raw_config)
     end
@@ -28,6 +33,8 @@ describe Config::Remark do
       EOS
       commit = stubbed_commit("config/.remarkrc" => raw_config)
       config = build_config(commit)
+      owner_config = instance_double("Config::Remark", content: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq "{\"heading-style\":\"setext\"}"
     end

--- a/spec/models/config/scss_spec.rb
+++ b/spec/models/config/scss_spec.rb
@@ -3,32 +3,15 @@ require "app/models/config/base"
 require "app/models/config/scss"
 require "app/models/config/parser"
 require "app/models/config/serializer"
+require "app/models/config_content"
 require "app/models/missing_owner"
+require "app/services/build_config"
 require "app/services/build_owner_hound_config"
 
 describe Config::Scss do
   describe "#content" do
     context "when an owner is provided" do
       it "merges the configuration into the owner's configuration" do
-        owner = instance_double(
-          "Owner",
-          hound_config: {
-            "linters" => {
-              "BemDepth" => {
-                "enabled" => false,
-                "max_elements" => 1,
-              },
-            },
-          },
-        )
-        raw_owner_config = <<~EOS
-          linters:
-            BemDepth:
-              enabled: false
-              max_elements: 1
-        EOS
-        owner_commit = stubbed_commit("config/scss.yml" => raw_owner_config)
-        owner_config = build_config(owner_commit)
         raw_config = <<~EOS
           linters:
             BangFormat:
@@ -37,8 +20,21 @@ describe Config::Scss do
               space_after_bang: false
         EOS
         commit = stubbed_commit("config/scss.yml" => raw_config)
+        hound_config = instance_double("HoundConfig")
+        owner = instance_double("Owner", hound_config: hound_config)
         config = build_config(commit, owner)
-        allow(BuildOwnerHoundConfig).to receive(:run).and_return(owner_config)
+        owner_config = instance_double(
+          "Config::Scss",
+          content: {
+            "linters" => {
+              "BemDepth" => {
+                "enabled" => false,
+                "max_elements" => 1,
+              },
+            },
+          },
+        )
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq(
           "linters" => {
@@ -67,6 +63,8 @@ describe Config::Scss do
         EOS
         commit = stubbed_commit("config/scss.yml" => raw_config)
         config = build_config(commit)
+        owner_config = instance_double("Config::Scss", content: {})
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq(
           "linters" => {
@@ -92,6 +90,8 @@ describe Config::Scss do
       EOS
       commit = stubbed_commit("config/scss.yml" => raw_config)
       config = build_config(commit)
+      owner_config = instance_double("Config::Scss", content: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq <<-EOS.strip_heredoc
         ---

--- a/spec/models/config/swift_spec.rb
+++ b/spec/models/config/swift_spec.rb
@@ -3,24 +3,29 @@ require "app/models/config/base"
 require "app/models/config/swift"
 require "app/models/config/parser"
 require "app/models/config/serializer"
+require "app/models/config_content"
 require "app/models/missing_owner"
+require "app/services/build_config"
 
 describe Config::Swift do
   describe "#content" do
     context "when an owner is provided" do
       it "merges the configuration into the owner's configuration" do
-        owner = instance_double(
-          "Owner",
-          hound_config: {
-            "excluded" => ["Carthage", "Pods"],
-          },
-        )
         raw_config = <<~EOS
           disabled_rules:
             - colon
         EOS
         commit = stubbed_commit("config/swiftlint.yml" => raw_config)
+        hound_config = instance_double("HoundConfig")
+        owner = instance_double("Owner", hound_config: hound_config)
         config = build_config(commit, owner)
+        owner_config = instance_double(
+          "Config::Swift",
+          content: {
+            "excluded" => ["Carthage", "Pods"],
+          },
+        )
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq(
           "disabled_rules" => ["colon"],
@@ -37,6 +42,8 @@ describe Config::Swift do
         EOS
         commit = stubbed_commit("config/swiftlint.yml" => raw_config)
         config = build_config(commit)
+        owner_config = instance_double("Config::Swift", content: {})
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq("disabled_rules" => ["colon"])
       end
@@ -51,6 +58,8 @@ describe Config::Swift do
       EOS
       commit = stubbed_commit("config/swiftlint.yml" => raw_config)
       config = build_config(commit)
+      owner_config = instance_double("Config::Swift", content: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq "---\ndisabled_rules:\n- colon\n"
     end

--- a/spec/models/config/tslint_spec.rb
+++ b/spec/models/config/tslint_spec.rb
@@ -5,7 +5,9 @@ require "app/models/config/parser"
 require "app/models/config/parser_error"
 require "app/models/config/serializer"
 require "app/models/config/json_with_comments"
+require "app/models/config_content"
 require "app/models/missing_owner"
+require "app/services/build_config"
 
 describe Config::Tslint do
   describe "#content" do
@@ -19,6 +21,8 @@ describe Config::Tslint do
       EOS
       commit = stubbed_commit("config/tslint.json" => raw_config)
       config = build_config(commit)
+      owner_config = instance_double("Config::Tslint", content: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.content).to eq("rules" => { "no-constructor-vars" => true })
     end
@@ -33,6 +37,8 @@ describe Config::Tslint do
         EOS
         commit = stubbed_commit("config/tslint.json" => raw_config)
         config = build_config(commit)
+        owner_config = instance_double("Config::Tslint", content: {})
+        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq("foo" => 1, "bar" => 2)
       end

--- a/spec/models/linter/coffee_script_spec.rb
+++ b/spec/models/linter/coffee_script_spec.rb
@@ -39,6 +39,8 @@ describe Linter::CoffeeScript do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "foo.coffee.js")
+      owner_config = instance_double("Config::CoffeeScript", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -39,6 +39,8 @@ describe Linter::Eslint do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.js")
       linter = build_linter
+      owner_config = instance_double("Config::Eslint", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/haml_spec.rb
+++ b/spec/models/linter/haml_spec.rb
@@ -23,6 +23,8 @@ describe Linter::Haml do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.haml")
+      owner_config = instance_double("Config::Haml", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -31,6 +31,8 @@ describe Linter::Remark do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.md")
       linter = build_linter
+      owner_config = instance_double("Config::Remark", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -31,6 +31,8 @@ describe Linter::Ruby do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.rb")
+      owner_config = instance_double("Config::Ruby", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/scss_spec.rb
+++ b/spec/models/linter/scss_spec.rb
@@ -23,6 +23,8 @@ describe Linter::Scss do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.scss")
+      owner_config = instance_double("Config::Scss", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/swift_spec.rb
+++ b/spec/models/linter/swift_spec.rb
@@ -23,6 +23,8 @@ describe Linter::Swift do
     it "returns a saved, incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "a.swift")
+      owner_config = instance_double("Swift::Config", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/tslint_spec.rb
+++ b/spec/models/linter/tslint_spec.rb
@@ -23,6 +23,8 @@ describe Linter::Tslint do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.ts")
       linter = build_linter
+      owner_config = instance_double("Config::Tslint", serialize: {})
+      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/missing_owner_spec.rb
+++ b/spec/models/missing_owner_spec.rb
@@ -3,8 +3,8 @@ require "app/models/missing_owner"
 
 RSpec.describe MissingOwner do
   describe "#hound_config" do
-    it "is an empty hash" do
-      expect(MissingOwner.new.hound_config).to eq({})
+    it "is a missing Hound configuration" do
+      expect(MissingOwner.new.hound_config.content).to eq({})
     end
   end
 end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -65,16 +65,11 @@ describe Owner do
 
   describe "#hound_config" do
     it "is the content of the owner's Hound configuration" do
-      config = instance_double(
-        "HoundConfig",
-        content: {
-          "LineLength" => { "Max" => 90 },
-        },
-      )
+      config = instance_double("HoundConfig")
       owner = create(:owner)
       allow(BuildOwnerHoundConfig).to receive(:run).and_return(config)
 
-      expect(owner.hound_config).to eq("LineLength" => { "Max" => 90 })
+      expect(owner.hound_config).to eq config
     end
   end
 end

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -158,7 +158,15 @@ describe BuildRunner do
         )
         invalid_config_file(pull_request, "config/rubocop.yml" => "!")
         github_api = stubbed_github_api
+        style_checker = instance_double("StyleChecker")
         stubbed_commenter
+        allow(StyleChecker).to receive(:new).and_return(style_checker)
+        allow(style_checker).to receive(:review_files).and_raise(
+          Config::ParserError.new(
+            I18n.t(:config_error_status, linter_name: "ruby"),
+            linter_name: "ruby",
+          ),
+        )
 
         build_runner.run
 


### PR DESCRIPTION
Before, we retrieved the configuration from the owner but not doing anything with it. This meant we were not merging the correct configurations. Update the base config to create a config object from the retrieved file.