### PR TITLE
Add a `main` landmark

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -19,7 +19,7 @@
       .flash{ class: key }
         = value
 
-    .content
+    %main.content{ role: "main" }
       = yield
 
     = render "application/footer"


### PR DESCRIPTION
Adding the `main` element helps to establish the semantic structure of
the document. It also maps to the `main` ARIA landmark, which some
assistive technologies like screen readers surface to the user and
allow them to navigate using them.

See: https://dequeuniversity.com/assets/html/jquery-summit/html5/slides/landmarks.html