### PR TITLE
Simplify footer styling

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -1,22 +1,12 @@
-footer {
-  padding: 4em 1em;
+.app-footer {
+  padding: $large-spacing $base-spacing;
   text-align: center;
+}
 
-  ul.footer-nav {
-    margin-bottom: 4em;
+.app-footer__nav {
+  margin-bottom: $base-spacing;
+}
 
-    li {
-      display: inline-block;
-
-      ~ li::before {
-        border-left: 1px solid $base-border-color;
-        content: "";
-        display: inline-block;
-        height: 1em;
-        margin-left: 0.5em;
-        padding-left: 0.5em;
-        vertical-align: middle;
-      }
-    }
-  }
+.app-footer__nav-link:not(:first-of-type) {
+  margin-left: $base-spacing;
 }

--- a/app/views/application/_footer.haml
+++ b/app/views/application/_footer.haml
@@ -1,28 +1,32 @@
-%footer
-  %ul.footer-nav
-    %li
-      = link_to "Source Code", "https://github.com/houndci/hound"
-    %li
-      = link_to "FAQ", "https://intercom.help/hound/frequently-asked-questions"
-    %li
-      = link_to "Terms", "https://github.com/houndci/hound/blob/master/doc/TERMS.md"
-    %li
-      = link_to "Privacy", "https://github.com/houndci/hound/blob/master/doc/PRIVACY.md"
-    %li
-      = link_to "Security", "https://github.com/houndci/hound/blob/master/doc/SECURITY.md"
+%footer.app-footer{ role: "contentinfo" }
+  %nav.app-footer__nav
+    = link_to "Source Code",
+      "https://github.com/houndci/hound",
+      class: "app-footer__nav-link"
+    = link_to "FAQ",
+      "https://intercom.help/hound/frequently-asked-questions",
+      class: "app-footer__nav-link"
+    = link_to "Terms",
+      "https://github.com/houndci/hound/blob/master/doc/TERMS.md",
+      class: "app-footer__nav-link"
+    = link_to "Privacy",
+      "https://github.com/houndci/hound/blob/master/doc/PRIVACY.md",
+      class: "app-footer__nav-link"
+    = link_to "Security",
+      "https://github.com/houndci/hound/blob/master/doc/SECURITY.md",
+      class: "app-footer__nav-link"
 
-  %article.legal
-    %p
-      Hound is maintained by #{link_to 'thoughtbot', 'http://thoughtbot.com'}.
-      Questions? Try the
-      #{link_to "FAQ", "https://intercom.help/hound/frequently-asked-questions"}
-      or Tweet
-      #{link_to "@houndci", "https://twitter.com/houndci", new_window_options}.
+  %p
+    Hound is maintained by #{link_to "thoughtbot", "https://thoughtbot.com/"}.
+    Questions? Try the
+    #{link_to "FAQ", "https://intercom.help/hound/frequently-asked-questions"}
+    or tweet
+    #{link_to "@houndci", "https://twitter.com/houndci", new_window_options}.
 
-    %p
-      Hound is Copyright &copy; #{Date.today.year} thoughtbot. It is open source
-      software and may be redistributed under the terms specified in the
-      #{link_to "LICENSE", "https://github.com/houndci/hound/blob/master/LICENSE"}.
+  %p
+    Hound is Copyright &copy; #{Date.today.year} thoughtbot. It is open source
+    software and may be redistributed under the terms specified in the
+    #{link_to "license", "https://github.com/houndci/hound/blob/master/LICENSE"}.
 
-    %p
-      The names and logos for Hound are trademarks of thoughtbot.
+  %p
+    The names and logos for Hound are trademarks of thoughtbot.


### PR DESCRIPTION
- Remove unnecessary over-qualified CSS selectors, e.g. `ul.footer-nav`.
- Wrap navigation items in a proper `nav` element, which maps to the
  navigation role in the accessibility tree.
- Remove unnecessary `article` element.
- Consistently use double quotes.

## Before

![screen shot 2017-06-02 at 13 17 43](https://cloud.githubusercontent.com/assets/903327/26736898/e697c032-4795-11e7-9d35-540d54b4cc66.png)

## After

![screen shot 2017-06-02 at 13 17 29](https://cloud.githubusercontent.com/assets/903327/26736901/e8fd26d2-4795-11e7-84c5-249e8cd23498.png)
