### PR TITLE
Webpack 2.x production build fixes (II)

### DIFF
--- a/lib/tasks/webpack.rake
+++ b/lib/tasks/webpack.rake
@@ -1,5 +1,5 @@
 namespace :webpack do
-  desc "Build the asset bundle with Webpack (production)"
+  desc "Build the asset bundle with Webpack"
   task :build do
     sh "npm run build"
   end

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build:watch": "node_modules/webpack/bin/webpack.js -w --config webpack.config.js",
     "test": "jest app/assets/javascripts/components/__tests__/*-test.jsx",
     "test:watch": "jest --watch app/assets/javascripts/components/__tests__/*-test.jsx",
-    "test:coverage": "jest --coverage app/assets/javascripts/components/__tests__/*-test.jsx",
-    "heroku-postbuild": "npm run build"
+    "test:coverage": "jest --coverage app/assets/javascripts/components/__tests__/*-test.jsx"
   },
   "engines": {
     "node": "7.4",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,17 +36,21 @@ if (isProd) {
         if_return: true,
         join_vars: true,
       },
+      // Mangling would reduce the size of the bundle, but it made the deploys
+      // crash on Heroku. The reason is yet unknown.
+      // So, in lieu of that - let's disable it.
+      mangle: false,
       output: {
         comments: false
       },
-      sourceMap: false,
+      sourceMap: false
     })
   );
 }
 
 module.exports = {
   context: __dirname,
-  devtool: isProd ? 'hidden-source-map' : 'cheap-module-eval-source-map',
+  devtool: isProd ? false : 'inline-source-map',
   entry: {
     vendor: [
       'babel-polyfill',
@@ -57,6 +61,7 @@ module.exports = {
       'react',
       'es5-shim/es5-shim',
       'es5-shim/es5-sham',
+      'lodash'
     ],
     app: [
       './app/assets/javascripts/components.jsx',


### PR DESCRIPTION
Hoping not creating source maps in production will help the bundle behave normally (also, only build said bundle once in Heroku).