### PR TITLE
Add the ability to quickly jump to organizations

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,3 +9,4 @@
 //= require classnames
 
 //= require sticky-header
+//= require quick-jump

--- a/app/assets/javascripts/components.jsx
+++ b/app/assets/javascripts/components.jsx
@@ -7,6 +7,7 @@ import Repo from './components/repo.jsx';
 import RepoActivationButton from './components/repo_activation_button.jsx';
 import RepoList from './components/repo_list.jsx';
 import RepoTools from './components/repo_tools.jsx';
+import RepoToolsOrganizations from './components/repo_tools_organizations.jsx';
 import RepoToolsPrivate from './components/repo_tools_private.jsx';
 import RepoToolsRefresh from './components/repo_tools_refresh.jsx';
 import RepoToolsSearch from './components/repo_tools_search.jsx';

--- a/app/assets/javascripts/components/__tests__/__snapshots__/repo_tools-test.jsx.snap
+++ b/app/assets/javascripts/components/__tests__/__snapshots__/repo_tools-test.jsx.snap
@@ -4,6 +4,7 @@ exports[`test renders appropriately with Show Private button (not syncing) 1`] =
   <RepoToolsSearch
     onSearchInput={[Function]} />
   <RepoToolsPrivate />
+  <RepoToolsOrganizations />
   <RepoToolsRefresh
     isSyncing={false}
     onRefreshClicked={[Function]} />
@@ -15,6 +16,7 @@ exports[`test renders appropriately without Show Private button (not syncing) 1`
   className="repo-tools">
   <RepoToolsSearch
     onSearchInput={[Function]} />
+  <RepoToolsOrganizations />
   <RepoToolsRefresh
     isSyncing={false}
     onRefreshClicked={[Function]} />

--- a/app/assets/javascripts/components/__tests__/__snapshots__/repo_tools_organizations-test.jsx.snap
+++ b/app/assets/javascripts/components/__tests__/__snapshots__/repo_tools_organizations-test.jsx.snap
@@ -1,0 +1,18 @@
+exports[`test renders a dropdown list containing organizations 1`] = `
+<div
+  className="repo-tools-org dropdown">
+  <i
+    className="fa fa-caret-down" />
+  <select
+    className="quick-jump">
+    <option
+      disabled={true}>
+      Quick jump to organization
+    </option>
+    <option
+      value="div[data-org-name=\'Test org\']">
+      Test org
+    </option>
+  </select>
+</div>
+`;

--- a/app/assets/javascripts/components/__tests__/__snapshots__/repo_tools_refresh-test.jsx.snap
+++ b/app/assets/javascripts/components/__tests__/__snapshots__/repo_tools_refresh-test.jsx.snap
@@ -5,7 +5,10 @@ exports[`test renders appropriately (when syncing) 1`] = `
     className="repo-tools-refresh-button"
     disabled="disabled"
     onClick={[Function]}>
-    <span />
+    <span>
+      <i
+        className="fa fa-refresh fa-fw fa-spin" />
+    </span>
   </button>
 </div>
 `;
@@ -17,7 +20,10 @@ exports[`test renders appropriately 1`] = `
     className="repo-tools-refresh-button"
     disabled={null}
     onClick={[Function]}>
-    <span />
+    <span>
+      <i
+        className="fa fa-refresh fa-fwundefined" />
+    </span>
   </button>
 </div>
 `;

--- a/app/assets/javascripts/components/__tests__/__snapshots__/repos_container-test.jsx.snap
+++ b/app/assets/javascripts/components/__tests__/__snapshots__/repos_container-test.jsx.snap
@@ -5,6 +5,7 @@ exports[`test renders appropriately 1`] = `
     onPrivateClicked={[Function]}
     onRefreshClicked={[Function]}
     onSearchInput={[Function]}
+    organizations={Array []}
     showPrivateButton={true} />
   <ReposView
     filterTerm={null}

--- a/app/assets/javascripts/components/__tests__/repo_tools_organizations-test.jsx
+++ b/app/assets/javascripts/components/__tests__/repo_tools_organizations-test.jsx
@@ -1,0 +1,15 @@
+import RepoToolsOrganizations from '../repo_tools_organizations.jsx';
+
+it('renders a dropdown list containing organizations', () => {
+  const organizations = [
+    { id: 1, name: "Test org" }
+  ]
+
+  const wrapper = shallow(
+    <RepoToolsOrganizations
+      organizations={organizations}
+    />
+  );
+
+  expect(wrapper).toMatchSnapshot();
+});

--- a/app/assets/javascripts/components/repo_tools.jsx
+++ b/app/assets/javascripts/components/repo_tools.jsx
@@ -1,3 +1,4 @@
+import RepoToolsOrganizations from './repo_tools_organizations.jsx';
 import RepoToolsSearch from './repo_tools_search.jsx';
 import RepoToolsRefresh from './repo_tools_refresh.jsx';
 import RepoToolsPrivate from './repo_tools_private.jsx';
@@ -9,12 +10,14 @@ class RepoTools extends React.Component {
       showPrivateButton,
       isSyncing,
       onRefreshClicked,
+      organizations
     } = this.props;
 
     return (
       <div className="repo-tools">
         <RepoToolsSearch onSearchInput={onSearchInput} />
         {showPrivateButton ? <RepoToolsPrivate /> : null}
+        <RepoToolsOrganizations organizations={organizations} />
         <RepoToolsRefresh
           isSyncing={isSyncing}
           onRefreshClicked={onRefreshClicked}

--- a/app/assets/javascripts/components/repo_tools_organizations.jsx
+++ b/app/assets/javascripts/components/repo_tools_organizations.jsx
@@ -1,0 +1,19 @@
+class RepoToolsOrganizations extends React.Component {
+  render() {
+    const { organizations } = this.props;
+
+    return (
+      <div className="repo-tools-org dropdown">
+        <i className="fa fa-caret-down"></i>
+        <select className="quick-jump">
+          <option disabled>Quick jump to organization</option>
+          {organizations.map( org => (
+            <option key={org.id} value={"div[data-org-name='" + org.name + "']"}>{org.name}</option>
+          ))}
+        </select>
+      </div>
+    )
+  }
+}
+
+module.exports = RepoToolsOrganizations;

--- a/app/assets/javascripts/components/repo_tools_refresh.jsx
+++ b/app/assets/javascripts/components/repo_tools_refresh.jsx
@@ -1,9 +1,7 @@
 class RepoToolsRefresh extends React.Component {
-  buttonText(isSyncing) {
+  refreshIcon(isSyncing) {
     if (isSyncing) {
-      return Hound.settings.syncingButtonText;
-    } else {
-      return Hound.settings.syncNowButtonText;
+      return " fa-spin";
     }
   }
 
@@ -17,7 +15,9 @@ class RepoToolsRefresh extends React.Component {
           disabled={isSyncing ? "disabled" : null}
           onClick={onRefreshClicked}
         >
-          <span>{this.buttonText(isSyncing)}</span>
+          <span>
+            <i className={"fa fa-refresh fa-fw" + this.refreshIcon(isSyncing)}></i>
+          </span>
         </button>
       </div>
     );

--- a/app/assets/javascripts/components/repos_container.jsx
+++ b/app/assets/javascripts/components/repos_container.jsx
@@ -283,6 +283,7 @@ class ReposContainer extends React.Component {
           onRefreshClicked={this.onRefreshClicked.bind(this)}
           onPrivateClicked={this.onPrivateClicked}
           isSyncing={this.state.isSyncing}
+          organizations={this.state.organizations}
         />
         <ReposView
           isSyncing={this.state.isSyncing}

--- a/app/assets/javascripts/quick-jump.js
+++ b/app/assets/javascripts/quick-jump.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+  $('.quick-jump').change( function () {
+    var targetPosition = $($(this).val()).offset().top - 120;
+    $('html,body').animate({ scrollTop: targetPosition}, 400);
+  });
+});

--- a/app/assets/stylesheets/components/_components.scss
+++ b/app/assets/stylesheets/components/_components.scss
@@ -1,5 +1,6 @@
 @import "allowance";
 @import "code";
+@import "dropdown";
 @import "footer";
 @import "header";
 @import "inline-flash";

--- a/app/assets/stylesheets/components/_dropdown.scss
+++ b/app/assets/stylesheets/components/_dropdown.scss
@@ -1,0 +1,16 @@
+.dropdown {
+  padding-right: 1em;
+  position: relative;
+
+  i {
+    position: absolute;
+    right: 40px;
+    top: 24px;
+  }
+
+  select {
+    @include appearance(none);
+    background: none;
+    border: 0;
+  }
+}

--- a/app/assets/stylesheets/pages/repos/_tools.scss
+++ b/app/assets/stylesheets/pages/repos/_tools.scss
@@ -44,13 +44,13 @@
 
   &:hover,
   &:focus {
-    background-color: rgba($purple, 0.1);
-    border-color: $purple;
-    color: $purple;
+    background-color: rgba($base-accent-color, 0.1);
+    border-color: $base-accent-color;
+    color: $base-accent-color;
     outline: none;
 
     &::placeholder {
-      color: $purple;
+      color: $base-accent-color;
     }
   }
 }
@@ -69,8 +69,12 @@
   }
 }
 
-.repo-tools-refresh {
+.repo-tools-org {
   @include span-columns(3 of 12, table);
+}
+
+.repo-tools-refresh {
+  @include span-columns(1 of 12, table);
   @include media($small-screen-only) {
     display: block;
     width: 100%;
@@ -78,9 +82,10 @@
 }
 
 .repo-tools-refresh-button,
-.repo-tools-private-button {
+.repo-tools-private-button,
+.dropdown select {
   background-color: $base-background-color;
-  border: 2px solid $base-border-color;
+  border: 2px solid $base-accent-color;
   border-radius: 3px;
   color: $light-font-color;
   font-size: 1em;
@@ -95,8 +100,8 @@
   width: 100%;
 
   &:hover {
-    background-color: $purple;
-    border-color: $purple;
+    background-color: $base-accent-color;
+    border-color: $base-accent-color;
     color: $white;
   }
 

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -69,7 +69,7 @@ feature "Repo list", js: true do
 
     expect(page).to have_content(repo.name)
 
-    click_button I18n.t("sync_repos")
+    find(".repo-tools-refresh-button").click
 
     expect(page).to have_text("TEST_GITHUB_LOGIN/TEST_GITHUB_REPO_NAME")
     expect(page).not_to have_text(repo.name)


### PR DESCRIPTION
Currently is there is a long list of repos it is difficult to get to navigate orgs in the repo list.

This PR adds a dropdown to jump to the users orgs, it also cleans up the 'repo tools' bar a bit, with a more concise refresh button, also styling to improve the identification of the buttons vs the search input:

**Before**
![screen shot 2017-01-17 at 11 42 10 am](https://cloud.githubusercontent.com/assets/1729878/22019110/000166b0-dcaa-11e6-85bd-c8d2edcfd64c.png)

**After**
![screen shot 2017-01-17 at 11 40 26 am](https://cloud.githubusercontent.com/assets/1729878/22019072/c7f38f14-dca9-11e6-80c9-3f25aa777a57.png)

**Active**
![screen shot 2017-01-17 at 11 40 38 am](https://cloud.githubusercontent.com/assets/1729878/22019071/c7dc6c12-dca9-11e6-9264-7d8677df6544.png)