### PR TITLE
Store unique repo ids in Stripe's metadata

### DIFF
--- a/app/models/payment_gateway_subscription.rb
+++ b/app/models/payment_gateway_subscription.rb
@@ -63,7 +63,7 @@ class PaymentGatewaySubscription
   end
 
   def append_repo_id_to_metadata(repo_id)
-    repo_ids = current_repo_ids + [repo_id]
+    repo_ids = (current_repo_ids + [repo_id.to_s]).uniq
 
     if metadata["repo_id"]
       metadata["repo_id"] = nil

--- a/spec/models/payment_gateway_subscription_spec.rb
+++ b/spec/models/payment_gateway_subscription_spec.rb
@@ -6,7 +6,7 @@ describe PaymentGatewaySubscription do
       plan = "tier1"
       succ = instance_double("Pricing")
       repo_id = 1
-      stripe_subscription = MockStripeSubscription.new(repo_ids: [])
+      stripe_subscription = MockStripeSubscription.new(repo_ids: ["1"])
       tier = instance_double("Tier")
       subscription = PaymentGatewaySubscription.new(
         stripe_subscription: stripe_subscription,


### PR DESCRIPTION
We've got some dups in there, this should clean it up.