### PR TITLE
Don't fetch config when there is no owner

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -32,11 +32,7 @@ module Config
     end
 
     def owner_config
-      BuildConfig.for(
-        hound_config: owner.hound_config,
-        name: linter_name,
-        owner: MissingOwner.new,
-      ).content
+      owner.config_content(linter_name)
     end
 
     def parse(content)

--- a/app/models/missing_owner.rb
+++ b/app/models/missing_owner.rb
@@ -1,7 +1,5 @@
 class MissingOwner
-  MissingHoundConfig = Struct.new(:content)
-
-  def hound_config
-    MissingHoundConfig.new({})
+  def config_content(*)
+    {}
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -13,7 +13,11 @@ class Owner < ApplicationRecord
     config_enabled? && config_repo.present?
   end
 
-  def hound_config
-    BuildOwnerHoundConfig.run(self)
+  def config_content(linter_name)
+    BuildConfig.for(
+      hound_config: BuildOwnerHoundConfig.run(self),
+      name: linter_name,
+      owner: MissingOwner.new,
+    ).content
   end
 end

--- a/spec/models/config/base_spec.rb
+++ b/spec/models/config/base_spec.rb
@@ -4,7 +4,6 @@ require "app/models/config/parser_error"
 require "app/models/config_content"
 require "app/models/config_content/remote"
 require "app/models/missing_owner"
-require "app/services/build_config"
 require "faraday"
 require "yaml"
 
@@ -39,17 +38,13 @@ describe Config::Base do
           commit: commit,
           content: content,
         )
-        owner = instance_double("Owner", hound_config: hound_config)
-        owner_config = instance_double(
-          "Config::Base",
-          content: {
-            "Metrics/ClassLength" => {
-              "Max" => 100,
-            },
+        owner_config_content = {
+          "Metrics/ClassLength" => {
+            "Max" => 100,
           },
-        )
+        }
+        owner = instance_double("Owner", config_content: owner_config_content)
         config = build_config(hound_config: hound_config, owner: owner)
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
         allow(ConfigContent).to receive(:new).and_return(config_content)
 
         expect(config.content).to eq(
@@ -70,15 +65,13 @@ describe Config::Base do
             },
           },
         )
-        content = { "test" => {} }
+        hound_config_content = { "test" => {} }
         hound_config = instance_double(
           "HoundConfig",
           commit: commit,
-          content: content,
+          content: hound_config_content,
         )
         config = build_config(hound_config: hound_config)
-        owner_config = instance_double("Config::Base", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
         allow(ConfigContent).to receive(:new).and_return(config_content)
 
         expect(config.content).to eq("LineLength" => { "Max" => 90 })
@@ -95,8 +88,6 @@ describe Config::Base do
           content: content,
         )
         config = build_config(hound_config: hound_config)
-        owner_config = instance_double("Config::Base", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
         allow(ConfigContent).to receive(:new).
           and_raise(ConfigContent::ContentError, "Oops! Something went wrong")
 

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -5,7 +5,6 @@ require "app/models/config/parser"
 require "app/models/config/parser_error"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
 
 describe Config::CoffeeScript do
   describe "#content" do
@@ -17,8 +16,6 @@ describe Config::CoffeeScript do
           EOS
         )
         config = build_config(commit)
-        owner_config = instance_double("Config::CoffeeScript", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         result = config.content
 
@@ -36,8 +33,6 @@ describe Config::CoffeeScript do
           EOS
         )
         config = build_config(commit)
-        owner_config = instance_double("Config::CoffeeScript", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         result = config.content
 
@@ -55,8 +50,6 @@ describe Config::CoffeeScript do
           EOS
         )
         config = build_config(commit)
-        owner_config = instance_double("Config::CoffeeScript", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect { config.content }.to raise_error(Config::ParserError)
       end

--- a/spec/models/config/haml_spec.rb
+++ b/spec/models/config/haml_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "app/models/config/base"
 require "app/models/config/haml"
 require "app/models/config/parser"
@@ -6,7 +5,6 @@ require "app/models/config/parser_error"
 require "app/models/config/serializer"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
 
 describe Config::Haml do
   describe "#content" do
@@ -18,18 +16,13 @@ describe Config::Haml do
               enabled: true
         EOS
         commit = stubbed_commit("config/haml.yml" => raw_config)
-        hound_config = instance_double("HoundConfig")
-        owner = instance_double("Owner", hound_config: hound_config)
-        config = build_config(commit, owner)
-        owner_config = instance_double(
-          "Config::Haml",
-          content: {
-            "linters" => {
-              "ClassAttributeWithStaticValue" => { "enabled" => true },
-            },
+        owner_config = {
+          "linters" => {
+            "ClassAttributeWithStaticValue" => { "enabled" => true },
           },
-        )
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
+        }
+        owner = instance_double("Owner", config_content: owner_config)
+        config = build_config(commit, owner)
 
         expect(config.content).to eq(
           "linters" => {
@@ -50,8 +43,6 @@ describe Config::Haml do
           EOS
         )
         config = build_config(commit)
-        owner_config = instance_double("Config::Haml", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq(
           "linters" => { "AltText" => { "enabled" => true } },
@@ -68,8 +59,6 @@ describe Config::Haml do
             EOS
           )
           config = build_config(commit)
-          owner_config = instance_double("Config::Haml", content: {})
-          allow(BuildConfig).to receive(:for).and_return(owner_config)
 
           expect { config.content }.to raise_error(
             Config::ParserError,
@@ -87,8 +76,6 @@ describe Config::Haml do
             EOS
           )
           config = build_config(commit)
-          owner_config = instance_double("Config::Haml", content: {})
-          allow(BuildConfig).to receive(:for).and_return(owner_config)
 
           expect { config.content }.to raise_error(
             Config::ParserError,

--- a/spec/models/config/python_spec.rb
+++ b/spec/models/config/python_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "app/models/config/base"
 require "app/models/config/parser"
 require "app/models/config/parser_error"
@@ -6,7 +5,6 @@ require "app/models/config/python"
 require "app/models/config/serializer"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
 require "inifile"
 
 describe Config::Python do
@@ -18,18 +16,13 @@ describe Config::Python do
           max-line-length = 160
         EOS
         commit = stubbed_commit("config/python.ini" => raw_config)
-        hound_config = instance_double("HoundConfig")
-        owner = instance_double("Owner", hound_config: hound_config)
-        config = build_config(commit, owner: owner)
-        owner_config = instance_double(
-          "Config::Python",
-          content: {
-            "flake8" => {
-              "max-complexity" => 10,
-            },
+        owner_config_content = {
+          "flake8" => {
+            "max-complexity" => 10,
           },
-        )
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
+        }
+        owner = instance_double("Owner", config_content: owner_config_content)
+        config = build_config(commit, owner: owner)
 
         expect(config.content).to eq(
           "flake8" => {
@@ -48,8 +41,6 @@ describe Config::Python do
         EOS
         commit = stubbed_commit("config/python.ini" => raw_config)
         config = build_config(commit)
-        owner_config = instance_double("Config::Python", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq("flake8" => { "max-line-length" => 160 })
       end
@@ -63,8 +54,6 @@ describe Config::Python do
           content: {},
         )
         config = Config::Python.new(hound_config)
-        owner_config = instance_double("Config::Python", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq({})
       end
@@ -79,8 +68,6 @@ describe Config::Python do
       EOS
       commit = stubbed_commit("config/python.ini" => raw_config)
       config = build_config(commit)
-      owner_config = instance_double("Config::Python", content: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq raw_config
     end

--- a/spec/models/config/remark_spec.rb
+++ b/spec/models/config/remark_spec.rb
@@ -5,7 +5,6 @@ require "app/models/config/parser"
 require "app/models/config/serializer"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
 
 describe Config::Remark do
   describe "#content" do
@@ -17,8 +16,6 @@ describe Config::Remark do
       EOS
       commit = stubbed_commit("config/.remarkrc" => raw_config)
       config = build_config(commit)
-      owner_config = instance_double("Config::Remark", content: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.content).to eq Config::Parser.json(raw_config)
     end
@@ -33,8 +30,6 @@ describe Config::Remark do
       EOS
       commit = stubbed_commit("config/.remarkrc" => raw_config)
       config = build_config(commit)
-      owner_config = instance_double("Config::Remark", content: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq "{\"heading-style\":\"setext\"}"
     end

--- a/spec/models/config/scss_spec.rb
+++ b/spec/models/config/scss_spec.rb
@@ -5,8 +5,6 @@ require "app/models/config/parser"
 require "app/models/config/serializer"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
-require "app/services/build_owner_hound_config"
 
 describe Config::Scss do
   describe "#content" do
@@ -20,21 +18,16 @@ describe Config::Scss do
               space_after_bang: false
         EOS
         commit = stubbed_commit("config/scss.yml" => raw_config)
-        hound_config = instance_double("HoundConfig")
-        owner = instance_double("Owner", hound_config: hound_config)
-        config = build_config(commit, owner)
-        owner_config = instance_double(
-          "Config::Scss",
-          content: {
-            "linters" => {
-              "BemDepth" => {
-                "enabled" => false,
-                "max_elements" => 1,
-              },
+        owner_config = {
+          "linters" => {
+            "BemDepth" => {
+              "enabled" => false,
+              "max_elements" => 1,
             },
           },
-        )
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
+        }
+        owner = instance_double("Owner", config_content: owner_config)
+        config = build_config(commit, owner)
 
         expect(config.content).to eq(
           "linters" => {
@@ -63,8 +56,6 @@ describe Config::Scss do
         EOS
         commit = stubbed_commit("config/scss.yml" => raw_config)
         config = build_config(commit)
-        owner_config = instance_double("Config::Scss", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq(
           "linters" => {
@@ -90,8 +81,6 @@ describe Config::Scss do
       EOS
       commit = stubbed_commit("config/scss.yml" => raw_config)
       config = build_config(commit)
-      owner_config = instance_double("Config::Scss", content: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq <<-EOS.strip_heredoc
         ---

--- a/spec/models/config/swift_spec.rb
+++ b/spec/models/config/swift_spec.rb
@@ -5,7 +5,6 @@ require "app/models/config/parser"
 require "app/models/config/serializer"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
 
 describe Config::Swift do
   describe "#content" do
@@ -16,16 +15,9 @@ describe Config::Swift do
             - colon
         EOS
         commit = stubbed_commit("config/swiftlint.yml" => raw_config)
-        hound_config = instance_double("HoundConfig")
-        owner = instance_double("Owner", hound_config: hound_config)
+        owner_config = { "excluded" => ["Carthage", "Pods"] }
+        owner = instance_double("Owner", config_content: owner_config)
         config = build_config(commit, owner)
-        owner_config = instance_double(
-          "Config::Swift",
-          content: {
-            "excluded" => ["Carthage", "Pods"],
-          },
-        )
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq(
           "disabled_rules" => ["colon"],
@@ -42,8 +34,6 @@ describe Config::Swift do
         EOS
         commit = stubbed_commit("config/swiftlint.yml" => raw_config)
         config = build_config(commit)
-        owner_config = instance_double("Config::Swift", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq("disabled_rules" => ["colon"])
       end
@@ -58,8 +48,6 @@ describe Config::Swift do
       EOS
       commit = stubbed_commit("config/swiftlint.yml" => raw_config)
       config = build_config(commit)
-      owner_config = instance_double("Config::Swift", content: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.serialize).to eq "---\ndisabled_rules:\n- colon\n"
     end

--- a/spec/models/config/tslint_spec.rb
+++ b/spec/models/config/tslint_spec.rb
@@ -7,7 +7,6 @@ require "app/models/config/serializer"
 require "app/models/config/json_with_comments"
 require "app/models/config_content"
 require "app/models/missing_owner"
-require "app/services/build_config"
 
 describe Config::Tslint do
   describe "#content" do
@@ -21,8 +20,6 @@ describe Config::Tslint do
       EOS
       commit = stubbed_commit("config/tslint.json" => raw_config)
       config = build_config(commit)
-      owner_config = instance_double("Config::Tslint", content: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       expect(config.content).to eq("rules" => { "no-constructor-vars" => true })
     end
@@ -37,8 +34,6 @@ describe Config::Tslint do
         EOS
         commit = stubbed_commit("config/tslint.json" => raw_config)
         config = build_config(commit)
-        owner_config = instance_double("Config::Tslint", content: {})
-        allow(BuildConfig).to receive(:for).and_return(owner_config)
 
         expect(config.content).to eq("foo" => 1, "bar" => 2)
       end

--- a/spec/models/linter/coffee_script_spec.rb
+++ b/spec/models/linter/coffee_script_spec.rb
@@ -39,8 +39,6 @@ describe Linter::CoffeeScript do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "foo.coffee.js")
-      owner_config = instance_double("Config::CoffeeScript", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -39,8 +39,6 @@ describe Linter::Eslint do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.js")
       linter = build_linter
-      owner_config = instance_double("Config::Eslint", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/haml_spec.rb
+++ b/spec/models/linter/haml_spec.rb
@@ -23,8 +23,6 @@ describe Linter::Haml do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.haml")
-      owner_config = instance_double("Config::Haml", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -31,8 +31,6 @@ describe Linter::Remark do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.md")
       linter = build_linter
-      owner_config = instance_double("Config::Remark", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -31,8 +31,6 @@ describe Linter::Ruby do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.rb")
-      owner_config = instance_double("Config::Ruby", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/scss_spec.rb
+++ b/spec/models/linter/scss_spec.rb
@@ -23,8 +23,6 @@ describe Linter::Scss do
     it "returns a saved and incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "lib/a.scss")
-      owner_config = instance_double("Config::Scss", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/swift_spec.rb
+++ b/spec/models/linter/swift_spec.rb
@@ -23,8 +23,6 @@ describe Linter::Swift do
     it "returns a saved, incomplete file review" do
       linter = build_linter
       commit_file = build_commit_file(filename: "a.swift")
-      owner_config = instance_double("Swift::Config", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/linter/tslint_spec.rb
+++ b/spec/models/linter/tslint_spec.rb
@@ -23,8 +23,6 @@ describe Linter::Tslint do
     it "returns a saved and incomplete file review" do
       commit_file = build_commit_file(filename: "lib/a.ts")
       linter = build_linter
-      owner_config = instance_double("Config::Tslint", serialize: {})
-      allow(BuildConfig).to receive(:for).and_return(owner_config)
 
       result = linter.file_review(commit_file)
 

--- a/spec/models/missing_owner_spec.rb
+++ b/spec/models/missing_owner_spec.rb
@@ -1,10 +1,9 @@
-require "spec_helper"
 require "app/models/missing_owner"
 
 RSpec.describe MissingOwner do
-  describe "#hound_config" do
+  describe "#config_content" do
     it "is a missing Hound configuration" do
-      expect(MissingOwner.new.hound_config.content).to eq({})
+      expect(MissingOwner.new.config_content("anything")).to eq({})
     end
   end
 end

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -63,13 +63,29 @@ describe Owner do
     end
   end
 
-  describe "#hound_config" do
-    it "is the content of the owner's Hound configuration" do
-      config = instance_double("HoundConfig")
-      owner = create(:owner)
-      allow(BuildOwnerHoundConfig).to receive(:run).and_return(config)
+  describe "#config_content" do
+    it "returns the content for a specific linter" do
+      owner_hound_config = {
+        "ruby" => {
+          "config_file" => ".rubocop.yml",
+        },
+      }
+      owner_ruby_config = {
+        "LineLength" => { "Max" => 90 },
+      }
+      owner_hound_contents = owner_hound_config.to_yaml
+      owner_ruby_contents = owner_ruby_config.to_yaml
+      owner = create(:owner, config_repo: "foo/bar", config_enabled: true)
+      github_api = instance_double("GithubApi", repo: true)
+      allow(github_api).to receive(:file_contents).
+        with("foo/bar", ".hound.yml", "HEAD").
+        and_return(double(content: Base64.encode64(owner_hound_contents)))
+      allow(github_api).to receive(:file_contents).
+        with("foo/bar", ".rubocop.yml", "HEAD").
+        and_return(double(content: Base64.encode64(owner_ruby_contents)))
+      allow(GithubApi).to receive(:new).and_return(github_api)
 
-      expect(owner.hound_config).to eq config
+      expect(owner.config_content("ruby")).to eq(owner_ruby_config)
     end
   end
 end


### PR DESCRIPTION
There was a infinite-loop situation, where we would attempt to keep
calling `content` (and subsequently `owner_config`) for each owner.
Since we moved to `MissingOwner`, we'd pass that in when there was no
owner, and thus loop infinitely passing around `MissingOwner` instance.

This prevents the above situation and returns empty config for
`MissingOwner`.