### PR TITLE
Consolidate the external API of all service objects

### DIFF
--- a/app/controllers/builds_controller.rb
+++ b/app/controllers/builds_controller.rb
@@ -39,6 +39,6 @@ class BuildsController < ApplicationController
   end
 
   def recent_builds_by_repo
-    RecentBuildsByRepoQuery.run(user: current_user)
+    RecentBuildsByRepoQuery.call(user: current_user)
   end
 end

--- a/app/controllers/repos_controller.rb
+++ b/app/controllers/repos_controller.rb
@@ -8,7 +8,7 @@ class ReposController < ApplicationController
           current_user.repos.clear
         end
 
-        repos = ReposWithMembershipOrSubscriptionQuery.new(current_user).run
+        repos = ReposWithMembershipOrSubscriptionQuery.call(current_user)
 
         render json: repos
       end

--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -3,9 +3,8 @@ module Buildable
     payload = Payload.new(payload_data)
 
     unless blacklisted?(payload)
-      UpdateRepoStatus.new(payload).run
-      build_runner = BuildRunner.new(payload)
-      build_runner.run
+      UpdateRepoStatus.call(payload)
+      BuildRunner.call(payload)
     end
   end
 

--- a/app/jobs/completed_file_review_job.rb
+++ b/app/jobs/completed_file_review_job.rb
@@ -9,7 +9,7 @@ class CompletedFileReviewJob
   # violations
   #   [{ line: 123, message: "WAT" }]
   def self.perform(attributes)
-    CompleteFileReview.run(attributes)
+    CompleteFileReview.call(attributes)
   rescue ActiveRecord::RecordNotFound
     Resque.enqueue_in(30, self, attributes)
   rescue Resque::TermException

--- a/app/jobs/report_invalid_config_job.rb
+++ b/app/jobs/report_invalid_config_job.rb
@@ -9,7 +9,7 @@ class ReportInvalidConfigJob
   # The following parameters are optional:
   # - message
   def self.perform(attributes)
-    ReportInvalidConfig.run(
+    ReportInvalidConfig.call(
       pull_request_number: attributes.fetch("pull_request_number"),
       commit_sha: attributes.fetch("commit_sha"),
       linter_name: attributes.fetch("linter_name"),

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -49,15 +49,15 @@ class HoundConfig
   end
 
   def resolved_aliases_config
-    ResolveConfigAliases.run(normalized_config)
+    ResolveConfigAliases.call(normalized_config)
   end
 
   def normalized_config
-    NormalizeConfig.run(parsed_config)
+    NormalizeConfig.call(parsed_config)
   end
 
   def resolved_conflicts_config
-    ResolveConfigConflicts.run(resolved_aliases_config)
+    ResolveConfigConflicts.call(resolved_aliases_config)
   end
 
   def parsed_config

--- a/app/models/jshint_config_builder.rb
+++ b/app/models/jshint_config_builder.rb
@@ -1,11 +1,8 @@
 class JshintConfigBuilder
+  static_facade :call
   pattr_initialize :hound_config
 
-  def self.for(hound_config)
-    new(hound_config).config
-  end
-
-  def config
+  def call
     Config::Jshint.new(load_content)
   end
 

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -68,7 +68,7 @@ module Linter
     end
 
     def config
-      @_config ||= BuildConfig.for(
+      @_config ||= BuildConfig.call(
         hound_config: hound_config,
         name: name,
         owner: owner,

--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -14,15 +14,15 @@ module Linter
     end
 
     def local_config
-      @_config ||= JshintConfigBuilder.for(hound_config)
+      @_config ||= JshintConfigBuilder.call(hound_config)
     end
 
     def owner_config
-      @_owner_config ||= JshintConfigBuilder.for(owner_hound_config)
+      @_owner_config ||= JshintConfigBuilder.call(owner_hound_config)
     end
 
     def owner_hound_config
-      BuildOwnerHoundConfig.run(build.repo.owner)
+      BuildOwnerHoundConfig.call(build.repo.owner)
     end
 
     def jsignore

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -14,8 +14,8 @@ class Owner < ApplicationRecord
   end
 
   def config_content(linter_name)
-    BuildConfig.for(
-      hound_config: BuildOwnerHoundConfig.run(self),
+    BuildConfig.call(
+      hound_config: BuildOwnerHoundConfig.call(self),
       name: linter_name,
       owner: MissingOwner.new,
     ).content

--- a/app/queries/recent_builds_by_repo_query.rb
+++ b/app/queries/recent_builds_by_repo_query.rb
@@ -1,15 +1,13 @@
 class RecentBuildsByRepoQuery
   NUMBER_OF_BUILDS = 20
 
-  def self.run(*args)
-    new(*args).run
-  end
+  static_facade :call
 
   def initialize(user:)
     @user = user
   end
 
-  def run
+  def call
     Build.find_by_sql([<<-SQL, user_id: @user.id, limit: NUMBER_OF_BUILDS])
       WITH user_builds AS (
         SELECT

--- a/app/queries/repos_with_membership_or_subscription_query.rb
+++ b/app/queries/repos_with_membership_or_subscription_query.rb
@@ -1,9 +1,11 @@
 class ReposWithMembershipOrSubscriptionQuery
+  static_facade :call
+
   def initialize(user)
     @user = user
   end
 
-  def run
+  def call
     @user.subscribed_repos.includes(:subscription) |
       @user.repos_by_activation_ability.includes(:subscription)
   end

--- a/app/services/build_config.rb
+++ b/app/services/build_config.rb
@@ -1,7 +1,5 @@
 class BuildConfig
-  def self.for(hound_config:, name:, owner:)
-    new(hound_config: hound_config, name: name, owner: owner).config
-  end
+  static_facade :call
 
   def initialize(hound_config:, name:, owner:)
     @hound_config = hound_config
@@ -9,7 +7,7 @@ class BuildConfig
     @owner = owner
   end
 
-  def config
+  def call
     config_class.new(hound_config, owner: owner)
   end
 

--- a/app/services/build_owner_hound_config.rb
+++ b/app/services/build_owner_hound_config.rb
@@ -2,15 +2,13 @@
 class BuildOwnerHoundConfig
   LATEST_SHA = "HEAD"
 
-  def self.run(*args)
-    new(*args).run
-  end
+  static_facade :call
 
   def initialize(owner)
     @owner = owner
   end
 
-  def run
+  def call
     if owner.has_config_repo? && config_repo_reachable?
       commit = Commit.new(config_repo.name, LATEST_SHA, github)
       HoundConfig.new(commit)

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -1,7 +1,8 @@
 class BuildRunner
+  static_facade :call
   pattr_initialize :payload
 
-  def run
+  def call
     if repo && relevant_pull_request?
       review_pull_request
     end
@@ -88,7 +89,7 @@ class BuildRunner
   end
 
   def report_config_file_as_invalid(exception)
-    ReportInvalidConfig.run(
+    ReportInvalidConfig.call(
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.head_sha,
       linter_name: exception.linter_name,

--- a/app/services/complete_build.rb
+++ b/app/services/complete_build.rb
@@ -1,7 +1,5 @@
 class CompleteBuild
-  def self.run(pull_request:, build:, token:)
-    new(pull_request: pull_request, build: build, token: token).run
-  end
+  static_facade :call
 
   def initialize(pull_request:, build:, token:)
     @build = build
@@ -10,7 +8,7 @@ class CompleteBuild
     @commenter = Commenter.new(pull_request)
   end
 
-  def run
+  def call
     if build.completed?
       commenter.comment_on_violations(priority_violations)
       set_commit_status

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -1,16 +1,14 @@
 class CompleteFileReview
-  def self.run(attributes)
-    new(attributes).run
-  end
+  static_facade :call
 
   def initialize(attributes)
     @attributes = attributes
   end
 
-  def run
+  def call
     create_violations!
 
-    CompleteBuild.run(
+    CompleteBuild.call(
       pull_request: pull_request,
       build: build,
       token: build.user_token,

--- a/app/services/normalize_config.rb
+++ b/app/services/normalize_config.rb
@@ -1,17 +1,15 @@
 class NormalizeConfig
-  def self.run(config)
-    new(config).run
-  end
+  static_facade :call
 
   def initialize(config)
     @config = config
   end
 
-  def run
+  def call
     @config.reduce({}) do |normalized_config, (key, value)|
       normalized_key = normalize_key(key)
       if value.is_a? Hash
-        normalized_config[normalized_key] = NormalizeConfig.run(value)
+        normalized_config[normalized_key] = NormalizeConfig.call(value)
       else
         normalized_config[normalized_key] = value
       end

--- a/app/services/rebuild_pull_request.rb
+++ b/app/services/rebuild_pull_request.rb
@@ -1,7 +1,5 @@
 class RebuildPullRequest
-  def self.call(*args)
-    new(*args).call
-  end
+  static_facade :call
 
   def initialize(repo:, pull_request_number:)
     @repo = repo

--- a/app/services/report_invalid_config.rb
+++ b/app/services/report_invalid_config.rb
@@ -1,7 +1,5 @@
 class ReportInvalidConfig
-  def self.run(**args)
-    new(**args).run
-  end
+  static_facade :call
 
   def initialize(pull_request_number:, commit_sha:, linter_name:, message: "")
     @pull_request_number = pull_request_number
@@ -10,7 +8,7 @@ class ReportInvalidConfig
     @message = message
   end
 
-  def run
+  def call
     commit_status.set_config_error(message)
   end
 

--- a/app/services/resolve_config_aliases.rb
+++ b/app/services/resolve_config_aliases.rb
@@ -5,15 +5,13 @@ class ResolveConfigAliases
     "coffeescript" => "coffee_script",
   }.freeze
 
-  def self.run(config)
-    new(config).run
-  end
+  static_facade :call
 
   def initialize(config)
     @config = config
   end
 
-  def run
+  def call
     @config.reduce({}) do |resolved_config, (key, value)|
       if ALIASES.keys.include? key
         resolved_config[ALIASES[key]] = value

--- a/app/services/resolve_config_conflicts.rb
+++ b/app/services/resolve_config_conflicts.rb
@@ -1,15 +1,13 @@
 class ResolveConfigConflicts
   CONFLICTS = { "eslint" => "jshint" }.freeze
 
-  def self.run(config)
-    new(config).run
-  end
+  static_facade :call
 
   def initialize(config)
     @config = config
   end
 
-  def run
+  def call
     @config.reduce({}) do |resolved_config, (linter, options)|
       if CONFLICTS.has_key?(linter) && options["enabled"] == true
         resolved_config[CONFLICTS[linter]] = { "enabled" => false }

--- a/app/services/update_repo_status.rb
+++ b/app/services/update_repo_status.rb
@@ -1,7 +1,8 @@
 class UpdateRepoStatus
+  static_facade :call
   pattr_initialize :payload
 
-  def run
+  def call
     if repo
       repo.update(repo_attributes)
     end

--- a/spec/features/job_failures_spec.rb
+++ b/spec/features/job_failures_spec.rb
@@ -8,7 +8,7 @@ feature "Job failures" do
     Resque::Failure.backend = Resque::Failure::Redis
     cleanup_test_failures
 
-    example.run
+    example.call
 
     cleanup_test_failures
     Resque::Failure.backend = previous_backend

--- a/spec/jobs/buildable_spec.rb
+++ b/spec/jobs/buildable_spec.rb
@@ -7,27 +7,23 @@ describe Buildable do
 
   describe "#perform" do
     it 'runs build runner' do
-      build_runner = double(:build_runner, run: nil)
       payload = stub_payload(payload_data)
-      allow(BuildRunner).to receive(:new).and_return(build_runner)
+      allow(BuildRunner).to receive(:call)
 
       BuildableTestJob.perform_now(payload_data)
 
       expect(Payload).to have_received(:new).with(payload_data)
-      expect(BuildRunner).to have_received(:new).with(payload)
-      expect(build_runner).to have_received(:run)
+      expect(BuildRunner).to have_received(:call).with(payload)
     end
 
     it "runs repo updater" do
-      repo_updater = double("RepoUpdater", run: nil)
       payload = stub_payload(payload_data)
-      allow(UpdateRepoStatus).to receive(:new).and_return(repo_updater)
+      allow(UpdateRepoStatus).to receive(:call)
 
       BuildableTestJob.perform_now(payload_data)
 
       expect(Payload).to have_received(:new).with(payload_data)
-      expect(UpdateRepoStatus).to have_received(:new).with(payload)
-      expect(repo_updater).to have_received(:run)
+      expect(UpdateRepoStatus).to have_received(:call).with(payload)
     end
 
     context "when the pull request has been blacklisted" do

--- a/spec/jobs/completed_file_review_job_spec.rb
+++ b/spec/jobs/completed_file_review_job_spec.rb
@@ -3,16 +3,16 @@ require "rails_helper"
 describe CompletedFileReviewJob do
   describe ".perform" do
     it "calls `CompleteFileReview`" do
-      allow(CompleteFileReview).to receive(:run)
+      allow(CompleteFileReview).to receive(:call)
 
       CompletedFileReviewJob.perform(attributes)
 
-      expect(CompleteFileReview).to have_received(:run).with(attributes)
+      expect(CompleteFileReview).to have_received(:call).with(attributes)
     end
 
     context "when build doesn't exist" do
       it "enqueues job with a 30 second delay" do
-        allow(CompleteFileReview).to receive(:run).
+        allow(CompleteFileReview).to receive(:call).
           and_raise(ActiveRecord::RecordNotFound)
         allow(Resque).to receive(:enqueue_in)
 
@@ -25,7 +25,7 @@ describe CompletedFileReviewJob do
 
     context "when Resque process is killed" do
       it "enqueues job" do
-        allow(CompleteFileReview).to receive(:run).
+        allow(CompleteFileReview).to receive(:call).
           and_raise(Resque::TermException.new(1))
         allow(Resque).to receive(:enqueue)
 

--- a/spec/jobs/report_invalid_config_job_spec.rb
+++ b/spec/jobs/report_invalid_config_job_spec.rb
@@ -9,11 +9,11 @@ describe ReportInvalidConfigJob do
         "linter_name" => "ruby",
         "message" => "Could not parse the given config file",
       }
-      allow(ReportInvalidConfig).to receive(:run)
+      allow(ReportInvalidConfig).to receive(:call)
 
       ReportInvalidConfigJob.perform(attributes)
 
-      expect(ReportInvalidConfig).to have_received(:run).with(
+      expect(ReportInvalidConfig).to have_received(:call).with(
         pull_request_number: attributes["pull_request_number"],
         commit_sha: attributes["commit_sha"],
         linter_name: attributes["linter_name"],

--- a/spec/models/jshint_config_builder_spec.rb
+++ b/spec/models/jshint_config_builder_spec.rb
@@ -5,7 +5,7 @@ require "app/models/config/jshint"
 require "app/models/jshint_config_builder"
 
 describe JshintConfigBuilder do
-  describe ".for" do
+  describe ".call" do
     context "when there is a jshint configuration" do
       it "takes a hound config and returns a jshint config with content" do
         commit = stubbed_commit(".jshintrc" => <<~CON)
@@ -21,7 +21,7 @@ describe JshintConfigBuilder do
           content: { "jshint" => { "config_file" => ".jshintrc" } },
         )
 
-        config = JshintConfigBuilder.for(hound_config)
+        config = JshintConfigBuilder.call(hound_config)
 
         expect(config).to be_a(Config::Jshint)
         expect(config.content).to eq(
@@ -39,7 +39,7 @@ describe JshintConfigBuilder do
           content: {},
         )
 
-        config = JshintConfigBuilder.for(hound_config)
+        config = JshintConfigBuilder.call(hound_config)
 
         expect(config).to be_a(Config::Jshint)
         expect(config.content).to eq({})

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -144,6 +144,6 @@ describe Linter::Jshint do
   end
 
   def stub_owner_hound_config(config)
-    allow(BuildOwnerHoundConfig).to receive(:run).and_return(config)
+    allow(BuildOwnerHoundConfig).to receive(:call).and_return(config)
   end
 end

--- a/spec/queries/recent_builds_by_repo_query_spec.rb
+++ b/spec/queries/recent_builds_by_repo_query_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe RecentBuildsByRepoQuery do
-  describe ".run" do
+  describe ".call" do
     it "returns the most recent build for each repo" do
       user = create(:user)
       repo1 = create(:membership, user: user).repo
@@ -21,7 +21,7 @@ describe RecentBuildsByRepoQuery do
         created_at: 1.hour.ago,
       )
 
-      builds = RecentBuildsByRepoQuery.run(user: user)
+      builds = RecentBuildsByRepoQuery.call(user: user)
 
       expect(builds).to match_array [recent_build1, recent_build2]
     end
@@ -33,7 +33,7 @@ describe RecentBuildsByRepoQuery do
       build1 = create(:build, pull_request_number: 1, repo: repo1)
       build2 = create(:build, pull_request_number: 2, repo: repo2)
 
-      builds = RecentBuildsByRepoQuery.run(user: user)
+      builds = RecentBuildsByRepoQuery.call(user: user)
 
       expect(builds).to eq [build2, build1]
     end
@@ -46,7 +46,7 @@ describe RecentBuildsByRepoQuery do
       build2 = create(:build, repo: repo2)
       stub_const("RecentBuildsByRepoQuery::NUMBER_OF_BUILDS", 1)
 
-      builds = RecentBuildsByRepoQuery.run(user: user)
+      builds = RecentBuildsByRepoQuery.call(user: user)
 
       expect(builds).to eq [build2]
     end

--- a/spec/queries/repos_with_membership_or_subscription_query_spec.rb
+++ b/spec/queries/repos_with_membership_or_subscription_query_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 describe ReposWithMembershipOrSubscriptionQuery do
-  describe "#run" do
+  describe "#call" do
     context "when user is not a member of a repo but has a subscription" do
       it "includes the orphaned repo" do
         subscribed_repo = create(:repo, private: true)
         user = create(:user)
         create(:subscription, user: user, repo: subscribed_repo)
 
-        repos = ReposWithMembershipOrSubscriptionQuery.new(user).run
+        repos = ReposWithMembershipOrSubscriptionQuery.new(user).call
 
         expect(repos).to include(subscribed_repo)
       end
@@ -20,7 +20,7 @@ describe ReposWithMembershipOrSubscriptionQuery do
       user.repos << subscribed_repo
       create(:subscription, user: user, repo: subscribed_repo)
 
-      repos = ReposWithMembershipOrSubscriptionQuery.new(user).run
+      repos = ReposWithMembershipOrSubscriptionQuery.new(user).call
 
       expect(repos).to eq [subscribed_repo]
     end

--- a/spec/requests/builds_spec.rb
+++ b/spec/requests/builds_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "POST /builds" do
 
   def stub_review_job(klass, violations:)
     allow(klass).to receive(:perform) do |attributes|
-      CompleteFileReview.run(
+      CompleteFileReview.call(
         "commit_sha" => attributes.fetch("commit_sha"),
         "filename" => attributes.fetch("filename"),
         "linter_name" => attributes.fetch("linter_name"),

--- a/spec/services/build_config_spec.rb
+++ b/spec/services/build_config_spec.rb
@@ -6,10 +6,10 @@ require "app/models/missing_owner"
 require "app/services/build_config"
 
 describe BuildConfig do
-  describe ".for" do
+  describe ".call" do
     context "when there is matching config class for the given name" do
       it "returns the matching config" do
-        config = BuildConfig.for(
+        config = BuildConfig.call(
           hound_config: double,
           name: "ruby",
           owner: instance_double("Owner"),
@@ -21,7 +21,7 @@ describe BuildConfig do
 
     context "when there is not matching config class for the given name" do
       it "returns the unsupported config" do
-        config = BuildConfig.for(
+        config = BuildConfig.call(
           hound_config: double,
           name: "non-existent-config",
           owner: instance_double("Owner"),

--- a/spec/services/build_owner_hound_config_spec.rb
+++ b/spec/services/build_owner_hound_config_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe BuildOwnerHoundConfig do
-  describe "#run" do
+  describe "#call" do
     context "when the owner has a configuration set" do
       it "returns the owner's config merged with the default HoundConfig" do
         github_api = instance_double("GithubApi", repo: "")
@@ -19,7 +19,7 @@ describe BuildOwnerHoundConfig do
         allow(Commit).to receive(:new).and_return(commit)
         allow(GithubApi).to receive(:new).and_return(github_api)
 
-        owner_config = BuildOwnerHoundConfig.run(owner)
+        owner_config = BuildOwnerHoundConfig.call(owner)
 
         expect(owner_config.content).
           to eq(default_hound_config.merge("remark" => { "enabled" => true }))
@@ -34,7 +34,7 @@ describe BuildOwnerHoundConfig do
           config_repo: "thoughtbot/guides",
         )
 
-        owner_config = BuildOwnerHoundConfig.run(owner)
+        owner_config = BuildOwnerHoundConfig.call(owner)
 
         expect(owner_config.content).to eq(default_hound_config)
       end
@@ -51,7 +51,7 @@ describe BuildOwnerHoundConfig do
         allow(GithubApi).to receive(:new).and_return(github_api)
         allow(github_api).to receive(:repo).and_raise(Octokit::NotFound)
 
-        owner_config = BuildOwnerHoundConfig.run(owner)
+        owner_config = BuildOwnerHoundConfig.call(owner)
 
         expect(owner_config.content).to eq(default_hound_config)
       end
@@ -69,7 +69,7 @@ describe BuildOwnerHoundConfig do
         allow(github_api).to receive(:repo).
           and_raise(Octokit::InvalidRepository)
 
-        owner_config = BuildOwnerHoundConfig.run(owner)
+        owner_config = BuildOwnerHoundConfig.call(owner)
 
         expect(owner_config.content).to eq(default_hound_config)
       end

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe CompleteBuild do
-  describe ".run" do
+  describe ".call" do
     context "when build has violations" do
       context "when the build is complete" do
         it "comments a maximum number of times" do
@@ -153,7 +153,7 @@ describe CompleteBuild do
     def run_service(build)
       head_commit = double("Commit", file_content: "")
       pull_request = double("PullRequest", head_commit: head_commit)
-      CompleteBuild.run(
+      CompleteBuild.call(
         pull_request: pull_request,
         build: build,
         token: "abc123",

--- a/spec/services/complete_file_review_spec.rb
+++ b/spec/services/complete_file_review_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
 describe CompleteFileReview do
-  describe ".run" do
+  describe ".call" do
     it "completes FileReview with violations" do
       file_review = create_file_review
       stub_build_report_run
       stub_pull_request
       stub_payload
 
-      CompleteFileReview.run(attributes)
+      CompleteFileReview.call(attributes)
 
       file_review.reload
       expect(file_review).to be_completed
@@ -23,9 +23,9 @@ describe CompleteFileReview do
       pull_request = stub_pull_request
       payload = stub_payload
 
-      CompleteFileReview.run(attributes)
+      CompleteFileReview.call(attributes)
 
-      expect(CompleteBuild).to have_received(:run).with(
+      expect(CompleteBuild).to have_received(:call).with(
         pull_request: pull_request,
         build: build,
         token: Hound::GITHUB_TOKEN,
@@ -52,9 +52,9 @@ describe CompleteFileReview do
         pull_request = stub_pull_request
         stub_payload
 
-        CompleteFileReview.run(attributes)
+        CompleteFileReview.call(attributes)
 
-        expect(CompleteBuild).to have_received(:run).with(
+        expect(CompleteBuild).to have_received(:call).with(
           pull_request: pull_request,
           build: correct_build,
           token: Hound::GITHUB_TOKEN,
@@ -83,7 +83,7 @@ describe CompleteFileReview do
   end
 
   def stub_build_report_run
-    allow(CompleteBuild).to receive(:run)
+    allow(CompleteBuild).to receive(:call)
   end
 
   def stub_pull_request

--- a/spec/services/normalize_config_spec.rb
+++ b/spec/services/normalize_config_spec.rb
@@ -1,12 +1,12 @@
 require "app/services/normalize_config"
 
 describe NormalizeConfig do
-  describe "#run" do
+  describe "#call" do
     context "given a hash with keys containing capital letters" do
       it "downcases the keys" do
         config = { "Ruby" => { "Enabled" => true } }
 
-        expect(NormalizeConfig.run(config)).to eq(
+        expect(NormalizeConfig.call(config)).to eq(
           "ruby" => { "enabled" => true },
         )
       end

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe ReportInvalidConfig do
-  describe ".run" do
+  describe ".call" do
     context "given a custom message" do
       it "reports the file as an invalid config file to Github" do
         commit_status = stubbed_commit_status(:set_config_error)
@@ -11,7 +11,7 @@ describe ReportInvalidConfig do
         linter_name = "ruby"
         message = "Invalid ruby file, woff"
 
-        ReportInvalidConfig.run(
+        ReportInvalidConfig.call(
           pull_request_number: pull_request_number,
           commit_sha: commit_sha,
           linter_name: linter_name,
@@ -34,7 +34,7 @@ describe ReportInvalidConfig do
         commit_sha = "abc123"
         linter_name = "ruby"
 
-        ReportInvalidConfig.run(
+        ReportInvalidConfig.call(
           pull_request_number: pull_request_number,
           commit_sha: commit_sha,
           linter_name: linter_name,

--- a/spec/services/resolve_config_aliases_spec.rb
+++ b/spec/services/resolve_config_aliases_spec.rb
@@ -1,7 +1,7 @@
 require "app/services/resolve_config_aliases"
 
 describe ResolveConfigAliases do
-  describe "#run" do
+  describe "#call" do
     context "when the config contains aliases" do
       it "renames them to the appropriate linter" do
         config = {
@@ -9,7 +9,7 @@ describe ResolveConfigAliases do
           "ruby" => { "enabled" => false },
         }
 
-        expect(ResolveConfigAliases.run(config).keys).
+        expect(ResolveConfigAliases.call(config).keys).
           to match_array(["jshint", "ruby"])
       end
     end

--- a/spec/services/resolve_config_conflicts_spec.rb
+++ b/spec/services/resolve_config_conflicts_spec.rb
@@ -1,12 +1,12 @@
 require "app/services/resolve_config_conflicts"
 
 describe ResolveConfigConflicts do
-  describe "#run" do
+  describe "#call" do
     context "given a config with conflicting linters" do
       it "disables the first conflicted linter found" do
         config = { "eslint" => { "enabled" => true } }
 
-        resolved_config = ResolveConfigConflicts.run(config)
+        resolved_config = ResolveConfigConflicts.call(config)
 
         expect(resolved_config["jshint"]).to eq("enabled" => false)
         expect(resolved_config["eslint"]).to eq("enabled" => true)

--- a/spec/services/update_repo_status_spec.rb
+++ b/spec/services/update_repo_status_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe UpdateRepoStatus do
-  describe "#run" do
+  describe "#call" do
     it "updates the repo name" do
       expected_repo_name = "foo/bar"
       repo = create(:repo, :active)
@@ -12,7 +12,7 @@ describe UpdateRepoStatus do
         private_repo?: repo.private,
       )
 
-      UpdateRepoStatus.new(payload).run
+      UpdateRepoStatus.new(payload).call
 
       repo.reload
       expect(repo.name).to eq(expected_repo_name)
@@ -28,7 +28,7 @@ describe UpdateRepoStatus do
         private_repo?: expected_status,
       )
 
-      UpdateRepoStatus.new(payload).run
+      UpdateRepoStatus.new(payload).call
 
       repo.reload
       expect(repo.private).to eq(expected_status)

--- a/spec/support/background_jobs.rb
+++ b/spec/support/background_jobs.rb
@@ -1,19 +1,19 @@
 RSpec.configure do |config|
   config.around(:each, type: :feature) do |example|
     run_background_jobs_immediately do
-      example.run
+      example.call
     end
   end
 
   config.around(:each, type: :request) do |example|
     run_background_jobs_immediately do
-      example.run
+      example.call
     end
   end
 
   config.around(:each, type: :job) do |example|
     run_background_jobs_immediately do
-      example.run
+      example.call
     end
   end
 


### PR DESCRIPTION
- Don't duplicate the methods signature in static facades

  Since the method signature, including its parameters are already
  present in the initializer. We can safely remove it from the static
  facade without hurting readability.

- Rename `#run` to `#call`.
- Rename `.run` to `.call`.
- Add static facades where they are missing.