### PR TITLE
Fix duplicate Owner#name issue

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -6,7 +6,7 @@ class Owner < ApplicationRecord
     owner.update!(
       github_id: github_id,
       name: name,
-      organization: organization
+      organization: organization,
     )
     owner
   end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -2,10 +2,12 @@ class Owner < ApplicationRecord
   has_many :repos
 
   def self.upsert(github_id:, name:, organization:)
-    owner = find_or_initialize_by(github_id: github_id)
-    owner.name = name
-    owner.organization = organization
-    owner.save!
+    owner = find_by(github_id: github_id) || find_by(name: name) || Owner.new
+    owner.update!(
+      github_id: github_id,
+      name: name,
+      organization: organization
+    )
     owner
   end
 

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -13,7 +13,7 @@ describe Owner do
         new_owner = Owner.upsert(
           github_id: github_id,
           name: name,
-          organization: organization
+          organization: organization,
         )
 
         expect(new_owner).to be_persisted
@@ -28,7 +28,7 @@ describe Owner do
         updated_owner = Owner.upsert(
           github_id: owner.github_id,
           name: new_name,
-          organization: true
+          organization: true,
         )
 
         expect(updated_owner.name).to eq new_name
@@ -44,7 +44,7 @@ describe Owner do
         updated_owner = Owner.upsert(
           github_id: new_id,
           name: "ralphbot",
-          organization: true
+          organization: true,
         )
 
         expect(updated_owner.name).to eq "ralphbot"

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -35,6 +35,22 @@ describe Owner do
         expect(updated_owner.organization).to eq true
       end
     end
+
+    context "when name exists" do
+      it "uses existing owner" do
+        create(:owner, github_id: 1234, name: "ralphbot")
+
+        new_id = 567
+        updated_owner = Owner.upsert(
+          github_id: new_id,
+          name: "ralphbot",
+          organization: true
+        )
+
+        expect(updated_owner.name).to eq "ralphbot"
+        expect(updated_owner.github_id).to eq new_id
+      end
+    end
   end
 
   describe "#has_config_repo?" do


### PR DESCRIPTION
An issue came to light for one of our users where his repos were not
being refreshed. After digging in a bit I found that the
`RepoSynchronization` service was calling `Owner.upsert` across all the
user's repositories and hitting a `PG::UniqueViolation` exception. The
following example illustrates it:

```ruby
user = User.find(####)
repo_synch = RepoSynchronization.new(user)
repo_synch.start

PG::UniqueViolation: ERROR:  duplicate key value violates unique constraint "index_owners_on_name"
DETAIL:  Key (name)=(organization-name) already exists.
: INSERT INTO "owners" ("created_at", "updated_at", "github_id", "name", "organization") VALUES ($1, $2, $3, $4, $5) RETURNING "id"
```

Since both `github_id` and `name` have unique constraints on those columns,
we should guard against trying to insert new records with existing names
as well.

This commit will check for existing `github_id`s first, then the `name`,
defaulting to a brand new record.