### PR TITLE
Remove unnecessary content_for helper

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -19,7 +19,7 @@
       .flash{ class: key }
         = value
 
-    .content{ class: content_for(:container_class) }
+    .content
       = yield
 
     = render "application/footer"

--- a/app/views/repos/index.haml
+++ b/app/views/repos/index.haml
@@ -1,5 +1,4 @@
 - content_for :page_title, 'Your Repos'
-- content_for :container_class, "repo-index"
 
 = render 'settings'
 


### PR DESCRIPTION
This is being used to inject the `repo-index` class, which is not used.