### PR TITLE
Support Sass-lint

### DIFF
--- a/app/helpers/configuration_helper.rb
+++ b/app/helpers/configuration_helper.rb
@@ -23,6 +23,10 @@ module ConfigurationHelper
     config_url("houndci/linters", "config/tslint.json")
   end
 
+  def sass_lint_config_url
+    config_url("sasstools/sass-lint", "lib/config/sass-lint.yml")
+  end
+
   private
 
   def config_url(slug, config_file)

--- a/app/models/config/sass_lint.rb
+++ b/app/models/config/sass_lint.rb
@@ -1,0 +1,7 @@
+module Config
+  class SassLint < Base
+    def serialize(data = content)
+      Serializer.yaml(data)
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -12,6 +12,7 @@ class HoundConfig
     Linter::Reek => { default: false },
     Linter::Remark => { default: false },
     Linter::Ruby => { default: true },
+    Linter::SassLint => { default: false },
     Linter::Scss => { default: true },
     Linter::SlimLint => { default: false },
     Linter::Stylelint => { default: false },

--- a/app/models/linter/sass_lint.rb
+++ b/app/models/linter/sass_lint.rb
@@ -1,0 +1,9 @@
+module Linter
+  class SassLint < Base
+    FILE_REGEXP = /.+\.s(a|c)ss\z/
+
+    def job_class
+      LintersJob
+    end
+  end
+end

--- a/app/services/resolve_config_conflicts.rb
+++ b/app/services/resolve_config_conflicts.rb
@@ -2,6 +2,7 @@ class ResolveConfigConflicts
   CONFLICTS = {
     "eslint" => "jshint",
     "stylelint" => "scss",
+    "sass_lint" => "scss",
   }.freeze
 
   static_facade :call

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -27,6 +27,8 @@
         = link_to "TSLint", "#tslint", class: "docs-nav-link"
       %li
         = link_to "Elixir", "#elixir", class: "docs-nav-link"
+      %li
+        = link_to "Sass-lint", "#sass-lint", class: "docs-nav-link"
 
   %section.docs-content
     %article.docs-article
@@ -536,6 +538,40 @@
             elixir:
               enabled: true
               config_file: .credo.exs
+
+    %article.docs-article#sass-lint
+      %h3 Sass-lint
+      %p
+        Hound uses
+        = link_to "sass-lint",
+          "https://github.com/sasstools/sass-lint",
+          new_window_options
+        with this
+        = link_to "config", sass_lint_config_url, new_window_options
+        by default.
+
+      %p
+        To enable Sass-lint style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            sass-lint:
+              enabled: true
+      %p
+        To change the way Sass-lint is configured, add
+        %em.code-inline .sass-lint.yml
+        file to your project,
+        specify your desired configuration
+        and refreence the file in your
+        %em.code-inline .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            sass-lint:
+              enabled: true
+              config_file: .sass-lint.yml
 
     %article.docs-article
       %h3 Didn't find what you where looking for?

--- a/spec/models/config/sass_lint_spec.rb
+++ b/spec/models/config/sass_lint_spec.rb
@@ -1,0 +1,82 @@
+require "app/models/config/base"
+require "app/models/config/sass_lint"
+require "app/models/config/parser"
+require "app/models/config/parser_error"
+require "app/models/config/serializer"
+require "app/models/config_content"
+require "app/models/missing_owner"
+
+describe Config::SassLint do
+  describe "#content" do
+    context "when an owner is provided" do
+      it "merges the configuration into the owner's configuration" do
+        raw_config = <<~EOS
+          rules:
+            indentation:
+              - 2
+              -
+                size: 2
+        EOS
+        owner_config = {
+          "rules" => {
+            "brace-style" => [
+              2,
+              { "style" => "stroustrup" },
+            ],
+          },
+        }
+        owner = instance_double("Owner", config_content: owner_config)
+        config = build_config(raw_config, owner)
+
+        expect(config.content).to eq(
+          "rules" => {
+            "indentation" => [2, { "size" => 2 }],
+            "brace-style" => [2, { "style" => "stroustrup" }],
+          },
+        )
+      end
+    end
+
+    context "when there is no owner" do
+      it "parses the configuration using to return a hash" do
+        raw_config = <<~EOS
+          rules:
+            indentation:
+              - 2
+              -
+                size: 2
+        EOS
+        config = build_config(raw_config)
+
+        expect(config.content).to eq(
+          "rules" => {
+            "indentation" => [2, { "size" => 2 }],
+          },
+        )
+      end
+    end
+  end
+
+  describe "#serialize" do
+    it "serializes the parsed content into YAML" do
+      raw_config = <<~EOS
+        rules:
+          indentation:
+            - 2
+            -
+              size: 2
+              foo: bar
+      EOS
+      config = build_config(raw_config)
+
+      expect(config.serialize).to eq <<~EOS
+        ---
+        rules:
+          indentation:
+          - 2
+          - size: 2
+            foo: bar
+        EOS
+    end
+  end
+end

--- a/spec/models/linter/sass_lint_spec.rb
+++ b/spec/models/linter/sass_lint_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Linter::SassLint do
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.scss foo.sass) }
+    let(:not_lintable_files) { %w(foo.css bar.html) }
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      linter = build_linter
+      commit_file = build_commit_file(filename: "scss/styles.scss")
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedule a review job" do
+      build = build(:build, commit_sha: "baa", pull_request_number: 23)
+      linter = build_linter(build)
+      stub_sass_config({})
+      commit_file = build_commit_file(filename: "scss/styles.scss")
+      allow(Resque).to receive(:enqueue)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        LintersJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        linter_name: "sass_lint",
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "{}",
+      )
+    end
+  end
+
+  private
+
+  def stub_sass_config(config = {})
+    stubbed_sass_config = double(
+      "SassConfig",
+      content: config,
+      serialize: config.to_s,
+    )
+    allow(Config::SassLint).to receive(:new).and_return(stubbed_sass_config)
+
+    stubbed_sass_config
+  end
+end

--- a/spec/services/resolve_config_conflicts_spec.rb
+++ b/spec/services/resolve_config_conflicts_spec.rb
@@ -12,5 +12,16 @@ describe ResolveConfigConflicts do
         expect(resolved_config["eslint"]).to eq("enabled" => true)
       end
     end
+
+    context "given a config with sass_lint enabled" do
+      it "disables default Scss linter" do
+        config = { "sass_lint" => { "enabled" => true } }
+
+        resolved_config = ResolveConfigConflicts.call(config)
+
+        expect(resolved_config["scss"]).to eq("enabled" => false)
+        expect(resolved_config["sass_lint"]).to eq("enabled" => true)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds Hound Support for Sass-lint using the single `linters` queue.

It includes an update to `/configurations` letting people know how to enable and configure Sass-lint.