### PR TITLE
Run react tests in `rake`'s default task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Houndapp::Application.load_tasks
 task(:default).clear
 
 # Run webpack:build before :spec
-task default: ["webpack:build", :spec]
+task default: ["webpack:build", "spec", "js:spec", "bundler:audit"]
 
 task "assets:precompile" => "webpack:build"
 
@@ -18,5 +18,3 @@ if defined? RSpec
     t.verbose = false
   end
 end
-
-task default: "bundler:audit"

--- a/circle.yml
+++ b/circle.yml
@@ -4,4 +4,4 @@ machine:
 
 test:
   override:
-    - bundle exec rake && npm run test
+    - bundle exec rake

--- a/lib/tasks/js.rake
+++ b/lib/tasks/js.rake
@@ -1,0 +1,5 @@
+namespace :js do
+  task spec: "webpack:build" do
+    sh "npm run test"
+  end
+end


### PR DESCRIPTION
- Add `js:spec` task to wrap `npm run build && npm run test`
- Add `builder:audit` task to the `default` task from the get go.