### PR TITLE
Improve headings outline and content

### DIFF
--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -8,7 +8,7 @@
       .home-hero
         %h1.home-hero-heading
           Code review tool for GitHub pull requests
-        %h2.home-hero-subheading
+        %p.home-hero-subheading
           Hound comments on style violations in GitHub pull requests, allowing
           you and your team to better review and maintain a clean codebase.
 
@@ -20,42 +20,42 @@
             = t("authenticate")
 
     .home-languages
-      %h4.home-heading--small.home-languages-heading Currently style checking
+      %h2.home-heading--small.home-languages-heading Currently style checking
 
       .inner-wrapper
         %ul.home-languages-list
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/coffeescript.svg", alt: ""
-            %h5.home-languages-list-item-heading CoffeeScript
+            %p.home-languages-list-item-heading CoffeeScript
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/go.svg", alt: ""
-            %h5.home-languages-list-item-heading Go
+            %p.home-languages-list-item-heading Go
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/haml.svg", alt: ""
-            %h5.home-languages-list-item-heading Haml
+            %p.home-languages-list-item-heading Haml
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/javascript.svg", alt: ""
-            %h5.home-languages-list-item-heading JavaScript
+            %p.home-languages-list-item-heading JavaScript
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/ruby.svg", alt: ""
-            %h5.home-languages-list-item-heading Ruby
+            %p.home-languages-list-item-heading Ruby
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/sass.svg", alt: ""
-            %h5.home-languages-list-item-heading Scss
+            %p.home-languages-list-item-heading Scss
           %li.home-languages-list-item
             .home-languages-list-item-logo
               = image_tag "languages/swift.svg", alt: ""
-            %h5.home-languages-list-item-heading Swift
+            %p.home-languages-list-item-heading Swift
 
 %section.home-importance
   .section-content
-    %h3.home-heading--large.home-importance-heading.section-title
+    %h2.home-heading--large.home-importance-heading.section-title
       Why does style matter?
 
     .inner-wrapper
@@ -63,7 +63,7 @@
         .home-importance-icon
           %i.fa.fa-bolt
         .home-importance-text
-          %h4.home-heading--small Convention
+          %p.home-heading--small Convention
           %p
             Defining and sticking with a style guide helps reduce the amount of
             decisions that developers need to make when writing code, helping to
@@ -73,7 +73,7 @@
         .home-importance-icon
           %i.fa.fa-ellipsis-h
         .home-importance-text
-          %h4.home-heading--small Consistency
+          %p.home-heading--small Consistency
           %p
             When every line of code is written in the same style, the whole
             codebase becomes easier to read, understand and de-bug. It also
@@ -84,7 +84,7 @@
         .home-importance-icon
           %i.fa.fa-magic
         .home-importance-text
-          %h4.home-heading--small Awesomeness
+          %p.home-heading--small Awesomeness
           %p
             A clean codebase is a reflection of a cohesive team. It gives the
             impression of a team working well together towards a common goal,
@@ -94,8 +94,8 @@
   .section-content
     %article.value-section
       .value-text
-        %h3.home-heading--large
-          Write code, submit a pull request, get review from Hound.
+        %h2.home-heading--large
+          How it works.
         %p
           Hound integrates with your existing workflow by reviewing and commenting
           on code the moment a GitHub pull request is opened or updated.
@@ -104,7 +104,7 @@
 
     %article.value-section
       .value-text
-        %h3.home-heading--large
+        %h2.home-heading--large
           Save time, get better reviews.
         %p
           Automated style checking with Hound gives developers more time to
@@ -117,7 +117,7 @@
     %figure.configuration-image
       = image_tag "home-page/guides.png"
     .configuration-text
-      %h4.home-heading--small
+      %h2.home-heading--small
         Use our guides or configure your own.
       %p
         Hound's default style guides build upon accepted industry standards and
@@ -130,18 +130,18 @@
 %section.home-pricing
   .section-content#pricing
     .section-title
-      %h3.home-pricing-heading.home-heading--large
-        Hound keeps your code style in check.
+      %h2.home-pricing-heading.home-heading--large
+        Pricing.
 
     %article.plans
       .inner-wrapper
-        %h4.plan-category
+        %h3.plan-category
           %i.fa.fa-book
           Private Repos
 
         = render(partial: @home.private_plans, as: :plan)
 
-        %h4.plan-category.open-source
+        %h3.plan-category.open-source
           %i.fa.fa-code-fork
           Open Source
 
@@ -150,7 +150,7 @@
 %section.home-security
   .section-content
     %article
-      %h4.home-heading--small
+      %h2.home-heading--small
         Uncomfortable giving us access to your code?
       %p
         Don’t worry, we get it. Our mission is to help you maintain a clean code

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -1,4 +1,4 @@
-- content_for :page_title, "Configuration"
+- content_for :page_title, "Documentation"
 
 .docs
   %nav.docs-nav
@@ -32,7 +32,7 @@
 
   %section.docs-content
     %article.docs-article
-      %h1 Hound Documentation
+      %h1 Documentation
       %p
         Want to modify style rules to better suit your preferences?
         Below you will find documentation on configuring style rules for each
@@ -46,7 +46,7 @@
         and we will help you out.
 
     %article.docs-article#configuration
-      %h3 Hound Configuration
+      %h2 Hound Configuration
 
       %p The following linters are enabled by default:
       %p
@@ -106,7 +106,7 @@
           fail_on_violations: true
 
     %article.docs-article#ruby
-      %h3 Ruby
+      %h2 Ruby
       %p
         Hound uses
         = link_to "RuboCop",
@@ -146,7 +146,7 @@
               enabled: false
 
     %article.docs-article#coffeescript
-      %h3 CoffeeScript
+      %h2 CoffeeScript
 
       %p
         Hound uses
@@ -173,7 +173,7 @@
               enabled: false
 
     %article.docs-article#javascript
-      %h3 JavaScript
+      %h2 JavaScript
 
       %p
         Hound uses
@@ -229,7 +229,7 @@
               enabled: false
 
     %article.docs-article#scss
-      %h3 SCSS
+      %h2 SCSS
 
       %p
         Hound uses
@@ -274,7 +274,7 @@
               enabled: false
 
     %article.docs-article#haml
-      %h3 Haml
+      %h2 Haml
 
       %p
         Hound uses
@@ -307,7 +307,7 @@
               enabled: false
 
     %article.docs-article#go
-      %h3 Go
+      %h2 Go
 
       %p
         Hound uses
@@ -326,7 +326,7 @@
               enabled: false
 
     %article.docs-article#swift
-      %h3 Swift
+      %h2 Swift
 
       %p
         Hound uses
@@ -368,7 +368,7 @@
           new_window_options
 
     %article.docs-article#eslint
-      %h3 ESLint
+      %h2 ESLint
 
       %p
         Hound uses
@@ -426,7 +426,7 @@
               ignore_file: .eslintignore
 
     %article.docs-article#python
-      %h3 Python
+      %h2 Python
 
       %p
         Hound uses
@@ -464,7 +464,7 @@
               config_file: .flake8.ini
 
     %article.docs-article#tslint
-      %h3 TSLint
+      %h2 TSLint
       %p
         Hound uses
         = link_to "TSLint",
@@ -499,7 +499,7 @@
               config_file: tslint.json
 
     %article.docs-article#elixir
-      %h3 Elixir
+      %h2 Elixir
       %p
         Hound uses
         = link_to "Credo",
@@ -540,7 +540,7 @@
               config_file: .credo.exs
 
     %article.docs-article#sass-lint
-      %h3 Sass-lint
+      %h2 Sass-lint
       %p
         Hound uses
         = link_to "sass-lint",

--- a/app/views/repos/_onboarding.haml
+++ b/app/views/repos/_onboarding.haml
@@ -4,15 +4,17 @@
     %ol.onboarding-steps
       %li.step
         - if current_user.has_active_repos?
-          %h4= t("onboarding.step_one_alt_title", count: current_user.repos.active.count )
+          %strong
+            = t("onboarding.step_one_alt_title",
+              count: current_user.repos.active.count )
         - else
-          %h4= t("onboarding.step_one_title")
+          %strong= t("onboarding.step_one_title")
         %p
           = t("onboarding.step_one_desc")
           = link_to(t("onboarding.step_one_link"), account_path)
       %li.step.current-step
-        %h4= t("onboarding.step_two_title")
+        %strong= t("onboarding.step_two_title")
         %p= t("onboarding.step_two_desc")
       %li.step
-        %h4= t("onboarding.step_three_title")
+        %strong= t("onboarding.step_three_title")
         %p= t("onboarding.step_three_desc")


### PR DESCRIPTION
Properly marking up headings provides semantic meaning to things like
assistive technology. This also allows screen readers to navigate
through headings, providing screen reader users an efficient way to
find and parse content. Skipping heading levels, or marking up
non-headings in heading elements can lead to confusion.

This commit also changes content within two headings to better convey
the content in their section:

- "Hound keeps your code style in check." is now "Pricing."
- "Write code, submit a pull request, get review from Hound." is now
  "How it works."