### PR TITLE
Sanitize Flake8 config

### DIFF
--- a/app/models/config/python.rb
+++ b/app/models/config/python.rb
@@ -7,7 +7,8 @@ module Config
     private
 
     def parse(file_content)
-      Parser.ini(file_content)
+      content = SanitizeIniFile.call(file_content)
+      Parser.ini(content)
     end
   end
 end

--- a/app/services/sanitize_ini_file.rb
+++ b/app/services/sanitize_ini_file.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+class SanitizeIniFile
+  static_facade :call
+
+  def initialize(config)
+    @config = config
+  end
+
+  def call
+    lines_without_comments.
+      map { |line| normalize_line(line) }.
+      join
+  end
+
+  private
+
+  def normalize_line(line)
+    case line.rstrip
+    when /.+=$/
+      line.rstrip + " "
+    when /^\s+.+,$/
+      line.strip
+    when /^\s+.+$/
+      line.lstrip
+    else
+      line
+    end
+  end
+
+  def lines_without_comments
+    @config.lines.
+      map { |line| line.gsub(/\s*#.*$/, "") }.
+      reject { |line| line.strip.blank? }
+  end
+end

--- a/spec/services/sanitize_ini_file_spec.rb
+++ b/spec/services/sanitize_ini_file_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "app/services/sanitize_ini_file"
+
+RSpec.describe SanitizeIniFile do
+  describe ".call" do
+    it "returns config with trailing slashes" do
+      config = <<~EOS
+        [flake8]
+        max-line-length = 80 # to support multiple splits
+        ignore =
+          # multiple spaces before operator
+          E221,
+          # multiple spaces after operator
+          E222,
+          # missing whitespace around operator
+          E225
+        max-complexity = 10
+      EOS
+
+      result = SanitizeIniFile.call(config)
+
+      expect(result).to eq <<~EOS
+        [flake8]
+        max-line-length = 80
+        ignore = E221,E222,E225
+        max-complexity = 10
+      EOS
+    end
+  end
+end


### PR DESCRIPTION
The configuration that Flake8 accepts from the config file can have
certain options on multiple lines, like:
```
[flake8]
ignore =
  # some comment
  E221,
  # another comment
  E222
```

The library we use to parse the ini file isn't able to handle that case
and errors out.

This solution puts the multi-line options on one line,
as well as removes all the comments from the config file.