### PR TITLE
Don't submit a review for zero violations

### DIFF
--- a/app/services/complete_build.rb
+++ b/app/services/complete_build.rb
@@ -13,7 +13,9 @@ class CompleteBuild
       new_violations = priority_violations.select do |violation|
         commenting_policy.comment_on?(violation)
       end
-      pull_request.comment_on_violations(new_violations)
+      if new_violations.any?
+        pull_request.comment_on_violations(new_violations)
+      end
       set_commit_status
       track_subscribed_build_completed
     end

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -87,6 +87,21 @@ describe CompleteBuild do
           I18n.t(:complete_status, count: 0),
         )
       end
+
+      it "does not send a PR review" do
+        stub_const("Hound::MAX_COMMENTS", 2)
+        build = stub_build([])
+        pull_request = stub_pull_request([])
+        stubbed_github_api
+
+        CompleteBuild.call(
+          pull_request: pull_request,
+          build: build,
+          token: "abc123",
+        )
+
+        expect(pull_request).not_to have_received(:comment_on_violations)
+      end
     end
 
     context "with subscribed private repo and opened pull request" do


### PR DESCRIPTION
Some jobs are failing with what appears to be an error message from
GitHub complaining about an empty review. We don't have great logging
capabilities into the job failures, so I'm making an assumption that not
submitting a review with empty comments with fix this.

> undefined method `map' for "You need to leave a comment indicating the
> requested changes."