### PR TITLE
Performance tune the repos endpoint

### DIFF
--- a/app/assets/javascripts/components/repos_container.jsx
+++ b/app/assets/javascripts/components/repos_container.jsx
@@ -162,7 +162,7 @@ class ReposContainer extends React.Component {
         this.deactivateUnsubscribedRepo(repo);
       }
     } else {
-      if (repo.price_in_dollars > 0) {
+      if (repo.price_in_cents > 0) {
         this.createSubscriptionWithExistingCard(repo);
       } else {
         this.activateFreeRepo(repo);
@@ -218,7 +218,7 @@ class ReposContainer extends React.Component {
 
     if (repo.private) {
       eventName = "Private Repo Activated";
-      price = repo.price_in_dollars;
+      price = repo.price_in_cents / 100;
     } else {
       eventName = "Public Repo Activated";
       price = 0.0;

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -26,7 +26,7 @@ class Tier
   attr_reader :user
 
   def count
-    repos.count
+    @count ||= repos.count
   end
 
   def previous_repo_count

--- a/app/queries/repos_with_membership_or_subscription_query.rb
+++ b/app/queries/repos_with_membership_or_subscription_query.rb
@@ -6,7 +6,24 @@ class ReposWithMembershipOrSubscriptionQuery
   end
 
   def call
-    @user.subscribed_repos.includes(:subscription) |
-      @user.repos_by_activation_ability.includes(:subscription)
+    subscribed_repos | activatable_repos
+  end
+
+  private
+
+  def subscribed_repos
+    @user.subscribed_repos.includes(*repo_includes)
+  end
+
+  def activatable_repos
+    @user.repos_by_activation_ability.includes(*repo_includes)
+  end
+
+  def repo_includes
+    [
+      :memberships,
+      :owner,
+      :subscription,
+    ]
   end
 end

--- a/app/serializers/repo_serializer.rb
+++ b/app/serializers/repo_serializer.rb
@@ -3,13 +3,11 @@ class RepoSerializer < ActiveModel::Serializer
     :admin,
     :active,
     :name,
-    :full_plan_name,
     :github_id,
     :id,
     :in_organization,
     :owner,
     :price_in_cents,
-    :price_in_dollars,
     :private,
     :stripe_subscription_id,
   )
@@ -22,14 +20,6 @@ class RepoSerializer < ActiveModel::Serializer
     end
   end
 
-  def price_in_dollars
-    object.plan_price
-  end
-
-  def full_plan_name
-    "#{object.plan_type} repo".titleize
-  end
-
   def admin
     has_admin_membership? || has_subscription?
   end
@@ -37,7 +27,7 @@ class RepoSerializer < ActiveModel::Serializer
   private
 
   def membership
-    @membership ||= object.memberships.find_by(user_id: scope.id)
+    @membership ||= object.memberships.detect { |m| m.user_id == scope.id }
   end
 
   def has_admin_membership?
@@ -45,6 +35,6 @@ class RepoSerializer < ActiveModel::Serializer
   end
 
   def has_subscription?
-    scope.subscribed_repos.include?(object)
+    object.subscription&.user_id == scope.id
   end
 end


### PR DESCRIPTION
Fixes a handful of N+1 issues for the repos.json endpoint.

Also removes the `price_in_dollars` fields from the response. It's
calculated from the old $12/repo business logic. Eventually the whole
`Plan` object should be removed, but that's out of scope for this PR.

For my user, this reduces the number of queries from 1391 to 7.