### PR TITLE
Fix coffeelint json config parsing

### DIFF
--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -3,5 +3,13 @@ module Config
     def serialize(data = content)
       Serializer.json(data)
     end
+
+    private
+
+    def parse(file_content)
+      json_with_comments = JsonWithComments.new(file_content)
+      content_without_comments = json_with_comments.without_comments
+      super(content_without_comments)
+    end
   end
 end

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -4,6 +4,7 @@ require "app/models/config/coffee_script"
 require "app/models/config/parser"
 require "app/models/config/parser_error"
 require "app/models/config_content"
+require "app/models/config/json_with_comments"
 require "app/models/missing_owner"
 
 describe Config::CoffeeScript do
@@ -27,6 +28,26 @@ describe Config::CoffeeScript do
       it "returns the content from GitHub as a hash" do
         raw_config = <<~EOS
           { "arrow_spacing": { "level": "error" } }
+        EOS
+        config = build_config(raw_config)
+
+        result = config.content
+
+        expect(result).to eq(
+          "arrow_spacing" => { "level" => "error" },
+        )
+      end
+    end
+
+    context "config with comments and trailing commas" do
+      it "returns the content from Github as a hash" do
+        raw_config = <<~EOS
+          {
+            "arrow_spacing": {
+                // this should be stripped out
+                "level": "error",
+            }
+          }
         EOS
         config = build_config(raw_config)
 


### PR DESCRIPTION
https://github.com/houndci/hound/commit/4632b20bf5c4fb00723ad4002547c445ddf5c7ab#diff-31c9aca594d7a0025b941e49336e8cc5R39 moved all parsing to be yaml - but coffeelint config is stored as json