### PR TITLE
Change primary typeface

### DIFF
--- a/app/assets/stylesheets/base/_base.scss
+++ b/app/assets/stylesheets/base/_base.scss
@@ -3,6 +3,7 @@
 @import "animations";
 @import "buttons";
 @import "extends";
+@import "fonts";
 @import "forms";
 @import "helpers";
 @import "tables";

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -1,0 +1,55 @@
+$_font-host-url: "http://font.thoughtbot.com/hound/";
+
+@include font-face(
+  "Tofino",
+  "#{$_font-host-url}Tofino-Book",
+  $asset-pipeline: false
+) {
+  font-style: normal;
+  font-weight: $font-weight-book;
+}
+
+@include font-face(
+  "Tofino",
+  "#{$_font-host-url}Tofino-BookItalic",
+  $asset-pipeline: false
+) {
+  font-style: italic;
+  font-weight: $font-weight-book;
+}
+
+@include font-face(
+  "Tofino",
+  "#{$_font-host-url}Tofino-Regular",
+  $asset-pipeline: false
+) {
+  font-style: normal;
+  font-weight: $font-weight-regular;
+}
+
+@include font-face(
+  "Tofino",
+  "#{$_font-host-url}Tofino-RegularItalic",
+  $asset-pipeline: false
+) {
+  font-style: italic;
+  font-weight: $font-weight-regular;
+}
+
+@include font-face(
+  "Tofino",
+  "#{$_font-host-url}Tofino-Medium",
+  $asset-pipeline: false
+) {
+  font-style: normal;
+  font-weight: $font-weight-medium;
+}
+
+@include font-face(
+  "Tofino",
+  "#{$_font-host-url}Tofino-MediumItalic",
+  $asset-pipeline: false
+) {
+  font-style: italic;
+  font-weight: $font-weight-medium;
+}

--- a/app/assets/stylesheets/base/_forms.scss
+++ b/app/assets/stylesheets/base/_forms.scss
@@ -1,3 +1,4 @@
-#{$all-text-inputs} {
+#{$all-text-inputs},
+select {
   font-family: $font-family-default;
 }

--- a/app/assets/stylesheets/base/_tables.scss
+++ b/app/assets/stylesheets/base/_tables.scss
@@ -20,8 +20,7 @@ table {
   th {
     background-color: $_table-heading-background-color;
     font-size: 0.8em;
-    font-weight: 600;
-    letter-spacing: 1px;
+    font-weight: $font-weight-medium;
     padding: 1em 1.4em;
     text-transform: uppercase;
   }

--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -3,8 +3,8 @@ body {
   color: $base-font-color;
   font-family: $font-family-default;
   font-size: 1em;
-  font-weight: $font-weight-light;
-  line-height: $base-line-height;
+  font-weight: $font-weight-book;
+  line-height: $line-height-default;
 }
 
 a {
@@ -28,25 +28,23 @@ h3,
 h4,
 h5,
 h6 {
-  line-height: normal;
+  font-family: $font-family-heading;
+  font-weight: $font-weight-regular;
+  line-height: $line-height-heading;
   margin-top: 0;
 }
 
 h1 {
   font-size: 3em;
-  font-weight: $font-weight-light;
-  letter-spacing: 1px;
   margin: 0 0 0.4em;
 }
 
 h2 {
   font-size: 1.2em;
-  font-weight: $font-weight-light;
-  letter-spacing: 1px;
 }
 
 p {
-  margin: 0 0 1em;
+  margin: 0 0 1.25em;
 }
 
 ul,
@@ -54,6 +52,10 @@ ol {
   list-style: none;
   margin: 0;
   padding: 0;
+}
+
+strong {
+  font-weight: $font-weight-medium;
 }
 
 figure {

--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -1,10 +1,10 @@
-$font-family-default: "Lato", $font-stack-system;
-$font-family-heading: $font-stack-georgia;
+$font-family-default: "Tofino", $font-stack-system;
+$font-family-heading: $font-family-default;
 $font-family-code: $font-stack-monaco;
 
-$font-weight-light: 300;
-$font-weight-normal: 400;
-$font-weight-bold: 700;
+$font-weight-book: 300;
+$font-weight-regular: 400;
+$font-weight-medium: 500;
 
 $font-size-small: 0.875em;
 $font-size-base: 1em;
@@ -13,7 +13,8 @@ $font-size-large: 2.7em;
 $font-size-xlarge: 3em;
 $font-size-xxlarge: 3.8em;
 
-$base-line-height: 1.4;
+$line-height-default: 1.7;
+$line-height-heading: 1.3;
 
 $black: #000;
 $gold: rgb(226, 206, 0);
@@ -56,9 +57,6 @@ $small-spacing: $base-spacing * 0.75;
 $medium-spacing: $base-spacing * 1.5;
 $large-spacing: $base-spacing * 3;
 
-$letter-spacing-base: 1px;
-$letter-spacing-large: 2px;
-
 // Focus
 $focus-outline-color: transparentize($base-accent-color, 0.4);
 $focus-outline-width: 3px;
@@ -69,3 +67,9 @@ $focus-outline-offset: 2px;
 $base-transition-timing: 0.2s;
 $base-easing: cubic-bezier(0.39, 0.575, 0.565, 1);
 $base-transition: all $base-transition-timing $base-easing;
+
+// Bourbon library settings
+$bourbon: (
+  "global-font-file-formats": "woff",
+  "rails-asset-pipeline": true,
+);

--- a/app/assets/stylesheets/components/_app-nav.scss
+++ b/app/assets/stylesheets/components/_app-nav.scss
@@ -1,7 +1,7 @@
 $_app-nav-layout-breakpoint: 42em;
 
 .app-nav {
-  font-weight: $font-weight-normal;
+  font-weight: $font-weight-regular;
 
   a {
     color: $base-font-color;

--- a/app/assets/stylesheets/components/_button.scss
+++ b/app/assets/stylesheets/components/_button.scss
@@ -7,7 +7,7 @@
   display: inline-block;
   font-family: $font-family-default;
   font-size: modular-scale(0);
-  font-weight: $font-weight-normal;
+  font-weight: $font-weight-regular;
   padding: modular-scale(-2) modular-scale(1);
   text-decoration: none;
   transition: background-color $base-transition-timing $base-easing,

--- a/app/assets/stylesheets/components/_pricing.scss
+++ b/app/assets/stylesheets/components/_pricing.scss
@@ -78,7 +78,6 @@
 .plan-price {
   color: $base-accent-color;
   font-size: 2.3em;
-  font-weight: $font-weight-light;
   line-height: 1;
 
   @include media($medium-large-screen-only) {

--- a/app/assets/stylesheets/pages/_builds.scss
+++ b/app/assets/stylesheets/pages/_builds.scss
@@ -4,7 +4,7 @@
   border-bottom-left-radius: $base-border-radius - 1px;
   border-bottom-right-radius: $base-border-radius - 1px;
   border-top: 2px solid $base-border-color;
-  font-weight: $font-weight-normal;
+  font-weight: $font-weight-regular;
   padding: $small-spacing 0;
   text-align: center;
   transition: $base-transition;
@@ -37,7 +37,7 @@
 
 .build-pull-request,
 .build-sha {
-  font-weight: $font-weight-light;
+  font-weight: $font-weight-book;
 }
 
 .build-time {
@@ -58,8 +58,7 @@
 
 .build-org-repo {
   font-size: 1.2em;
-  font-weight: 700;
-  letter-spacing: 1px;
+  font-weight: $font-weight-medium;
 }
 
 .build-time,

--- a/app/assets/stylesheets/pages/accounts/_show.scss
+++ b/app/assets/stylesheets/pages/accounts/_show.scss
@@ -29,7 +29,6 @@
 
   .update-card {
     float: right;
-    font-weight: $font-weight-light;
 
     i.fa {
       display: inline-block;
@@ -71,7 +70,6 @@
 
   input[type="text"],
   input[type="email"] {
-    font-weight: $font-weight-light;
     min-width: 20em;
     padding: 0.5em;
   }

--- a/app/assets/stylesheets/pages/home/_home-hero.scss
+++ b/app/assets/stylesheets/pages/home/_home-hero.scss
@@ -17,8 +17,6 @@
 
 .home-hero-heading {
   font-size: $font-size-xxlarge;
-  font-weight: $font-weight-light;
-  letter-spacing: $letter-spacing-base;
   margin-bottom: $xsmall-spacing;
 
   @include media($medium-screen-down) {
@@ -32,8 +30,6 @@
 
 .home-hero-subheading {
   font-size: $font-size-base;
-  font-weight: $font-weight-light;
-  letter-spacing: $letter-spacing-base;
   margin-bottom: 0;
 
   @include media($medium-screen-up) {

--- a/app/assets/stylesheets/pages/home/_home-languages.scss
+++ b/app/assets/stylesheets/pages/home/_home-languages.scss
@@ -34,8 +34,7 @@
   background: $white;
   display: inline-block;
   font-family: $font-family-heading;
-  font-style: italic;
-  font-weight: $font-weight-light;
+  font-weight: $font-weight-book;
   margin: 2px 0 $base-spacing;
   padding: 0 $small-spacing;
   position: relative;
@@ -79,9 +78,5 @@
 }
 
 .home-languages-list-item-heading {
-  font-size: $font-size-small;
-  font-weight: $font-weight-bold;
-  letter-spacing: $letter-spacing-large;
   margin-bottom: 0;
-  text-transform: uppercase;
 }

--- a/app/assets/stylesheets/pages/home/_home-objects.scss
+++ b/app/assets/stylesheets/pages/home/_home-objects.scss
@@ -13,15 +13,12 @@
   }
 
   p {
-    letter-spacing: $letter-spacing-base;
     margin: 0;
   }
 }
 
 .home-heading--large {
   font-size: 1.8em;
-  font-weight: $font-weight-light;
-  letter-spacing: $letter-spacing-base;
   margin-bottom: $xsmall-spacing;
 
   @include media($medium-screen-up) {
@@ -35,7 +32,6 @@
 
 .home-heading--small {
   font-size: $font-size-medium;
-  font-weight: $font-weight-bold;
-  letter-spacing: $letter-spacing-base;
+  font-weight: $font-weight-medium;
   margin-bottom: $xsmall-spacing;
 }

--- a/app/assets/stylesheets/pages/repos/_index.scss
+++ b/app/assets/stylesheets/pages/repos/_index.scss
@@ -28,7 +28,6 @@
   @include ellipsis;
   color: $medium-font-color;
   font-size: 1.5em;
-  font-weight: $font-weight-light;
   line-height: 1;
   padding-bottom: 2px;
   transition: $base-transition;
@@ -36,8 +35,7 @@
   @include media($small-screen-only) {
     display: block;
     font-size: 1.2em;
-    font-weight: $font-weight-normal;
-    letter-spacing: 1px;
+    font-weight: $font-weight-regular;
     margin-bottom: 0.6em;
   }
 }
@@ -63,8 +61,7 @@
   border-radius: 20px;
   color: $purple;
   display: inline-block;
-  font-weight: $font-weight-normal;
-  letter-spacing: 1px;
+  font-weight: $font-weight-regular;
   padding: 0.4em 1em;
   text-align: center;
   transition: none;

--- a/app/assets/stylesheets/pages/repos/_onboarding.scss
+++ b/app/assets/stylesheets/pages/repos/_onboarding.scss
@@ -56,7 +56,7 @@
       color: $base-accent-color;
       counter-increment: step;
       content: counter(step);
-      font-weight: 600;
+      font-weight: $font-weight-medium;
       font-size: 0.8em;
       line-height: 20px;
       text-align: center;
@@ -70,7 +70,7 @@
 
     h4 {
       color: $base-font-color;
-      font-weight: 600;
+      font-weight: $font-weight-medium;
       margin-bottom: 0.4em;
     }
 

--- a/app/assets/stylesheets/pages/repos/_organization.scss
+++ b/app/assets/stylesheets/pages/repos/_organization.scss
@@ -60,8 +60,7 @@ $dropdown-arrow: $white image-url("select-arrow.svg") no-repeat;
 
 .organization-header-title {
   @include ellipsis;
-  font-weight: bold;
-  letter-spacing: 0;
+  font-weight: $font-weight-medium;
   line-height: 1.4;
   margin-bottom: 0;
 }

--- a/app/assets/stylesheets/pages/repos/_tools.scss
+++ b/app/assets/stylesheets/pages/repos/_tools.scss
@@ -27,9 +27,8 @@
   box-sizing: border-box;
   color: $base-font-color;
   display: block;
-  font-weight: $font-weight-normal;
+  font-weight: $font-weight-regular;
   height: 60px;
-  letter-spacing: 1px;
   margin: 0;
   padding: 0.8em 1em;
   transition: $base-transition;
@@ -37,8 +36,7 @@
 
   &::placeholder {
     color: $base-font-color;
-    font-weight: $font-weight-normal;
-    letter-spacing: 1px;
+    font-weight: $font-weight-regular;
     transition: color $base-transition-timing $base-easing;
   }
 
@@ -84,9 +82,8 @@
   border-radius: 3px;
   color: $base-font-color;
   font-size: 1em;
-  font-weight: $font-weight-normal;
+  font-weight: $font-weight-regular;
   height: 60px;
-  letter-spacing: 1px;
   margin: 0;
   padding: 0.8em 1em;
   text-align: center;

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -6,8 +6,6 @@
       = [content_for(:page_title), "Hound"].compact.uniq.join(" - ")
     - if content_for? :meta_description
       %meta{ content: content_for(:meta_description) }
-    %link{ href: "https://fonts.googleapis.com/css?family=Lato:300,400,700",
-           rel: "stylesheet" }
     = stylesheet_link_tag    "application", :media => "all"
     = javascript_include_tag "https://js.stripe.com/v2/"
     = javascript_include_tag "https://checkout.stripe.com/checkout.js"


### PR DESCRIPTION
I find Lato—the current typeface used across the app—to be a tad too friendly and wobbly (the flow and alignment between characters is inconsistent); lacking structure. Given those characteristics, this makes text feel disjointed from the strong, hefty Hound logo. I also find Lato to be quite thin and hard to read sometimes.

I recently came across the [Tofino](http://tofino.losttype.com/) typeface and tried it out on the Hound app. I think improves readability, but also pairs really well with the Hound logo. Even better, we can remove a bunch of CSS that tweaked letter spacing because Tofino is better built.

**Note:** I only have a free trial/personal version of Tofino, which I used to try it out on the app. We’d need to purchase a commercial license which is a flat $80, and also add it as a webfont to the app (which is why I labeled this as a WIP).

![2017-06-23 14 50 32](https://user-images.githubusercontent.com/903327/27496273-6aa0d7b8-5823-11e7-904a-d597a72a8346.gif)

---

**With Tofino:**

![houndci com-home-tofino](https://user-images.githubusercontent.com/903327/27496408-cc4a16dc-5823-11e7-929b-8fcc33609a4b.png)
