### PR TITLE
Add support for stylelint

### DIFF
--- a/app/jobs/stylelint_review_job.rb
+++ b/app/jobs/stylelint_review_job.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+class StylelintReviewJob
+  @queue = :stylelint_review
+end

--- a/app/models/config/stylelint.rb
+++ b/app/models/config/stylelint.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+module Config
+  class Stylelint < Base
+    def serialize(data = content)
+      Serializer.json(data)
+    end
+
+    private
+
+    def parse(file_content)
+      json_with_comments = JsonWithComments.new(file_content)
+      content_without_comments = json_with_comments.without_comments
+      super(content_without_comments)
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -13,6 +13,7 @@ class HoundConfig
     Linter::Remark => { default: false },
     Linter::Ruby => { default: true },
     Linter::Scss => { default: true },
+    Linter::Stylelint => { default: false },
     Linter::Swift => { default: true },
     Linter::Tslint => { default: false },
   }.freeze

--- a/app/models/linter/stylelint.rb
+++ b/app/models/linter/stylelint.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+module Linter
+  class Stylelint < Base
+    FILE_REGEXP = /.+(\.scss|\.css|\.less)\z/
+  end
+end

--- a/app/services/resolve_config_conflicts.rb
+++ b/app/services/resolve_config_conflicts.rb
@@ -1,5 +1,8 @@
 class ResolveConfigConflicts
-  CONFLICTS = { "eslint" => "jshint" }.freeze
+  CONFLICTS = {
+    "eslint" => "jshint",
+    "stylelint" => "scss",
+  }.freeze
 
   static_facade :call
 

--- a/spec/models/linter/stylelint_spec.rb
+++ b/spec/models/linter/stylelint_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 describe Linter::Stylelint do
   it_behaves_like "a linter" do
     let(:lintable_files) { %w(foo.scss) }
-    let(:not_lintable_files) { %w(foo.xxx) }
+    let(:not_lintable_files) { %w(foo.sass) }
   end
 
   describe "#file_review" do
@@ -41,7 +41,7 @@ describe Linter::Stylelint do
   end
 
   def stub_scss_config(config = {})
-    stubbed_scss_config = double(
+    stubbed_scss_config = instance_double(
       "StylelintConfig",
       content: config,
       serialize: config.to_s,

--- a/spec/models/linter/stylelint_spec.rb
+++ b/spec/models/linter/stylelint_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+describe Linter::Stylelint do
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.scss) }
+    let(:not_lintable_files) { %w(foo.xxx) }
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      linter = build_linter
+      commit_file = build_commit_file(filename: "lib/a.scss")
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      linter = build_linter(build)
+      stub_scss_config({})
+      commit_file = build_commit_file(filename: "lib/a.scss")
+      allow(Resque).to receive(:enqueue)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        StylelintReviewJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        linter_name: "stylelint",
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "{}",
+      )
+    end
+  end
+
+  def stub_scss_config(config = {})
+    stubbed_scss_config = double(
+      "StylelintConfig",
+      content: config,
+      serialize: config.to_s,
+    )
+    allow(Config::Stylelint).to receive(:new).and_return(stubbed_scss_config)
+
+    stubbed_scss_config
+  end
+
+  def raw_hound_config
+    <<~EOS
+      stylelint:
+        enabled: true
+        config_file: config/.stylelintrc.json
+    EOS
+  end
+end


### PR DESCRIPTION
We worked with @gmq to add support for https://stylelint.io/

It works quite similar to tslint and eslint.
We've rolled this in our infrastructure and it's looking good

this should close https://github.com/houndci/hound/issues/1037