### PR TITLE
Add private badge to repos list

### DIFF
--- a/app/assets/javascripts/components/repo.jsx
+++ b/app/assets/javascripts/components/repo.jsx
@@ -28,8 +28,7 @@ class Repo extends React.Component {
   render() {
     const { isProcessingId, repo } = this.props;
     const { active, id, name, price_in_cents } = repo;
-
-    const showPrivate = !active && price_in_cents > 0;
+    const showPrivate = price_in_cents > 0;
 
     return (
       <li
@@ -45,10 +44,13 @@ class Repo extends React.Component {
           {name}
         </div>
 
-        <div className={classNames(
-          "repo-activation-toggle",
-          {"repo-activation-toggle--private": showPrivate}
-        )}>
+        { showPrivate &&
+          <span className="badge margin-left-small">
+            Private
+          </span>
+        }
+
+        <div className="repo-activation-toggle">
           {this.renderButton()}
         </div>
       </li>

--- a/app/assets/stylesheets/components/_badge.scss
+++ b/app/assets/stylesheets/components/_badge.scss
@@ -1,0 +1,10 @@
+.badge {
+  border: 1px solid $light-gray;
+  border-radius: 3px;
+  color: $base-font-color;
+  display: inline-block;
+  font-size: $font-size-small;
+  line-height: 1;
+  margin: 0;
+  padding: 0.125em 0.25em;
+}

--- a/app/assets/stylesheets/components/_components.scss
+++ b/app/assets/stylesheets/components/_components.scss
@@ -1,6 +1,7 @@
 @import "allowance";
 @import "app-nav";
 @import "avatar";
+@import "badge";
 @import "button";
 @import "code";
 @import "footer";

--- a/app/assets/stylesheets/pages/repos/_index.scss
+++ b/app/assets/stylesheets/pages/repos/_index.scss
@@ -1,12 +1,9 @@
 .repo {
   @include clearfix;
+  align-items: center;
   border-top: 1px solid $base-border-color;
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
   padding: 1em;
-  position: relative;
-  width: 100%;
 
   @include media($small-screen-only) {
     display: block;
@@ -44,7 +41,7 @@
   color: $medium-font-color;
   font-size: 1.5em;
   font-weight: $font-weight-light;
-  height: 100%;
+  line-height: 1;
   padding-bottom: 2px;
   transition: $base-transition;
 
@@ -70,10 +67,6 @@
     padding: 0;
     text-align: left;
   }
-}
-
-.repo-activation-toggle--private {
-  min-width: 250px;
 }
 
 .repo-toggle {

--- a/app/assets/stylesheets/utilities/_margin.scss
+++ b/app/assets/stylesheets/utilities/_margin.scss
@@ -1,3 +1,7 @@
 .margin-right-x-small {
-  margin-right: $xsmall-spacing;
+  margin-right: $xsmall-spacing !important;
+}
+
+.margin-left-small {
+  margin-left: $small-spacing !important;
 }


### PR DESCRIPTION
This is an alternative approach to https://github.com/houndci/hound/pull/1296.

**Note:** This is just the design implementation. Functionality for the following items is still needed:

- The `ariaDescribedby` attribute in the React component doesn’t yet render anything.
- The `idName ` attribute in the React component doesn’t yet render anything.
- The logic for only rendering this badge when a repo is indeed private is not implemented (i.e. “Private” is showing on every single repo right now).

![screen shot 2017-06-02 at 16 38 04](https://cloud.githubusercontent.com/assets/903327/26743977/ec8b6676-47b1-11e7-8627-9f9c5bc2d05b.png)
