### PR TITLE
Update rubocop config names and options for new version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,33 +10,6 @@ AllCops:
   StyleGuideCopsOnly: false
 Rails:
   Enabled: true
-Style/AccessModifierIndentation:
-  Description: Check indentation of private/protected visibility modifiers.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
-  Enabled: true
-  EnforcedStyle: indent
-  SupportedStyles:
-  - outdent
-  - indent
-Style/AlignHash:
-  Description: Align the elements of a hash literal if they span more than one line.
-  Enabled: true
-  EnforcedHashRocketStyle: key
-  EnforcedColonStyle: key
-  EnforcedLastArgumentHashStyle: always_inspect
-  SupportedLastArgumentHashStyles:
-  - always_inspect
-  - always_ignore
-  - ignore_implicit
-  - ignore_explicit
-Style/AlignParameters:
-  Description: Align the parameters of a method call if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
-  Enabled: true
-  EnforcedStyle: with_first_parameter
-  SupportedStyles:
-  - with_first_parameter
-  - with_fixed_indentation
 Style/AndOr:
   Description: Use &&/|| instead of and/or.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-and-or-or
@@ -61,15 +34,6 @@ Style/BracesAroundHashParameters:
   - braces
   - no_braces
   - context_dependent
-Style/CaseIndentation:
-  Description: Indentation of when in a case/when/[else/]end.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
-  Enabled: true
-  IndentWhenRelativeTo: case
-  SupportedStyles:
-  - case
-  - end
-  IndentOneStep: false
 Style/ClassAndModuleChildren:
   Description: Checks style of children classes and modules.
   Enabled: false
@@ -106,40 +70,6 @@ Style/CommentAnnotation:
   - OPTIMIZE
   - HACK
   - REVIEW
-Style/DotPosition:
-  Description: Checks the position of the dot in multi-line method calls.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
-  Enabled: true
-  EnforcedStyle: trailing
-  SupportedStyles:
-  - leading
-  - trailing
-Style/EmptyLineBetweenDefs:
-  Description: Use empty lines between defs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
-  Enabled: true
-  AllowAdjacentOneLineDefs: false
-Style/EmptyLinesAroundBlockBody:
-  Description: Keeps track of empty lines around block bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-Style/EmptyLinesAroundClassBody:
-  Description: Keeps track of empty lines around class bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
-Style/EmptyLinesAroundModuleBody:
-  Description: Keeps track of empty lines around module bodies.
-  Enabled: true
-  EnforcedStyle: no_empty_lines
-  SupportedStyles:
-  - empty_lines
-  - no_empty_lines
 Style/Encoding:
   Description: Use UTF-8 as the source file encoding.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
@@ -158,14 +88,6 @@ Style/FrozenStringLiteralComment:
     Add the frozen_string_literal comment to the top of files
     to help transition from Ruby 2.3.0 to Ruby 3.0.
   Enabled: false
-Style/FirstParameterIndentation:
-  Description: Checks the indentation of the first parameter in a method call.
-  Enabled: true
-  EnforcedStyle: special_for_inner_method_call_in_parentheses
-  SupportedStyles:
-  - consistent
-  - special_for_inner_method_call
-  - special_for_inner_method_call_in_parentheses
 Style/For:
   Description: Checks use of for or each in multiline loops.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-for-loops
@@ -207,18 +129,6 @@ Style/IfUnlessModifier:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
   MaxLineLength: 80
-Style/IndentationWidth:
-  Description: Use 2 spaces for indentation.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: true
-  Width: 2
-Style/IndentHash:
-  Description: Checks the indentation of the first key in a hash literal.
-  Enabled: true
-  EnforcedStyle: special_inside_parentheses
-  SupportedStyles:
-  - special_inside_parentheses
-  - consistent
 Style/LambdaCall:
   Description: Use lambda.call(...) instead of lambda.(...).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
@@ -257,21 +167,6 @@ Style/MethodName:
   SupportedStyles:
   - snake_case
   - camelCase
-Style/MultilineMethodCallIndentation:
-  Description: Checks indentation of method calls with the dot operator
-    that span more than one line.
-  Enabled: true
-  EnforcedStyle: indented
-  SupportedStyles:
-    - aligned
-    - indented
-Style/MultilineOperationIndentation:
-  Description: Checks indentation of binary operations that span more than one line.
-  Enabled: true
-  EnforcedStyle: indented
-  SupportedStyles:
-  - aligned
-  - indented
 Style/NumericLiterals:
   Description: Add underscores to large numeric literals to improve their readability.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscores-in-numerics
@@ -334,7 +229,6 @@ Style/RegexpLiteral:
     '/' character.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-r
   Enabled: false
-  MaxSlashes: 1
 Style/Semicolon:
   Description: Don't use semicolons to terminate expressions.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon
@@ -381,68 +275,17 @@ Style/StringLiteralsInInterpolation:
   SupportedStyles:
   - single_quotes
   - double_quotes
-Style/SpaceAroundBlockParameters:
-  Description: Checks the spacing inside and after block parameters pipes.
-  Enabled: true
-  EnforcedStyleInsidePipes: no_space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceAroundEqualsInParameterDefault:
-  Description: Checks that the equals signs in parameter default assignments have
-    or don't have surrounding space depending on configuration.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceBeforeBlockBraces:
-  Description: Checks that the left block brace has or doesn't have space before it.
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-Style/SpaceInsideBlockBraces:
-  Description: Checks that block braces have or don't have surrounding space. For
-    blocks taking parameters, checks that the left brace has or doesn't have trailing
-    space.
-  Enabled: true
-  EnforcedStyle: space
-  SupportedStyles:
-  - space
-  - no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: true
-Style/SpaceInsideHashLiteralBraces:
-  Description: Use spaces inside hash literal braces - or don't.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-  EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
-  SupportedStyles:
-  - space
-  - no_space
 Style/SymbolProc:
   Description: Use symbols as procs instead of blocks when possible.
   Enabled: true
   IgnoredMethods:
   - respond_to
-Style/TrailingBlankLines:
-  Description: Checks trailing blank lines and final newline.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
-  Enabled: true
-  EnforcedStyle: final_newline
-  SupportedStyles:
-  - final_newline
-  - final_blank_line
 Style/TrailingCommaInLiteral:
   Description: Checks for trailing comma in parameter lists and literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: true
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
   - comma
   - no_comma
 Style/TrailingCommaInArguments:
@@ -450,7 +293,7 @@ Style/TrailingCommaInArguments:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
   Enabled: true
   EnforcedStyleForMultiline: comma
-  SupportedStyles:
+  SupportedStylesForMultiline:
   - comma
   - no_comma
 Style/TrivialAccessors:
@@ -553,15 +396,15 @@ Lint/AssignmentInCondition:
 Lint/EndAlignment:
   Description: Align ends correctly.
   Enabled: true
-  AlignWith: keyword
-  SupportedStyles:
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
   - keyword
   - variable
 Lint/DefEndAlignment:
   Description: Align ends corresponding to defs correctly.
   Enabled: true
-  AlignWith: start_of_line
-  SupportedStyles:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
   - start_of_line
   - def
 Rails/ActionFilter:
@@ -614,9 +457,6 @@ Style/SymbolArray:
   Description: Use %i or %I for arrays of symbols.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-i
   Enabled: false
-Style/ExtraSpacing:
-  Description: Do not use unnecessary spacing.
-  Enabled: true
 Style/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.
   Enabled: false
@@ -624,10 +464,6 @@ Style/Alias:
   Description: Use alias_method instead of alias.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#alias-method
   Enabled: false
-Style/AlignArray:
-  Description: Align the elements of an array literal if they span more than one line.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
-  Enabled: true
 Style/ArrayJoin:
   Description: Use Array#join instead of Array#*.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#array-join
@@ -651,9 +487,6 @@ Style/BeginBlock:
 Style/BlockComments:
   Description: Do not use block comments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-block-comments
-  Enabled: true
-Style/BlockEndNewline:
-  Description: Put end statement of multiline block on its own line.
   Enabled: true
 Style/BlockDelimiters:
   Description: Avoid using {...} for multi-line blocks (multiline chaining is always
@@ -684,9 +517,6 @@ Style/ColonMethodCall:
   Description: 'Do not use :: for method call.'
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#double-colons
   Enabled: false
-Style/CommentIndentation:
-  Description: Indentation of comments.
-  Enabled: true
 Style/ConstantName:
   Description: Constants should use SCREAMING_SNAKE_CASE.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#screaming-snake-case
@@ -695,10 +525,6 @@ Style/DefWithParentheses:
   Description: Use def with parentheses when there are arguments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#method-parens
   Enabled: true
-Style/DeprecatedHashMethods:
-  Description: Checks for use of deprecated Hash methods.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
-  Enabled: false
 Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
@@ -709,20 +535,8 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Description: Prefer `each_with_object` over `inject` or `reduce`.
   Enabled: false
-Style/ElseAlignment:
-  Description: Align elses and elsifs correctly.
-  Enabled: true
 Style/EmptyElse:
   Description: Avoid empty else-clauses.
-  Enabled: true
-Style/EmptyLines:
-  Description: Don't use several empty lines in a row.
-  Enabled: true
-Style/EmptyLinesAroundAccessModifier:
-  Description: Keep blank lines around access modifiers.
-  Enabled: true
-Style/EmptyLinesAroundMethodBody:
-  Description: Keeps track of empty lines around method bodies.
   Enabled: true
 Style/EmptyLiteral:
   Description: Prefer literals to Array.new/Hash.new/String.new.
@@ -731,10 +545,6 @@ Style/EmptyLiteral:
 Style/EndBlock:
   Description: Avoid the use of END blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-END-blocks
-  Enabled: true
-Style/EndOfLine:
-  Description: Use Unix-style line endings.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
   Enabled: true
 Style/EvenOdd:
   Description: Favor the use of Fixnum#even? && Fixnum#odd?
@@ -748,12 +558,6 @@ Style/IfWithSemicolon:
   Description: Do not use if x; .... Use the ternary operator instead.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-semicolon-ifs
   Enabled: false
-Style/IndentationConsistency:
-  Description: Keep indentation straight.
-  Enabled: true
-Style/IndentArray:
-  Description: Checks the indentation of the first element in an array literal.
-  Enabled: true
 Style/InfiniteLoop:
   Description: Use Kernel#loop for infinite loops.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#infinite-loop
@@ -762,15 +566,11 @@ Style/Lambda:
   Description: Use the new lambda literal syntax for single-line blocks.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#lambda-multi-line
   Enabled: false
-Style/LeadingCommentSpace:
-  Description: Comments should start with a space.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
-  Enabled: true
 Style/LineEndConcatenation:
   Description: Use \ instead of + or << to concatenate two string literals at line
     end.
   Enabled: false
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Description: Do not use parentheses for method calls with no arguments.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-args-no-parens
   Enabled: true
@@ -778,9 +578,6 @@ Style/ModuleFunction:
   Description: Checks for usage of `extend self` in modules.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#module-function
   Enabled: false
-Style/MultilineBlockLayout:
-  Description: Ensures newlines after multiline block do statements.
-  Enabled: true
 Style/MultilineIfThen:
   Description: Do not use then for multi-line if/unless.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-then
@@ -821,6 +618,10 @@ Style/PerlBackrefs:
   Description: Avoid Perl-style regex back references.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-perl-regexp-last-matchers
   Enabled: false
+Style/PreferredHashMethods:
+  Description: Checks for use of deprecated Hash methods.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-key
+  Enabled: false
 Style/Proc:
   Description: Use proc instead of Proc.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc
@@ -846,62 +647,6 @@ Style/SelfAssignment:
     used.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#self-assignment
   Enabled: false
-Style/SpaceBeforeFirstArg:
-  Description: Checks that exactly one space is used between a method name and the
-    first argument for method calls without parentheses.
-  Enabled: true
-Style/SpaceAfterColon:
-  Description: Use spaces after colons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceAfterComma:
-  Description: Use spaces after commas.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceAroundKeyword:
-  Description: Use spaces after if/elsif/unless/while/until/case/when.
-  Enabled: true
-Style/SpaceAfterMethodName:
-  Description: Do not put a space between a method name and the opening parenthesis
-    in a method definition.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
-  Enabled: true
-Style/SpaceAfterNot:
-  Description: Tracks redundant space after the ! operator.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
-  Enabled: true
-Style/SpaceAfterSemicolon:
-  Description: Use spaces after semicolons.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceBeforeComma:
-  Description: No spaces before commas.
-  Enabled: true
-Style/SpaceBeforeComment:
-  Description: Checks for missing space between code and a comment on the same line.
-  Enabled: true
-Style/SpaceBeforeSemicolon:
-  Description: No spaces before semicolons.
-  Enabled: true
-Style/SpaceAroundOperators:
-  Description: Use spaces around operators.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
-  Enabled: true
-Style/SpaceAroundKeyword:
-  Description: Put a space before the modifier keyword.
-  Enabled: true
-Style/SpaceInsideBrackets:
-  Description: No spaces after [ or before ].
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: true
-Style/SpaceInsideParens:
-  Description: No spaces after ( or before ).
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
-  Enabled: true
-Style/SpaceInsideRangeLiteral:
-  Description: No spaces inside range literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
-  Enabled: true
 Style/SpecialGlobalVars:
   Description: Avoid Perl-style global variables.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-cryptic-perlisms
@@ -909,14 +654,6 @@ Style/SpecialGlobalVars:
 Style/StructInheritance:
   Description: Checks for inheritance from Struct.new.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-extend-struct-new
-  Enabled: true
-Style/Tab:
-  Description: No hard tabs.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
-  Enabled: true
-Style/TrailingWhitespace:
-  Description: Avoid trailing whitespace.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
   Enabled: true
 Style/UnlessElse:
   Description: Do not use unless with else. Rewrite these with the positive case first.
@@ -945,6 +682,275 @@ Style/WhenThen:
 Style/WhileUntilDo:
   Description: Checks for redundant do after while or until.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-multiline-while-do
+  Enabled: true
+Layout/AccessModifierIndentation:
+  Description: Check indentation of private/protected visibility modifiers.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-public-private-protected
+  Enabled: true
+  EnforcedStyle: indent
+  SupportedStyles:
+  - outdent
+  - indent
+Layout/AlignHash:
+  Description: Align the elements of a hash literal if they span more than one line.
+  Enabled: true
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
+Layout/AlignParameters:
+  Description: Align the parameters of a method call if they span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-double-indent
+  Enabled: true
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+Layout/CaseIndentation:
+  Description: Indentation of when in a case/when/[else/]end.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#indent-when-to-case
+  Enabled: true
+  EnforcedStyle: case
+  SupportedStyles:
+  - case
+  - end
+  IndentOneStep: false
+Layout/CommentIndentation:
+  Description: Indentation of comments.
+  Enabled: true
+Layout/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#consistent-multi-line-chains
+  Enabled: true
+  EnforcedStyle: trailing
+  SupportedStyles:
+  - leading
+  - trailing
+Layout/EmptyLineBetweenDefs:
+  Description: Use empty lines between defs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#empty-lines-between-methods
+  Enabled: true
+  AllowAdjacentOneLineDefs: false
+Layout/EmptyLinesAroundBlockBody:
+  Description: Keeps track of empty lines around block bodies.
+  Enabled: true
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+Layout/EmptyLinesAroundClassBody:
+  Description: Keeps track of empty lines around class bodies.
+  Enabled: true
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+Layout/EmptyLinesAroundModuleBody:
+  Description: Keeps track of empty lines around module bodies.
+  Enabled: true
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+Layout/FirstParameterIndentation:
+  Description: Checks the indentation of the first parameter in a method call.
+  Enabled: true
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+  - consistent
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+Layout/IndentationWidth:
+  Description: Use 2 spaces for indentation.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
+  Enabled: true
+  Width: 2
+Layout/IndentHash:
+  Description: Checks the indentation of the first key in a hash literal.
+  Enabled: true
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+Layout/MultilineMethodCallIndentation:
+  Description: Checks indentation of method calls with the dot operator
+    that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+  SupportedStyles:
+    - aligned
+    - indented
+Layout/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span more than one line.
+  Enabled: true
+  EnforcedStyle: indented
+  SupportedStyles:
+  - aligned
+  - indented
+Layout/SpaceAroundBlockParameters:
+  Description: Checks the spacing inside and after block parameters pipes.
+  Enabled: true
+  EnforcedStyleInsidePipes: no_space
+  SupportedStylesInsidePipes:
+  - space
+  - no_space
+Layout/SpaceAroundEqualsInParameterDefault:
+  Description: Checks that the equals signs in parameter default assignments have
+    or don't have surrounding space depending on configuration.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-around-equals
+  Enabled: true
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+Layout/SpaceBeforeBlockBraces:
+  Description: Checks that the left block brace has or doesn't have space before it.
+  Enabled: true
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+Layout/SpaceBeforeFirstArg:
+  Description: Put a space between a method name and the first argument in a method
+    call without parentheses.
+  Enabled: true
+Layout/SpaceInsideBlockBraces:
+  Description: Checks that block braces have or don't have surrounding space. For
+    blocks taking parameters, checks that the left brace has or doesn't have trailing
+    space.
+  Enabled: true
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SpaceBeforeBlockParameters: true
+Layout/SpaceInsideHashLiteralBraces:
+  Description: Use spaces inside hash literal braces - or don't.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+  - space
+  - no_space
+Layout/TrailingBlankLines:
+  Description: Checks trailing blank lines and final newline.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#newline-eof
+  Enabled: true
+  EnforcedStyle: final_newline
+  SupportedStyles:
+  - final_newline
+  - final_blank_line
+Layout/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: true
+Layout/AlignArray:
+  Description: Align the elements of an array literal if they span more than one line.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#align-multiline-arrays
+  Enabled: true
+Layout/BlockEndNewline:
+  Description: Put end statement of multiline block on its own line.
+  Enabled: true
+Layout/CommentIndentation:
+  Description: Indentation of comments.
+  Enabled: true
+Layout/ElseAlignment:
+  Description: Align elses and elsifs correctly.
+  Enabled: true
+Layout/EmptyLines:
+  Description: Don't use several empty lines in a row.
+  Enabled: true
+Layout/EmptyLinesAroundAccessModifier:
+  Description: Keep blank lines around access modifiers.
+  Enabled: true
+Layout/EmptyLinesAroundMethodBody:
+  Description: Keeps track of empty lines around method bodies.
+  Enabled: true
+Layout/EndOfLine:
+  Description: Use Unix-style line endings.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#crlf
+  Enabled: true
+Layout/IndentationConsistency:
+  Description: Keep indentation straight.
+  Enabled: true
+Layout/IndentArray:
+  Description: Checks the indentation of the first element in an array literal.
+  Enabled: true
+Layout/LeadingCommentSpace:
+  Description: Comments should start with a space.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space
+  Enabled: true
+Layout/MultilineBlockLayout:
+  Description: Ensures newlines after multiline block do statements.
+  Enabled: true
+Layout/SpaceBeforeFirstArg:
+  Description: Checks that exactly one space is used between a method name and the
+    first argument for method calls without parentheses.
+  Enabled: true
+Layout/SpaceAfterColon:
+  Description: Use spaces after colons.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+Layout/SpaceAfterComma:
+  Description: Use spaces after commas.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+Layout/SpaceAroundKeyword:
+  Description: Use spaces after if/elsif/unless/while/until/case/when.
+  Enabled: true
+Layout/SpaceAfterMethodName:
+  Description: Do not put a space between a method name and the opening parenthesis
+    in a method definition.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#parens-no-spaces
+  Enabled: true
+Layout/SpaceAfterNot:
+  Description: Tracks redundant space after the ! operator.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-bang
+  Enabled: true
+Layout/SpaceAfterSemicolon:
+  Description: Use spaces after semicolons.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+Layout/SpaceBeforeComma:
+  Description: No spaces before commas.
+  Enabled: true
+Layout/SpaceBeforeComment:
+  Description: Checks for missing space between code and a comment on the same line.
+  Enabled: true
+Layout/SpaceBeforeSemicolon:
+  Description: No spaces before semicolons.
+  Enabled: true
+Layout/SpaceAroundOperators:
+  Description: Use spaces around operators.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
+  Enabled: true
+Layout/SpaceAroundKeyword:
+  Description: Put a space before the modifier keyword.
+  Enabled: true
+Layout/SpaceInsideBrackets:
+  Description: No spaces after [ or before ].
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
+  Enabled: true
+Layout/SpaceInsideParens:
+  Description: No spaces after ( or before ).
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
+  Enabled: true
+Layout/SpaceInsideRangeLiteral:
+  Description: No spaces inside range literals.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
+  Enabled: true
+Layout/Tab:
+  Description: No hard tabs.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
+  Enabled: true
+Layout/TrailingWhitespace:
+  Description: Avoid trailing whitespace.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-whitespace
   Enabled: true
 Lint/AmbiguousOperator:
   Description: Checks for ambiguous operators in the first argument of a method invocation
@@ -988,9 +994,6 @@ Lint/EnsureReturn:
   Description: Do not use return in an ensure block.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-return-ensure
   Enabled: true
-Lint/Eval:
-  Description: The use of eval represents a serious security risk.
-  Enabled: true
 Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
@@ -1024,10 +1027,6 @@ Lint/RescueException:
 Lint/ShadowingOuterLocalVariable:
   Description: Do not use the same name as outer local variable for block arguments
     or block local variables.
-  Enabled: true
-Lint/SpaceBeforeFirstArg:
-  Description: Put a space between a method name and the first argument in a method
-    call without parentheses.
   Enabled: true
 Lint/StringConversionInInterpolation:
   Description: Checks for Object#to_s usage in string interpolation.
@@ -1069,3 +1068,6 @@ Lint/Void:
 Rails/Delegate:
   Description: Prefer delegate method for delegations.
   Enabled: false
+Security/Eval:
+  Description: The use of eval represents a serious security risk.
+  Enabled: true


### PR DESCRIPTION
After the May 31 update of the version of rubocop that Hound uses, I found that I needed to update these configurations.

This goes a few steps further than #1367, re-sorting the names alphabetically, and also removing/updating option names that caused warnings.