### PR TITLE
Masquerading as a user

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -2,7 +2,15 @@ module Admin
   class ApplicationController < Administrate::ApplicationController
     before_action :authenticate_admin
 
+    helper_method :sidebar_resources
+
     private
+
+    def sidebar_resources
+      Administrate::Namespace.new(namespace).resources.select do |resource|
+        DashboardManifest::DASHBOARDS.include?(resource)
+      end
+    end
 
     def authenticate_admin
       unless github_admin?

--- a/app/controllers/admin/masquerades_controller.rb
+++ b/app/controllers/admin/masquerades_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Admin
+  class MasqueradesController < Admin::ApplicationController
+    def show
+      requested_user = User.find_by(username: params[:username])
+      session[:masqueraded_user_id] = requested_user.id
+
+      redirect_to repos_path
+    end
+
+    def destroy
+      session.delete(:masqueraded_user_id)
+
+      redirect_to repos_path
+    end
+  end
+end

--- a/app/views/admin/application/_sidebar.html.haml
+++ b/app/views/admin/application/_sidebar.html.haml
@@ -1,0 +1,6 @@
+%ul.sidebar__list
+  - sidebar_resources.each do |resource|
+    %li
+      = link_to display_resource_name(resource),
+        [namespace, resource],
+        class: "sidebar__link sidebar__link--#{nav_link_state(resource)}"

--- a/app/views/application/_header.haml
+++ b/app/views/application/_header.haml
@@ -31,7 +31,12 @@
               .avatar{ style: "background-image: url('#{avatar}')" }
             %span= current_user.username
         %li
-          = link_to t("sign_out"), sign_out_path, class: "sign-out"
+          - if masquerading?
+            = link_to t("stop_masquerading"),
+              admin_masquerade_path(current_user.username),
+              method: :delete
+          - else
+            = link_to t("sign_out"), sign_out_path, class: "sign-out"
       - else
         %li
           = link_to "Pricing", root_path(anchor: "pricing"), class: "pricing"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
   syncing_repos: "Loading..."
   authenticate: "Sign In with GitHub"
   sign_out: "Sign Out"
+  stop_masquerading: "Stop Masquerading"
   active_repos: "Active repos"
   search_placeholder: "Search by repo"
   pending_status: "Hound is busy reviewing changes..."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Houndapp::Application.routes.draw do
       resources dashboard_resource
     end
 
+    resources :masquerades, param: :username, only: [:show, :destroy]
     root controller: DashboardManifest::ROOT_DASHBOARD, action: :index
   end
 

--- a/spec/controllers/subscriptions_controller_spec.rb
+++ b/spec/controllers/subscriptions_controller_spec.rb
@@ -104,9 +104,8 @@ describe SubscriptionsController, "#create" do
           repos: repos,
           token: "TEST_USER_TOKEN",
         )
-        users = class_double(User, first: user)
         allow(RepoActivator).to receive(:new).and_return(repo_activator)
-        allow(User).to receive(:where).and_return(users)
+        allow(User).to receive(:find_by).and_return(user)
 
         put :update, params: { repo_id: 1 }
 

--- a/spec/features/admin_masquerades_spec.rb
+++ b/spec/features/admin_masquerades_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+feature "Admin masquerades as user" do
+  scenario "admin sees user repos and can stop masquerading" do
+    repo = create(:repo)
+    admin = create(:user, username: "admin", token: "admin")
+    user = create(:user, repos: [repo], username: "admin", token: "user")
+    stub_const("Hound::ADMIN_GITHUB_USERNAMES", ["admin"])
+
+    sign_in_as(admin, "admin")
+    visit admin_masquerade_path(user.username)
+
+    expect(current_path).to eq(repos_path)
+    within "header .account" do
+      expect(page).to have_text(user.username)
+    end
+
+    click_on "Stop Masquerading"
+
+    within "header .account" do
+      expect(page).to have_text(admin.username)
+    end
+  end
+end

--- a/spec/requests/admin/masquerades_spec.rb
+++ b/spec/requests/admin/masquerades_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe "GET /masqerades?username=:username" do
+  context "as an admin" do
+    it "redirects to repos as the maqueraded user" do
+      admin = create(:user, username: "admin", token: "admin-token")
+      user = create(:user, username: "us3rn4me", token: "user-token")
+      stub_const("Hound::ADMIN_GITHUB_USERNAMES", ["admin"])
+
+      sign_in_as(admin)
+      get admin_masquerade_path(username: user.username)
+
+      expect(response).to redirect_to(repos_path)
+      follow_redirect!
+      expect(response.body).to include("us3rn4me")
+      expect(session[:masqueraded_user_id]).to eq(user.id)
+      expect(session[:remember_token]).to eq(admin.remember_token)
+    end
+  end
+
+  context "as a non-admin user" do
+    it "redirects to root and does not masquerade as user" do
+      non_admin = create(:user, token: "non-admin-token")
+      user = create(:user, username: "us3rn4me", token: "user-token")
+
+      sign_in_as(non_admin)
+      get admin_masquerade_path(username: user.username)
+
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(response.body).not_to include("us3rn4me")
+      expect(session[:masqueraded_user_id]).to be_nil
+      expect(session[:remember_token]).to eq(non_admin.remember_token)
+    end
+  end
+
+  def sign_in_as(user)
+    stub_oauth(username: user.username, email: user.email, token: user.token)
+    get "/auth/github"
+    follow_redirect!
+  end
+end


### PR DESCRIPTION
This adds a route that admins can go to that will put them in a mode where they
masquerade as the user they provided. They can then browse hound as if they were
that user, and then click "Stop Masquerading" to return to their own account.

![screen shot 2017-03-03 at 15 41 05](https://cloud.githubusercontent.com/assets/3799709/23573001/dc436e0c-0027-11e7-9d4a-7d4ef562fbaf.png)

https://trello.com/c/h9VtPK6F/800-as-an-admin-i-would-like-to-masquerade-as-a-user-so-that-i-may-help-debug-issues-that-they-are-running-into