### PR TITLE
Fix color contrast of text

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -133,7 +133,7 @@
       }
 
       a {
-        color: $light-font-color;
+        color: $base-font-color;
         display: inline-block;
         font-weight: $font-weight-light;
         letter-spacing: 1px;

--- a/app/assets/stylesheets/pages/_builds.scss
+++ b/app/assets/stylesheets/pages/_builds.scss
@@ -4,7 +4,6 @@
   border-bottom-left-radius: $base-border-radius - 1px;
   border-bottom-right-radius: $base-border-radius - 1px;
   border-top: 2px solid $base-border-color;
-  color: $light-font-color;
   font-weight: $font-weight-normal;
   padding: $small-spacing 0;
   text-align: center;
@@ -39,17 +38,12 @@
 .build-pull-request,
 .build-sha {
   font-weight: $font-weight-light;
-
-  span {
-    color: $light-font-color;
-  }
 }
 
 .build-time {
   span {
     background-color: $base-background-color;
     border-radius: $base-border-radius;
-    color: $light-font-color;
     font-size: 0.75em;
     padding: ($xsmall-spacing / 2) $xsmall-spacing;
   }

--- a/app/assets/stylesheets/pages/_docs.scss
+++ b/app/assets/stylesheets/pages/_docs.scss
@@ -63,7 +63,7 @@
 }
 
 .docs-nav-link {
-  color: $light-font-color;
+  color: $base-font-color;
   display: block;
   padding: $small-spacing 0;
   text-align: right;

--- a/app/assets/stylesheets/pages/home/_home-languages.scss
+++ b/app/assets/stylesheets/pages/home/_home-languages.scss
@@ -79,7 +79,6 @@
 }
 
 .home-languages-list-item-heading {
-  color: $light-font-color;
   font-size: $font-size-small;
   font-weight: $font-weight-bold;
   letter-spacing: $letter-spacing-large;

--- a/app/assets/stylesheets/pages/repos/_organization.scss
+++ b/app/assets/stylesheets/pages/repos/_organization.scss
@@ -37,9 +37,7 @@ $dropdown-arrow: $white image-url("select-arrow.svg") no-repeat;
 }
 
 .organization-header-label {
-  color: $light-font-color;
   display: inline-block;
-  font-weight: 500;
 }
 
 .organization-header-select {


### PR DESCRIPTION
By increasing the contrast between foreground and background colors we
help those with low vision impairments and color deficiencies read and
navigate our content.

This change meets WCAG 2.0 AA contrast ratio thresholds and removes 12
violations thrown by [axe-core](https://github.com/dequelabs/axe-core)
when run on the home page.

## Before

![screencapture-localhost-5000-1496156728822](https://cloud.githubusercontent.com/assets/903327/26590196/eea64bf6-4527-11e7-9d2b-4f4b8c615784.png)

## After

![screencapture-localhost-5000-1496156575116](https://cloud.githubusercontent.com/assets/903327/26590148/d6740906-4527-11e7-8192-4f5dbf0ef841.png)
