### PR TITLE
Simplify limiting of review body comment

### DIFF
--- a/app/models/review_body.rb
+++ b/app/models/review_body.rb
@@ -15,18 +15,7 @@ class ReviewBody
       output = HEADER
       room_left = MAX_BODY_LENGTH - output.size
 
-      errors.each do |error|
-        error_details = build_error_details(error, room_left - 1)
-
-        if error_details
-          room_left -= (error_details.size + 1)
-          output += "\n#{error_details}"
-        else
-          break
-        end
-      end
-
-      output
+      output + build_errors(errors, room_left)
     else
       ""
     end
@@ -35,6 +24,21 @@ class ReviewBody
   private
 
   attr_reader :errors
+
+  def build_errors(errors, room_left)
+    head, *tail = errors
+    error_details = "\n" + build_error_details(head, room_left - 1)
+
+    if (room_left - error_details.size) >= 0
+      if tail.any?
+        error_details + build_errors(tail, room_left - error_details.size)
+      else
+        error_details
+      end
+    else
+      ""
+    end
+  end
 
   def build_error_details(error, room_left)
     summary = error_summary(error)

--- a/app/models/review_body.rb
+++ b/app/models/review_body.rb
@@ -2,9 +2,9 @@
 class ReviewBody
   MAX_BODY_LENGTH = 65536
   SUMMARY_LENGTH = 80
-  LINE_DELIMITER = "<br>"
   HEADER = "Some files could not be reviewed due to errors:"
-  DETAILS_FORMAT = "<details><summary>%s</summary><pre>%s</pre></details>"
+  DETAILS_FORMAT = "<details>\n<summary>%s</summary>\n<pre>%s</pre>\n</details>"
+  FORMAT_PLACEHOLDER_CHARCTERS = 4
 
   def initialize(errors)
     @errors = errors
@@ -12,8 +12,21 @@ class ReviewBody
 
   def to_s
     if errors.any?
-      error_details = errors.map { |error| build_error_details(error) }
-      [HEADER].concat(error_details).join
+      output = HEADER
+      room_left = MAX_BODY_LENGTH - output.size
+
+      errors.each do |error|
+        error_details = build_error_details(error, room_left - 1)
+
+        if error_details
+          room_left -= (error_details.size + 1)
+          output += "\n#{error_details}"
+        else
+          break
+        end
+      end
+
+      output
     else
       ""
     end
@@ -23,33 +36,17 @@ class ReviewBody
 
   attr_reader :errors
 
-  def build_error_details(error)
+  def build_error_details(error, room_left)
     summary = error_summary(error)
-    details = error[0...(allowed_error_length - summary.length)].
-      lines.
-      map(&:rstrip).
-      join(LINE_DELIMITER)
+    allowed_size = room_left -
+      (summary.size + DETAILS_FORMAT.size - FORMAT_PLACEHOLDER_CHARCTERS)
 
-    sprintf(DETAILS_FORMAT, summary, details)
+    if allowed_size > 0
+      sprintf(DETAILS_FORMAT, summary, error[0...allowed_size])
+    end
   end
 
   def error_summary(error)
     error.lines.first.strip.truncate(SUMMARY_LENGTH)
-  end
-
-  def allowed_error_length
-    (MAX_BODY_LENGTH - formatting_characters_size) / errors.size
-  end
-
-  def formatting_characters_size
-    HEADER.length + all_detail_formats_length + all_lines_delimiters_length
-  end
-
-  def all_detail_formats_length
-    DETAILS_FORMAT.size * errors.size
-  end
-
-  def all_lines_delimiters_length
-    (errors.flat_map(&:lines).size - errors.size) * LINE_DELIMITER.length
   end
 end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -79,11 +79,18 @@ describe PullRequest do
             body: violation.messages.join,
           },
         ],
-        "Some files could not be reviewed due to errors:" \
-          "<details><summary>invalid config</summary>" \
-          "<pre>invalid config</pre></details>" \
-          "<details><summary>foo</summary>" \
-          "<pre>foo<br>  bar</pre></details>",
+        <<~EOS.chomp
+          Some files could not be reviewed due to errors:
+          <details>
+          <summary>invalid config</summary>
+          <pre>invalid config</pre>
+          </details>
+          <details>
+          <summary>foo</summary>
+          <pre>foo
+            bar</pre>
+          </details>
+        EOS
       )
     end
   end

--- a/spec/models/review_body_spec.rb
+++ b/spec/models/review_body_spec.rb
@@ -18,34 +18,45 @@ RSpec.describe ReviewBody do
 
         result = review_body.to_s
 
-        expect(result).to eq(
-          "Some files could not be reviewed due to errors:" \
-            "<details><summary>invalid config</summary>" \
-            "<pre>invalid config</pre></details>" \
-            "<details><summary>foo</summary>" \
-            "<pre>foo<br>  bar</pre></details>",
-        )
+        expect(result).to eq <<~EOS.chomp
+          Some files could not be reviewed due to errors:
+          <details>
+          <summary>invalid config</summary>
+          <pre>invalid config</pre>
+          </details>
+          <details>
+          <summary>foo</summary>
+          <pre>foo
+            bar</pre>
+          </details>
+        EOS
       end
 
       context "when errors are too long" do
         it "truncates the errors" do
-          stub_const("ReviewBody::MAX_BODY_LENGTH", 200)
+          stub_const("ReviewBody::HEADER", "errs")
+          stub_const("ReviewBody::DETAILS_FORMAT", "%s:\n'%s'")
+          stub_const("ReviewBody::SUMMARY_LENGTH", 5)
+          stub_const("ReviewBody::MAX_BODY_LENGTH", 40)
           review_body = ReviewBody.new(
             [
-              "invalid config",
-              "rule is unknown\n  MyRule",
+              "err1\n  foo",
+              "err2\n  bar\n  baz",
             ],
           )
 
           result = review_body.to_s
 
-          expect(result).to eq(
-            "Some files could not be reviewed due to errors:" \
-              "<details><summary>invalid config</summary>" \
-              "<pre>invalid</pre></details>" \
-              "<details><summary>rule is unknown</summary>" \
-              "<pre>rule i</pre></details>",
-          )
+          expect(result.size).to eq 40
+          expect(result).to eq <<~EOS.chomp
+            errs
+            err1:
+            'err1
+              foo'
+            err2:
+            'err2
+              b'
+          EOS
         end
       end
     end

--- a/spec/requests/builds_spec.rb
+++ b/spec/requests/builds_spec.rb
@@ -25,11 +25,13 @@ RSpec.describe "POST /builds" do
 
       post builds_path, params: { payload: payload }
 
-      expect(FakeGithub.review_body).to eq(
-        "Some files could not be reviewed due to errors:" \
-        "<details><summary>invalid config syntax</summary>" \
-        "<pre>invalid config syntax</pre></details>",
-      )
+      expect(FakeGithub.review_body).to eq <<~EOS.chomp
+        Some files could not be reviewed due to errors:
+        <details>
+        <summary>invalid config syntax</summary>
+        <pre>invalid config syntax</pre>
+        </details>
+      EOS
       expect(FakeGithub.comments).to match_array [
         {
           body: new_violation1[:message],


### PR DESCRIPTION
The previous algorithm wasn't quite correct and difficult to understand.
This simplifies it a bit, and only displays the errors that fit within
the character limit.

Also, simplify the line delimiter to be newline `\n` character rather
than `<br>` tag.