### PR TITLE
Show which repos are private in the list

### DIFF
--- a/app/assets/javascripts/components/__tests__/__snapshots__/repo-test.jsx.snap
+++ b/app/assets/javascripts/components/__tests__/__snapshots__/repo-test.jsx.snap
@@ -7,6 +7,15 @@ exports[`test renders a repo appropriately 1`] = `
   </div>
   <div
     className="repo-activation-toggle">
+    <label
+      className="repo-label tooltip">
+      <i
+        className="fa fa-lock" />
+      <span
+        className="tooltip--message">
+        Private Repo
+      </span>
+    </label>
     <RepoActivationButton
       isProcessingId={null}
       onRepoClicked={[Function]}

--- a/app/assets/javascripts/components/repo.jsx
+++ b/app/assets/javascripts/components/repo.jsx
@@ -49,6 +49,11 @@ class Repo extends React.Component {
           "repo-activation-toggle",
           {"repo-activation-toggle--private": showPrivate}
         )}>
+          <label className="repo-label tooltip">
+            <i className="fa fa-lock"></i>
+            <span className="tooltip--message">Private Repo</span>
+          </label>
+
           {this.renderButton()}
         </div>
       </li>

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -12,11 +12,14 @@ $font-size-medium: 1.25em;
 $font-size-large: 2.7em;
 $font-size-xlarge: 3em;
 $font-size-xxlarge: 3.8em;
+$font-size-icon: 1.25em;
 
 $base-line-height: 1.4;
 
 $black: #000;
 $gold: rgb(226, 206, 0);
+$dark-gold: darken($gold, 10%);
+$light-gold: lighten($gold, 50%);
 $green: rgb(132, 240, 156);
 $light-gray: rgb(230, 230, 230);
 $purple: rgb(168, 115, 209);
@@ -31,6 +34,9 @@ $medium-font-color: rgb(140, 140, 140);
 $base-accent-color: $purple;
 $base-secondary-color: lighten($purple, 10%);
 $code-background-color: rgba(#99abc0, 0.25);
+$highlight-color: $gold;
+$highlight-color-dark: $dark-gold;
+$highlight-color-light: $light-gold;
 
 $home-gradient-top: rgb(196, 115, 209);
 $home-gradient-bottom: rgb(153, 115, 209);
@@ -56,6 +62,7 @@ $base-border: 1px solid $base-border-color;
 $base-border-radius: 5px;
 
 $base-spacing: 1.25em;
+$xxsmall-spacing: $base-spacing * 0.25;
 $xsmall-spacing: $base-spacing * 0.5;
 $small-spacing: $base-spacing * 0.75;
 $medium-spacing: $base-spacing * 1.5;

--- a/app/assets/stylesheets/components/_components.scss
+++ b/app/assets/stylesheets/components/_components.scss
@@ -9,4 +9,6 @@
 @import "logo";
 @import "plan-markers";
 @import "pricing";
+@import "repo-label";
 @import "toggle_switch";
+@import "tooltip";

--- a/app/assets/stylesheets/components/_repo-label.scss
+++ b/app/assets/stylesheets/components/_repo-label.scss
@@ -1,0 +1,30 @@
+.repo-label {
+  color: $medium-font-color;
+  display: none;
+  margin-right: $small-spacing;
+  position: relative;
+  transition: color $base-transition-timing $base-easing;
+  vertical-align: middle;
+
+  @include media($small-screen-only) {
+    margin-left: $base-spacing;
+    margin-top: $xxsmall-spacing;
+  }
+
+  .fa {
+    font-size: $font-size-icon;
+    margin-right: 6px;
+  }
+
+  &:hover {
+    color: $highlight-color;
+  }
+}
+
+.repo-activation-toggle--private {
+  min-width: 250px;
+
+  .repo-label {
+    display: inline-block;
+  }
+}

--- a/app/assets/stylesheets/components/_tooltip.scss
+++ b/app/assets/stylesheets/components/_tooltip.scss
@@ -1,0 +1,37 @@
+.tooltip {
+  position: relative;
+
+  &:hover {
+    .tooltip--message {
+      display: block;
+    }
+  }
+}
+
+.tooltip--message {
+  @include position (absolute, 50% 100% null null);
+  background: $highlight-color-light;
+  border: 1px solid $highlight-color;
+  border-radius: $base-border-radius;
+  color: $highlight-color-dark;
+  display: none;
+  margin-right: $small-spacing;
+  padding: $xxsmall-spacing $xsmall-spacing;
+  transform: translateY(-50%);
+  white-space: nowrap;
+
+  &::before,
+  &::after {
+    @include position (absolute, 50% null null 100%);
+    @include size(0);
+    border: 6px solid transparent;
+    border-left: 6px solid $highlight-color;
+    content: "";
+    transform: translateY(-50%);
+  }
+
+  &::after {
+    border-left-color: $highlight-color-light;
+    margin-left: -1px;
+  }
+}

--- a/app/assets/stylesheets/pages/repos/_index.scss
+++ b/app/assets/stylesheets/pages/repos/_index.scss
@@ -11,7 +11,7 @@
   @include media($small-screen-only) {
     display: block;
     height: auto;
-    padding: 1em 0;
+    padding: 1em;
   }
 }
 
@@ -70,10 +70,6 @@
     padding: 0;
     text-align: left;
   }
-}
-
-.repo-activation-toggle--private {
-  min-width: 250px;
 }
 
 .repo-toggle {


### PR DESCRIPTION
Right now there's no way to identify which repos in the list are private or not, after toggling 'include private repos'

This PR adds a visual indicator to help with this, on hover there is a label:

![screen shot 2017-01-17 at 11 31 10 am](https://cloud.githubusercontent.com/assets/1729878/22018766/772e6640-dca8-11e6-89ca-cd5189e85d04.png)
