### PR TITLE
Set Hound up to Flog Ruby changes

### DIFF
--- a/app/jobs/flog_review_job.rb
+++ b/app/jobs/flog_review_job.rb
@@ -1,0 +1,3 @@
+class FlogReviewJob
+  @queue = :flog_review
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -4,6 +4,7 @@ class HoundConfig
     Linter::CoffeeScript,
     Linter::Credo,
     Linter::Eslint,
+    Linter::Flog,
     Linter::Go,
     Linter::Haml,
     Linter::Jshint,
@@ -17,6 +18,7 @@ class HoundConfig
   BETA_LINTERS = %w(
     credo
     eslint
+    flog
     remark
     python
     tslint

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -41,7 +41,7 @@ module Linter
     def build_review_job_attributes(commit_file)
       {
         commit_sha: build.commit_sha,
-        config: config.serialize,
+        config: serialized_configuration,
         content: commit_file.content,
         filename: commit_file.filename,
         linter_name: name,
@@ -72,6 +72,10 @@ module Linter
         name: name,
         owner: owner,
       )
+    end
+
+    def serialized_configuration
+      config.serialize
     end
   end
 end

--- a/app/models/linter/flog.rb
+++ b/app/models/linter/flog.rb
@@ -1,0 +1,11 @@
+module Linter
+  class Flog < Base
+    FILE_REGEXP = /.+\.r(b|ake)\z/
+
+    private
+
+    def serialized_configuration
+      "--- {}\n"
+    end
+  end
+end

--- a/spec/models/linter/flog_spec.rb
+++ b/spec/models/linter/flog_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+module Linter
+  RSpec.describe Flog do
+    describe ".can_lint?" do
+      context "when given a '.rb' file" do
+        it "is true" do
+          expect(Flog.can_lint?("foo.rb")).to be(true)
+        end
+      end
+
+      context "when given a '.rake' file" do
+        it "is true" do
+          expect(Flog.can_lint?("foo.rake")).to be(true)
+        end
+      end
+
+      context "when given a non-Ruby file" do
+        it "is false" do
+          expect(Flog.can_lint?("foo.js")).to be(false)
+        end
+      end
+    end
+
+    describe "#enabled?" do
+      context "when Flog linting is enabled" do
+        it "is true" do
+          build = instance_double("Build")
+          hound_config = instance_double("HoundConfig", linter_enabled?: true)
+          linter = Flog.new(build: build, hound_config: hound_config)
+
+          expect(linter).to be_enabled
+        end
+      end
+    end
+
+    describe "#file_included?" do
+      it "is always true" do
+        build = instance_double("Build")
+        hound_config = instance_double("HoundConfig", linter_enabled?: true)
+        linter = Flog.new(build: build, hound_config: hound_config)
+
+        expect(linter.file_included?).to be(true)
+      end
+    end
+
+    describe "#file_review" do
+      it "is a new file review" do
+        repo = instance_double("Repo", owner: nil)
+        build = instance_double(
+          "Build",
+          commit_sha: "somesha",
+          pull_request_number: 123,
+          repo: repo,
+        )
+        commit_file = instance_double(
+          "CommitFile",
+          content: "code",
+          filename: "lib/ruby.rb",
+          patch: "patch",
+        )
+        file_review = instance_double("FileReview")
+        hound_config = instance_double("HoundConfig")
+        missing_owner = instance_double("MissingOwner")
+        allow(FileReview).to receive(:create!).and_return(file_review)
+        allow(MissingOwner).to receive(:new).and_return(missing_owner)
+        allow(Resque).to receive(:enqueue)
+        linter = Flog.new(build: build, hound_config: hound_config)
+
+        expect(linter.file_review(commit_file)).to eq file_review
+        expect(Resque).to have_received(:enqueue)
+      end
+    end
+
+    describe "#name" do
+      it "is the class name converted to a config-friendly format" do
+        build = instance_double("Build")
+        hound_config = instance_double("HoundConfig")
+        linter = Flog.new(build: build, hound_config: hound_config)
+
+        expect(linter.name).to eq "flog"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before, we only checked Ruby files using Rubocop. This only allowed us to comment on the style of the files. Added a Flog integration which will comment on Ruby methods that are too complex.

![](http://i.giphy.com/14hWUIZK0rKFS8.gif)