### PR TITLE
Always merge configurations

### DIFF
--- a/app/models/config/go.rb
+++ b/app/models/config/go.rb
@@ -1,9 +1,4 @@
 module Config
   class Go < Base
-    DEFAULT_CONFIG = ""
-
-    def content
-      DEFAULT_CONFIG
-    end
   end
 end

--- a/app/models/linter/python.rb
+++ b/app/models/linter/python.rb
@@ -4,10 +4,6 @@ module Linter
 
     private
 
-    def config
-      Config::Python.new(hound_config, owner: owner)
-    end
-
     def enqueue_job(attributes)
       Resque.push(
         "python_review",

--- a/spec/models/config/go_spec.rb
+++ b/spec/models/config/go_spec.rb
@@ -2,14 +2,25 @@ require "spec_helper"
 require "app/models/config/base"
 require "app/models/config/go"
 require "app/models/config/parser"
+require "app/models/config_content"
+require "app/models/missing_owner"
 
 describe Config::Go do
   describe "#content" do
-    it "returns an empty string" do
-      hound_config = double("HoundConfig")
-      config = Config::Go.new(hound_config)
+    it "returns an empty hash" do
+      config_content = instance_double("ConfigContent", load: {})
+      content = { go: { enabled: true } }
+      raw_content = <<~EOS
+        go:
+          enabled: true
+      EOS
+      commit = instance_double("Commit", file_content: raw_content)
+      hound_config = double("HoundConfig", commit: commit, content: content)
+      owner = instance_double("Owner", config_content: {})
+      allow(ConfigContent).to receive(:new).and_return(config_content)
+      config = Config::Go.new(hound_config, owner: owner)
 
-      expect(config.content).to eq ""
+      expect(config.content).to eq({})
     end
   end
 end

--- a/spec/models/config/go_spec.rb
+++ b/spec/models/config/go_spec.rb
@@ -15,7 +15,11 @@ describe Config::Go do
           enabled: true
       EOS
       commit = instance_double("Commit", file_content: raw_content)
-      hound_config = double("HoundConfig", commit: commit, content: content)
+      hound_config = instance_double(
+        "HoundConfig",
+        commit: commit,
+        content: content,
+      )
       owner = instance_double("Owner", config_content: {})
       allow(ConfigContent).to receive(:new).and_return(config_content)
       config = Config::Go.new(hound_config, owner: owner)

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -46,7 +46,7 @@ describe Linter::Go do
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,
-        config: Config::Go::DEFAULT_CONFIG,
+        config: {},
       )
     end
   end


### PR DESCRIPTION
Before, the Python and Go linters had their own specific configurations when they did not need to. Updated both of the linters to inherit the configuration implementation from their bases.

https://trello.com/c/PMwYwgPL

![](http://i.giphy.com/l0Ex0OMEzCwcC5Nza.gif)