### PR TITLE
Rescue & handle RecordNotUnique error in repo sync

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -7,6 +7,17 @@ class Owner < ApplicationRecord
     owner.organization = organization
     owner.save!
     owner
+
+  rescue ActiveRecord::RecordNotUnique => exception
+    Raven.capture_exception(
+      exception,
+      extra: {
+        github_id: github_id,
+        name: name,
+      },
+    )
+
+    raise exception
   end
 
   def has_config_repo?


### PR DESCRIPTION
The `RepoSynchronization` service object has recently run into an issue
where a user has had a repo owner with a different github_id, but a name
for the Owner/Org that is the same as a previous Owner record. This has
caused an exception during the synchronization process that was not
recovered.

This commit will rescue that exception in the RepoSynchronization service
object, and will continue the `each` loop if it encounters it.

Down in the Owner model class, however, the upsert that creates this
exception will send the error to Raven along with some additional info
on the offending repo - the github_id and the name.