### PR TITLE
DeprecatedHashMethods -> PreferredHashMethods

### DIFF
--- a/spec/support/fixtures/thoughtbot_rubocop_config.yml
+++ b/spec/support/fixtures/thoughtbot_rubocop_config.yml
@@ -65,7 +65,7 @@ CyclomaticComplexity:
 Delegate:
   Enabled: false
 
-DeprecatedHashMethods:
+PreferredHashMethods:
   Enabled: false
 
 Documentation:


### PR DESCRIPTION
Why:

RuboCop has renamed this key
https://github.com/bbatsov/rubocop/blob/master/CHANGELOG.md#changes-12

This PR:

Changes DeprecatedHashMethods to PreferredHashMethods