### PR TITLE
Update helper to use Resource objects

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -8,7 +8,7 @@ module Admin
 
     def navigation_resources
       Administrate::Namespace.new(namespace).resources.select do |resource|
-        DashboardManifest::DASHBOARDS.include?(resource)
+        DashboardManifest::DASHBOARDS.include?(resource.name)
       end
     end
 

--- a/app/views/admin/application/_navigation.html.haml
+++ b/app/views/admin/application/_navigation.html.haml
@@ -1,5 +1,5 @@
 %nav.navigation{ role: "navigation" }
   - navigation_resources.each do |resource|
     = link_to display_resource_name(resource),
-      [namespace, resource],
+      [namespace, resource.path],
       class: "navigation__link navigation__link--#{nav_link_state(resource)}"

--- a/spec/features/admin_authorization_spec.rb
+++ b/spec/features/admin_authorization_spec.rb
@@ -6,7 +6,8 @@ feature "Admin authorization" do
     admin = create(:user, username: "admin_user")
 
     sign_in_as(admin, token)
-    visit admin_bulk_customers_path
+    visit admin_blacklisted_pull_requests_path
+    click_link "Bulk Customers"
 
     expect(page).to have_admin_bulk_customers_header
   end


### PR DESCRIPTION
The Administrate update changed the return value from
`namespace.resources` to return an array of `Resource` objects instead
of resource names. This updates the helpers and ensures that if the
admin navigation gets clobbered in the future a test fails.