### PR TITLE
Add reek as a linter to main Hound app

### DIFF
--- a/app/jobs/reek_review_job.rb
+++ b/app/jobs/reek_review_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class ReekReviewJob
+  @queue = :reek_review
+end

--- a/app/models/config/reek.rb
+++ b/app/models/config/reek.rb
@@ -1,0 +1,7 @@
+module Config
+  class Reek < Base
+    def content
+      ""
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -10,6 +10,7 @@ class HoundConfig
     Linter::Jshint,
     Linter::Remark,
     Linter::Python,
+    Linter::Reek,
     Linter::Ruby,
     Linter::Scss,
     Linter::Swift,
@@ -19,6 +20,7 @@ class HoundConfig
     credo
     eslint
     flog
+    reek
     remark
     python
     tslint

--- a/app/models/linter/reek.rb
+++ b/app/models/linter/reek.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Linter
+  class Reek < Base
+    FILE_REGEXP = /.+\.r(b|ake)\z/
+  end
+
+  private
+
+  def serialized_configuration
+    "--- {}\n"
+  end
+end

--- a/spec/models/linter/reek_spec.rb
+++ b/spec/models/linter/reek_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe Linter::Reek do
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.rb foo.rake) }
+    let(:not_lintable_files) { %w(foo.js) }
+  end
+
+  describe "#file_review" do
+    it "is a new file review" do
+      repo = instance_double("Repo", owner: nil)
+      build = instance_double(
+        "Build",
+        commit_sha: "somesha",
+        pull_request_number: 123,
+        repo: repo,
+      )
+      commit_file = instance_double(
+        "CommitFile",
+        content: "code",
+        filename: "lib/ruby.rb",
+        patch: "patch",
+      )
+      file_review = instance_double("FileReview")
+      hound_config = instance_double("HoundConfig")
+      missing_owner = instance_double("MissingOwner")
+      allow(FileReview).to receive(:create!).and_return(file_review)
+      allow(MissingOwner).to receive(:new).and_return(missing_owner)
+      allow(Resque).to receive(:enqueue)
+      linter = Linter::Reek.new(build: build, hound_config: hound_config)
+
+      expect(linter.file_review(commit_file)).to eq file_review
+      expect(Resque).to have_received(:enqueue)
+    end
+  end
+
+  describe "#name" do
+    it "is the class name converted to a config-friendly format" do
+      build = instance_double("Build")
+      hound_config = instance_double("HoundConfig")
+      linter = Linter::Reek.new(build: build, hound_config: hound_config)
+
+      expect(linter.name).to eq "reek"
+    end
+  end
+end


### PR DESCRIPTION
In addition to the soon-to-be merged flog linter, this commit enables using reek to surface potential code smells.

More information on reek is available here: https://github.com/troessner/reek