### PR TITLE
Store linters and their default config in a hash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,10 +159,10 @@ and services being used, and the default configuration for each linter.
    * [config](https://raw.githubusercontent.com/houndci/hound/master/config/style_guides/haml.yml)
 1. Go
    * [houndci/go](https://github.com/houndci/go)
-1. Markdown (beta)
+1. Markdown
    * [houndci/remark](https://github.com/houndci/remark)
    * [config](https://github.com/wooorm/remark-lint#rules)
-1. Swift (beta)
+1. Swift
    * [houndci/swift](https://github.com/houndci/swift)
    * [config](https://github.com/houndci/swift/blob/master/config/default.yml)
 

--- a/app/models/config/ruby.rb
+++ b/app/models/config/ruby.rb
@@ -37,7 +37,11 @@ module Config
     end
 
     def legacy?
-      (configured_languages & HoundConfig::LINTER_NAMES).empty?
+      (configured_languages & all_linter_names).empty?
+    end
+
+    def all_linter_names
+      HoundConfig::LINTERS.keys.map { |klass| klass.name.demodulize.underscore }
     end
 
     def configured_languages

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -1,31 +1,21 @@
 # frozen_string_literal: true
 class HoundConfig
-  LINTERS = [
-    Linter::CoffeeScript,
-    Linter::Credo,
-    Linter::Eslint,
-    Linter::Flog,
-    Linter::Go,
-    Linter::Haml,
-    Linter::Jshint,
-    Linter::Remark,
-    Linter::Python,
-    Linter::Reek,
-    Linter::Ruby,
-    Linter::Scss,
-    Linter::Swift,
-    Linter::Tslint,
-  ].freeze
-  LINTER_NAMES = LINTERS.map { |klass| klass.name.demodulize.underscore }.freeze
-  BETA_LINTERS = %w(
-    credo
-    eslint
-    flog
-    reek
-    remark
-    python
-    tslint
-  ).freeze
+  LINTERS = {
+    Linter::CoffeeScript => { default: true },
+    Linter::Credo => { default: false },
+    Linter::Eslint => { default: false },
+    Linter::Flog => { default: false },
+    Linter::Go => { default: true },
+    Linter::Haml => { default: true },
+    Linter::Jshint => { default: true },
+    Linter::Python => { default: false },
+    Linter::Reek => { default: false },
+    Linter::Remark => { default: false },
+    Linter::Ruby => { default: true },
+    Linter::Scss => { default: true },
+    Linter::Swift => { default: true },
+    Linter::Tslint => { default: false },
+  }.freeze
   CONFIG_FILE = ".hound.yml"
 
   attr_reader_initialize :commit
@@ -48,8 +38,9 @@ class HoundConfig
   private
 
   def default_config
-    LINTER_NAMES.each.with_object({}) do |name, config|
-      config[name] = { "enabled" => !BETA_LINTERS.include?(name) }
+    LINTERS.each.with_object({}) do |(linter_class, config), result|
+      name = linter_class.name.demodulize.underscore
+      result[name] = { "enabled" => config[:default] }
     end
   end
 

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -15,7 +15,7 @@ class StyleChecker
   end
 
   def find_able_linters(filename)
-    HoundConfig::LINTERS.
+    HoundConfig::LINTERS.keys.
       select { |linter_class| linter_class.can_lint?(filename) }.
       map { |linter_class| build_linter(linter_class) }
   end


### PR DESCRIPTION
This makes it straight forward to see which linter is enabled by
default.
This gets away from the legacy "beta" concept and makes it easier to
enable/disable future linters.