### PR TITLE
Ensure inherit config is merged before owner's

### DIFF
--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -4,7 +4,7 @@ module Config
       if legacy?
         hound_config.content
       else
-        parse_inherit_from(super)
+        super
       end
     end
 
@@ -14,16 +14,20 @@ module Config
 
     private
 
+    def load
+      config = super
+      inherited_config = parse_inherit_from(config)
+      inherited_config.deep_merge(config.except("inherit_from"))
+    end
+
     def parse_inherit_from(config)
       inherit_from = Array(config.fetch("inherit_from", []))
 
-      inherited_config = inherit_from.reduce({}) do |result, ancestor_file_path|
+      inherit_from.reduce({}) do |result, ancestor_file_path|
         raw_ancestor_config = commit.file_content(ancestor_file_path)
         ancestor_config = safe_parse(raw_ancestor_config) || {}
         result.merge(ancestor_config)
       end
-
-      inherited_config.merge(config.except("inherit_from"))
     end
 
     def safe_parse(content)


### PR DESCRIPTION
There was a logical error, where owner's (org-level) config was merged
with the repo config first, and then merged with the repo's inherited
config. Thus, the last step of merging with inherited allowed for the
owner cofig to override the inherited (which is the repo's config still).