### PR TITLE
Pass empty string to review body when no errors

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -72,6 +72,8 @@ class PullRequest
       error_details = errors.map { |error| build_error_details(error) }
       ["Some files could not be reviewed due to errors:"].
         concat(error_details).join
+    else
+      ""
     end
   end
 

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -60,31 +60,57 @@ describe PullRequest do
   end
 
   describe "#make_comments" do
-    it "posts a review with comments to GitHub as the Hound user" do
-      payload = payload_stub
-      github = instance_double("GithubApi", create_pull_request_review: nil)
-      pull_request = pull_request_stub(github, payload)
-      violation = violation_stub
-      review_errors = ["invalid config", "foo\n  bar"]
+    context "when no errors in file reviews exist" do
+      it "posts a review with comments to GitHub as the Hound user" do
+        payload = payload_stub
+        github = instance_double("GithubApi", create_pull_request_review: nil)
+        pull_request = pull_request_stub(github, payload)
+        violation = violation_stub
 
-      pull_request.make_comments([violation], review_errors)
+        pull_request.make_comments([violation], [])
 
-      expect(github).to have_received(:create_pull_request_review).with(
-        "org/repo",
-        payload.pull_request_number,
-        [
-          {
-            path: violation.filename,
-            position: violation.patch_position,
-            body: violation.messages.join,
-          },
-        ],
-        "Some files could not be reviewed due to errors:" \
-        "<details><summary>invalid config</summary>" \
-        "<pre>invalid config</pre></details>" \
-        "<details><summary>foo</summary>" \
-        "<pre>foo<br>  bar</pre></details>",
-      )
+        expect(github).to have_received(:create_pull_request_review).with(
+          "org/repo",
+          payload.pull_request_number,
+          [
+            {
+              path: violation.filename,
+              position: violation.patch_position,
+              body: violation.messages.join,
+            },
+          ],
+          ""
+        )
+      end
+    end
+
+    context "when file reviews contain errors" do
+      it "posts a review with comments to GitHub as the Hound user" do
+        payload = payload_stub
+        github = instance_double("GithubApi", create_pull_request_review: nil)
+        pull_request = pull_request_stub(github, payload)
+        violation = violation_stub
+        review_errors = ["invalid config", "foo\n  bar"]
+
+        pull_request.make_comments([violation], review_errors)
+
+        expect(github).to have_received(:create_pull_request_review).with(
+          "org/repo",
+          payload.pull_request_number,
+          [
+            {
+              path: violation.filename,
+              position: violation.patch_position,
+              body: violation.messages.join,
+            },
+          ],
+          "Some files could not be reviewed due to errors:" \
+          "<details><summary>invalid config</summary>" \
+          "<pre>invalid config</pre></details>" \
+          "<details><summary>foo</summary>" \
+          "<pre>foo<br>  bar</pre></details>",
+        )
+      end
     end
   end
 


### PR DESCRIPTION
GitHub doesn't like nil for `body` property when creating a file review.
It gives us an error like:
```
422 - Invalid request. For 'properties/body', nil is not a string.
```