### PR TITLE
Dry up testing common linter behavior

### DIFF
--- a/spec/models/linter/base_spec.rb
+++ b/spec/models/linter/base_spec.rb
@@ -10,15 +10,10 @@ module Linter
   end
 end
 
-describe Linter::Base do
-  describe ".can_lint?" do
-    it "uses the FILE_REGEXP to determine the match" do
-      yes_lint = Linter::Test.can_lint?("foo.yes")
-      no_lint = Linter::Test.can_lint?("foo.no")
-
-      expect(yes_lint).to eq true
-      expect(no_lint).to eq false
-    end
+describe Linter::Test do
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.yes) }
+    let(:not_lintable_files) { %w(foo.no bar.nope) }
   end
 
   describe "#file_included?" do

--- a/spec/models/linter/coffee_script_spec.rb
+++ b/spec/models/linter/coffee_script_spec.rb
@@ -1,38 +1,9 @@
 require "rails_helper"
 
 describe Linter::CoffeeScript do
-  describe ".can_lint?" do
-    context "given a .coffee file" do
-      it "returns true" do
-        result = Linter::CoffeeScript.can_lint?("foo.coffee")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a .coffee.erb file" do
-      it "returns true" do
-        result = Linter::CoffeeScript.can_lint?("foo.coffee.erb")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a .coffee.js file" do
-      it "returns true" do
-        result = Linter::CoffeeScript.can_lint?("foo.coffee.js")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-coffee file" do
-      it "returns false" do
-        result = Linter::CoffeeScript.can_lint?("foo.js")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.coffee foo.coffee.erb foo.coffee.js) }
+    let(:not_lintable_files) { %w(foo.js) }
   end
 
   describe "#file_review" do
@@ -69,13 +40,13 @@ describe Linter::CoffeeScript do
   end
 
   def stub_coffeelint_config(config = {})
-    stubbged_config = instance_double(
+    stubbed_config = instance_double(
       Config::CoffeeScript,
       content: config,
       serialize: Config::Serializer.json(config),
     )
-    allow(Config::CoffeeScript).to receive(:new).and_return(stubbged_config)
+    allow(Config::CoffeeScript).to receive(:new).and_return(stubbed_config)
 
-    stubbged_config
+    stubbed_config
   end
 end

--- a/spec/models/linter/credo_spec.rb
+++ b/spec/models/linter/credo_spec.rb
@@ -1,29 +1,8 @@
-require "rails_helper"
+require "spec_helper"
 
 describe Linter::Credo do
-  describe ".can_lint?" do
-    context "given an .ex file" do
-      it "returns true" do
-        result = Linter::Credo.can_lint?("foo.ex")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given an .exs file" do
-      it "returns true" do
-        result = Linter::Credo.can_lint?("foo.exs")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-markdown file" do
-      it "returns false" do
-        result = Linter::Credo.can_lint?("foo.txt")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.ex foo.exs) }
+    let(:not_lintable_files) { %w(foo.txt) }
   end
 end

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -1,38 +1,9 @@
 require "rails_helper"
 
 describe Linter::Eslint do
-  describe ".can_lint?" do
-    context "given an .es6 file" do
-      it "returns true" do
-        result = Linter::Eslint.can_lint?("foo.es6")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a .js file" do
-      it "returns true" do
-        result = Linter::Eslint.can_lint?("foo.js")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a .jsx file" do
-      it "returns true" do
-        result = Linter::Eslint.can_lint?("foo.jsx")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-eslint file" do
-      it "returns false" do
-        result = Linter::Eslint.can_lint?("foo.js.coffee")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.es6 foo.js foo.jsx) }
+    let(:not_lintable_files) { %w(foo.js.coffee) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -1,22 +1,9 @@
 require "rails_helper"
 
 describe Linter::Go do
-  describe ".can_lint?" do
-    context "given a .go file" do
-      it "returns true" do
-        result = Linter::Go.can_lint?("foo.go")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-go file" do
-      it "returns false" do
-        result = Linter::Go.can_lint?("foo.rb")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.go) }
+    let(:not_lintable_files) { %w(foo.rb) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/haml_spec.rb
+++ b/spec/models/linter/haml_spec.rb
@@ -1,22 +1,9 @@
 require "rails_helper"
 
 describe Linter::Haml do
-  describe ".can_lint?" do
-    context "given a .haml file" do
-      it "returns true" do
-        result = Linter::Haml.can_lint?("foo.haml")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-haml file" do
-      it "returns false" do
-        result = Linter::Haml.can_lint?("foo.rb")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.haml) }
+    let(:not_lintable_files) { %w(foo.rb) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -1,30 +1,9 @@
 require "rails_helper"
 
 describe Linter::Jshint do
-  describe ".can_lint?" do
-    context "given a .js file" do
-      it "returns true" do
-        result = Linter::Jshint.can_lint?("foo.js")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a .js.coffee file" do
-      it "returns false" do
-        result = Linter::Jshint.can_lint?("foo.js.coffee")
-
-        expect(result).to eq false
-      end
-    end
-
-    context "given a non-js file" do
-      it "returns false" do
-        result = Linter::Jshint.can_lint?("foo.rb")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.js) }
+    let(:not_lintable_files) { %w(foo.js.coffee foo.rb) }
   end
 
   describe "#file_included?" do

--- a/spec/models/linter/python_spec.rb
+++ b/spec/models/linter/python_spec.rb
@@ -1,22 +1,9 @@
 require "rails_helper"
 
 describe Linter::Python do
-  describe ".can_lint?" do
-    context "given a .python file" do
-      it "returns true" do
-        result = Linter::Python.can_lint?("foo.py")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-python file" do
-      it "returns false" do
-        result = Linter::Python.can_lint?("foo.rb")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.py) }
+    let(:not_lintable_files) { %w(foo.rb) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/remark_spec.rb
+++ b/spec/models/linter/remark_spec.rb
@@ -1,30 +1,9 @@
 require "rails_helper"
 
 describe Linter::Remark do
-  describe ".can_lint?" do
-    context "given an .md file" do
-      it "returns true" do
-        result = Linter::Remark.can_lint?("foo.md")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given an .markdown file" do
-      it "returns true" do
-        result = Linter::Remark.can_lint?("foo.markdown")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-markdown file" do
-      it "returns false" do
-        result = Linter::Remark.can_lint?("foo.txt")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.md foo.markdown) }
+    let(:not_lintable_files) { %w(foo.txt) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/ruby_spec.rb
+++ b/spec/models/linter/ruby_spec.rb
@@ -1,30 +1,9 @@
 require "rails_helper"
 
 describe Linter::Ruby do
-  describe ".can_lint?" do
-    context "given a .rb file" do
-      it "returns true" do
-        result = Linter::Ruby.can_lint?("foo.rb")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a .rake file" do
-      it "returns true" do
-        result = Linter::Ruby.can_lint?("foo.rake")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-ruby file" do
-      it "returns false" do
-        result = Linter::Ruby.can_lint?("foo.js")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.rb foo.rake) }
+    let(:not_lintable_files) { %w(foo.js) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/scss_spec.rb
+++ b/spec/models/linter/scss_spec.rb
@@ -1,22 +1,9 @@
 require "rails_helper"
 
 describe Linter::Scss do
-  describe ".can_lint?" do
-    context "given an .scss file" do
-      it "returns true" do
-        result = Linter::Scss.can_lint?("foo.scss")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-scss file" do
-      it "returns false" do
-        result = Linter::Scss.can_lint?("foo.css")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.scss) }
+    let(:not_lintable_files) { %w(foo.css) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/swift_spec.rb
+++ b/spec/models/linter/swift_spec.rb
@@ -1,22 +1,9 @@
 require "rails_helper"
 
 describe Linter::Swift do
-  describe ".can_lint?" do
-    context "given a .swift file" do
-      it "returns true" do
-        result = Linter::Swift.can_lint?("foo.swift")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-swift file" do
-      it "returns false" do
-        result = Linter::Swift.can_lint?("foo.c")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.swift) }
+    let(:not_lintable_files) { %w(foo.c) }
   end
 
   describe "#file_review" do

--- a/spec/models/linter/tslint_spec.rb
+++ b/spec/models/linter/tslint_spec.rb
@@ -1,22 +1,9 @@
 require "rails_helper"
 
 describe Linter::Tslint do
-  describe ".can_lint?" do
-    context "given a .ts file" do
-      it "returns true" do
-        result = Linter::Tslint.can_lint?("foo.ts")
-
-        expect(result).to eq true
-      end
-    end
-
-    context "given a non-typescript file" do
-      it "returns false" do
-        result = Linter::Tslint.can_lint?("foo.js.coffee")
-
-        expect(result).to eq false
-      end
-    end
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.ts) }
+    let(:not_lintable_files) { %w(foo.js.coffee) }
   end
 
   describe "#file_review" do

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -1,0 +1,19 @@
+RSpec.shared_examples "a linter" do
+  describe ".can_lint?" do
+    it "rejects files based on FILE_REGEXP" do
+      not_lintable_files.each do |file|
+        no_lint = described_class.can_lint?(file)
+
+        expect(no_lint).to eq false
+      end
+    end
+
+    it "accepts files based on FILE_REGEXP" do
+      lintable_files.each do |file|
+        yes_lint = described_class.can_lint?(file)
+
+        expect(yes_lint).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
While reviewing the specs for the suite of linters there is common
behavior that is repeatedly tested that is ripe for extraction to
something like a shared example.

To reduce boilerplate I've started with one quick win - a small test to
assert that linters allow only certain types of files and/or extensions.