### PR TITLE
Update config docs

### DIFF
--- a/app/assets/stylesheets/components/_code.scss
+++ b/app/assets/stylesheets/components/_code.scss
@@ -17,5 +17,5 @@
 
 .code-inline {
   border-radius: 2px;
-  padding: 0.3em 0.5em 0.2em;
+  padding: 0.1em;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,4 +10,8 @@ module ApplicationHelper
       where(memberships: { user_id: current_user.id }).
       empty?
   end
+
+  def new_window_options(options = {})
+    options.merge(target: "_blank", rel: "noopener noreferrer")
+  end
 end

--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -3,10 +3,6 @@ module ConfigurationHelper
     config_url("bbatsov/rubocop", "config/enabled.yml")
   end
 
-  def jshint_config_url
-    config_url("houndci/linters", "config/jshintrc")
-  end
-
   def eslint_config_url
     config_url("houndci/linters", "config/eslintrc")
   end

--- a/app/views/application/_footer.haml
+++ b/app/views/application/_footer.haml
@@ -16,8 +16,8 @@
       Hound is maintained by #{link_to 'thoughtbot', 'http://thoughtbot.com'}.
       Questions? Try the
       #{link_to "FAQ", "https://intercom.help/hound/frequently-asked-questions"}
-      or
-      Tweet #{link_to "@houndci", "https://twitter.com/houndci", target: "_blank"}.
+      or Tweet
+      #{link_to "@houndci", "https://twitter.com/houndci", new_window_options}.
 
     %p
       Hound is Copyright &copy; #{Date.today.year} thoughtbot. It is open source

--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -36,7 +36,7 @@
         %li
           = link_to "Pricing", root_path(anchor: "pricing"), class: "pricing"
         %li
-          - options = { target: "_blank", class: "tweet-us" }
+          - options = new_window_options(class: "tweet-us")
           = link_to "https://twitter.com/houndci", options do
             %span @houndci
         %li.auth-container

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -139,7 +139,7 @@
       %p
         Hound's default style guides build upon accepted industry standards and
         are the result of years of utilization in software projects at
-        = link_to "thoughtbot.", "http://thoughtbot.com/", target: "blank"
+        = link_to "thoughtbot.", "http://thoughtbot.com/", new_window_options
         Have your own style guide or need to modify the default?
         Hound provides the ability to customize your guides to best suit your
         team's needs.
@@ -176,5 +176,5 @@
 
       .actions
         = link_to "https://github.com/houndci/hound/blob/master/doc/SECURITY.md",
-          target: "_blank", class: "security-policy" do
+          new_window_options(class: "security-policy") do
           %span Read our security policy

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -161,14 +161,14 @@
       %p
         Hound uses
         = link_to "JSHint", "https://github.com/jshint/jshint", target: :blank
-        with this
-        = link_to "config", jshint_config_url, target: :blank
-        by default.
+        to review JavaScript code by default.
 
       %p
-        To change the way JSHint is configured, copy the
-        = link_to "default config file", jshint_config_url, target: :blank
-        into your project, make changes and reference the file in your
+        To change the way JSHint is configured, add
+        %em.code-inline .jshintrc
+        file to your project,
+        specify your desired configuration
+        and reference the file in your
         %em.code-inline .hound.yml
 
       %p
@@ -178,14 +178,20 @@
               config_file: .jshintrc
 
       %p
+        Check out
+        = link_to "JSHint configuration", "http://jshint.com/docs/options/",
+          target: :blank
+        for supported options.
+
+      %p
         To ignore certain files and directories, add
         %em.code-inline .jshintignore
         file to your project,
         include in it path patterns for files/directories that you want ignored,
         and reference the ignore file in your
         %em.code-inline .hound.yml
-        \. See
-        = link_to "linter docs", "http://jshint.com/docs/cli/", target: :blank
+        file. See
+        = link_to "linter docs", "http://jshint.com/docs/cli", target: :blank
         for more info ("Ignoring Files" section).
 
         %code.code-block
@@ -196,6 +202,7 @@
       %p
         To disable JavaScript style checking, add the following to your
         %em.code-inline .hound.yml
+        file.
 
         %code.code-block
           :preserve

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -35,7 +35,7 @@
       %p
         If this page doesn't help you find what you are looking for,
         please tweet at us
-        = link_to "@houndci", "https://twitter.com/houndci", target: :blank
+        = link_to "@houndci", "https://twitter.com/houndci", new_window_options
         or email us at #{mail_to "hound@thoughtbot.com"}
         and we will help you out.
 
@@ -81,7 +81,7 @@
         Hound can be configured to use
         = link_to "GitHub's Status API",
           "https://github.com/blog/1935-see-results-from-all-pull-request-status-checks",
-          target: :blank
+          new_window_options
         to mark a pull request as failed if any violations are found.
         To do so, add the following to your
         %em.code-inline .hound.yml
@@ -96,21 +96,23 @@
         Hound uses
         = link_to "RuboCop",
           "https://github.com/bbatsov/rubocop",
-          target: :blank
+          new_window_options
         to review Ruby code.
 
       %p
         By default, Hound uses the
         = succeed "." do
-          = link_to "default RuboCop config", rubocop_config_url, target: :blank
+          = link_to "default RuboCop config",
+            rubocop_config_url,
+            new_window_options
         To change the way RuboCop is configured, add a
         %em.code-inline .rubocop.yml
         file to your project, configure it as desired
         (see the
         = succeed ")," do
-          = link_to("RuboCop docs",
+          = link_to "RuboCop docs",
             "http://rubocop.readthedocs.io/en/latest/",
-            target: :blank)
+            new_window_options
         and reference it in
         %em.code-inline .hound.yml
 
@@ -133,7 +135,7 @@
 
       %p
         Hound uses
-        = link_to "CoffeeLint", "http://www.coffeelint.org", target: :blank
+        = link_to "CoffeeLint", "http://www.coffeelint.org", new_window_options
         with the default configuration.
 
       %p
@@ -160,7 +162,8 @@
 
       %p
         Hound uses
-        = link_to "JSHint", "https://github.com/jshint/jshint", target: :blank
+        = link_to "JSHint", "https://github.com/jshint/jshint",
+          new_window_options
         to review JavaScript code by default.
 
       %p
@@ -180,7 +183,7 @@
       %p
         Check out
         = link_to "JSHint configuration", "http://jshint.com/docs/options/",
-          target: :blank
+          new_window_options
         for supported options.
 
       %p
@@ -191,7 +194,8 @@
         and reference the ignore file in your
         %em.code-inline .hound.yml
         file. See
-        = link_to "linter docs", "http://jshint.com/docs/cli", target: :blank
+        = link_to "linter docs", "http://jshint.com/docs/cli",
+          new_window_options
         for more info ("Ignoring Files" section).
 
         %code.code-block
@@ -214,9 +218,9 @@
 
       %p
         Hound uses
-        = link_to "ESLint", "http://eslint.org/", target: :blank
+        = link_to "ESLint", "http://eslint.org/", new_window_options
         with this
-        = link_to "config", eslint_config_url, target: :blank
+        = link_to "config", eslint_config_url, new_window_options
         by default.
 
       %p
@@ -247,7 +251,7 @@
         For more information on configuring ESLint rules, see the
         = link_to "ESLint Rules Documentation",
           "http://eslint.org/docs/rules/",
-          target: :blank
+          new_window_options
 
       %p
         To ignore certain files and directories, add
@@ -259,7 +263,7 @@
         \. See
         = link_to "linter docs",
           "http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories",
-          target: :blank
+          new_window_options
         for more info.
 
         %code.code-block
@@ -274,14 +278,14 @@
         Hound uses
         = link_to "scss-lint",
           "https://github.com/causes/scss-lint",
-          target: :blank
+          new_window_options
         with this
-        = link_to "config", scss_config_url, target: :blank
+        = link_to "config", scss_config_url, new_window_options
         by default.
 
       %p
         To change the way scss-lint is configured, simply copy the
-        = link_to "default config file", scss_config_url, target: :blank
+        = link_to "default config file", scss_config_url, new_window_options
         into your project, make changes and reference the file in your
         %em.code-inline .hound.yml
 
@@ -319,14 +323,14 @@
         Hound uses
         = link_to "haml-lint",
           "https://github.com/brigade/haml-lint",
-          target: :blank
+          new_window_options
         with this
-        = link_to "config", haml_config_url, target: :blank
+        = link_to "config", haml_config_url, new_window_options
         by default.
 
       %p
         To change the way haml-lint is configured, simply copy the
-        = link_to "default config file", haml_config_url, target: :blank
+        = link_to "default config file", haml_config_url, new_window_options
         into your project, make changes and reference the file in your
         %em.code-inline .hound.yml
 
@@ -364,11 +368,11 @@
         Hound uses
         = link_to "Flake8",
           "http://flake8.readthedocs.org/en/latest/",
-          target: :blank
+          new_window_options
         with this
         = link_to "default config",
           "http://flake8.readthedocs.org/en/latest/config.html#default",
-          target: :blank
+          new_window_options
         by default.
 
       %p
@@ -384,7 +388,7 @@
         To change the way Flake8 is configured, create a
         = link_to ".ini file",
           "http://flake8.readthedocs.org/en/latest/config.html#per-project",
-          target: :blank
+          new_window_options
         with your custom configuration and reference the file in
         %em.code-inline .hound.yml
 
@@ -402,14 +406,14 @@
         Hound uses
         = link_to "SwiftLint",
           "https://github.com/realm/SwiftLint",
-          target: :blank
+          new_window_options
         with this
-        = link_to "config", swift_config_url, target: :blank
+        = link_to "config", swift_config_url, new_window_options
         by default.
 
       %p
         To change the way SwiftLint is configured, copy the
-        = link_to "default config file", swift_config_url, target: :blank
+        = link_to "default config file", swift_config_url, new_window_options
         into your project, make changes and reference the file in your
         %em.code-inline .hound.yml
 
@@ -435,13 +439,13 @@
         , you can read about it on the
         = link_to "SwiftLint Configuration Documentation",
           "https://github.com/realm/SwiftLint#configuration",
-          target: :blank
+          new_window_options
 
     %article.docs-article
       %h3 Didn't find what you where looking for?
 
       %p
         Please tweet at us
-        = link_to "@houndci", "https://twitter.com/houndci", target: :blank
+        = link_to "@houndci", "https://twitter.com/houndci", new_window_options
         or email us at #{mail_to "hound@thoughtbot.com"}
         and we will help you out.


### PR DESCRIPTION
* Remove default config docs for JSHint, since we're now starting new customers with JSHint defaults.
* Use safe new tab opening options