### PR TITLE
Update dotenv gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,9 +100,10 @@ GEM
     diff-lcs (1.2.5)
     domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (2.0.1)
-    dotenv-rails (2.0.1)
-      dotenv (= 2.0.1)
+    dotenv (2.2.1)
+    dotenv-rails (2.2.1)
+      dotenv (= 2.2.1)
+      railties (>= 3.2, < 5.2)
     email_validator (1.6.0)
       activemodel
     erubis (2.7.0)


### PR DESCRIPTION
Test were failing locally, because `.env.local` was not being ignored
when tests run. Seems to be fixed on upgrade.