### PR TITLE
Add `lang` attribute to `html` element

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{ lang: I18n.locale }
   %head
     %meta{ content: "width=device-width,initial-scale=1", name: "viewport" }
     %title


### PR DESCRIPTION
- Declaring the language attribute on the `html` element allows
  assistive technology to understand the human language of the page.
  Screen readers use this information to read out the text with correct
  pronunciation.
- Marking the language can also assist user agents in providing
  definitions using a dictionary.