### PR TITLE
By default, do not enable HTTPS when running specs

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,2 @@
+RAILS_ENV=test
+ENABLE_HTTPS=no

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 ENV["RAILS_ENV"] ||= "test"
+ENV["ENABLE_HTTPS"] = "no"
 
 require "config/environment"
 require "rspec/rails"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,4 @@
 ENV["RAILS_ENV"] ||= "test"
-ENV["ENABLE_HTTPS"] = "no"
 
 require "config/environment"
 require "rspec/rails"


### PR DESCRIPTION
Until this commit the specs hitting app endpoints would have their
behavior altered depending on what was set in your `.env.local` file for
`ENABLE_HTTPS`. It should always be set to "no" when the specs are being
run.