### PR TITLE
Make details URL optional when updating status

### DIFF
--- a/app/jobs/report_invalid_config_job.rb
+++ b/app/jobs/report_invalid_config_job.rb
@@ -8,12 +8,14 @@ class ReportInvalidConfigJob
   #
   # The following parameters are optional:
   # - message
+  # - details_url
   def self.perform(attributes)
     ReportInvalidConfig.call(
       pull_request_number: attributes.fetch("pull_request_number"),
       commit_sha: attributes.fetch("commit_sha"),
       linter_name: attributes.fetch("linter_name"),
       message: attributes["message"],
+      details_url: attributes["details_url"],
     )
   end
 end

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -19,8 +19,8 @@ class CommitStatus
     github.create_error_status(repo_name, sha, message)
   end
 
-  def set_config_error(message)
-    github.create_error_status(repo_name, sha, message, configuration_url)
+  def set_config_error(message, details_url = nil)
+    github.create_error_status(repo_name, sha, message, details_url)
   end
 
   def set_internal_error
@@ -31,10 +31,6 @@ class CommitStatus
   private
 
   attr_reader :repo_name, :sha, :token
-
-  def configuration_url
-    Rails.application.routes.url_helpers.configuration_url(host: Hound::HOST)
-  end
 
   def github
     @github ||= GithubApi.new(token)

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -93,10 +93,15 @@ class BuildRunner
       pull_request_number: payload.pull_request_number,
       commit_sha: payload.head_sha,
       linter_name: exception.linter_name,
+      details_url: configuration_url,
     )
   end
 
   def set_no_violations_status
     commit_status.set_success(0)
+  end
+
+  def configuration_url
+    Rails.application.routes.url_helpers.configuration_url(host: Hound::HOST)
   end
 end

--- a/app/services/report_invalid_config.rb
+++ b/app/services/report_invalid_config.rb
@@ -1,20 +1,21 @@
 class ReportInvalidConfig
   static_facade :call
 
-  def initialize(pull_request_number:, commit_sha:, linter_name:, message: "")
+  def initialize(pull_request_number:, commit_sha:, linter_name:, message: "", details_url: nil)
     @pull_request_number = pull_request_number
     @commit_sha = commit_sha
     @linter_name = linter_name
     @message = message
+    @details_url = details_url
   end
 
   def call
-    commit_status.set_config_error(message)
+    commit_status.set_config_error(message, details_url)
   end
 
   private
 
-  attr_reader :pull_request_number, :commit_sha, :linter_name
+  attr_reader :pull_request_number, :commit_sha, :linter_name, :details_url
 
   def message
     @message.presence || I18n.t(:config_error_status, linter_name: linter_name)

--- a/spec/jobs/report_invalid_config_job_spec.rb
+++ b/spec/jobs/report_invalid_config_job_spec.rb
@@ -8,6 +8,7 @@ describe ReportInvalidConfigJob do
         "commit_sha" => "abc123",
         "linter_name" => "ruby",
         "message" => "Could not parse the given config file",
+        "details_url" => "http://example.com/configuration",
       }
       allow(ReportInvalidConfig).to receive(:call)
 
@@ -18,6 +19,7 @@ describe ReportInvalidConfigJob do
         commit_sha: attributes["commit_sha"],
         linter_name: attributes["linter_name"],
         message: attributes["message"],
+        details_url: attributes["details_url"],
       )
     end
   end

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -82,7 +82,7 @@ describe CommitStatus do
         token: token,
       )
 
-      commit_status.set_config_error(message)
+      commit_status.set_config_error(message, configuration_url)
 
       expect(github_api).to have_received(:create_error_status).with(
         repo_name,

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -18,7 +18,37 @@ describe ReportInvalidConfig do
           message: message,
         )
 
-        expect(commit_status).to have_received(:set_config_error).with(message)
+        expect(commit_status).to(
+          have_received(:set_config_error).with(message, nil),
+        )
+        expect(Build).to have_received(:find_by!).with(
+          pull_request_number: pull_request_number,
+          commit_sha: commit_sha,
+        )
+      end
+    end
+
+    context "given a details URL" do
+      it "reports the file as an invalid config file to Github with a details link" do
+        commit_status = stubbed_commit_status(:set_config_error)
+        stubbed_build(repo_name: "houndci/hound")
+        pull_request_number = "42"
+        commit_sha = "abc123"
+        linter_name = "ruby"
+        message = "Invalid ruby file, woff"
+        details_url = "http://example.com"
+
+        ReportInvalidConfig.call(
+          pull_request_number: pull_request_number,
+          commit_sha: commit_sha,
+          linter_name: linter_name,
+          message: message,
+          details_url: details_url,
+        )
+
+        expect(commit_status).to(
+          have_received(:set_config_error).with(message, details_url),
+        )
         expect(Build).to have_received(:find_by!).with(
           pull_request_number: pull_request_number,
           commit_sha: commit_sha,
@@ -43,7 +73,7 @@ describe ReportInvalidConfig do
         expected_message =
           "Error parsing config for: ruby. Click \"details\" for assistance."
         expect(commit_status).to have_received(:set_config_error).
-          with(expected_message)
+          with(expected_message, nil)
         expect(Build).to have_received(:find_by!).with(
           pull_request_number: pull_request_number,
           commit_sha: commit_sha,


### PR DESCRIPTION
* Specifically when updating status to failed due to an invalid config
* Explicitly pass configuration URL in build runner