### PR TITLE
Remove unused PullRequest method

### DIFF
--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -23,10 +23,6 @@ class PullRequest
     )
   end
 
-  def repository_owner_name
-    payload.repository_owner_name
-  end
-
   def opened?
     payload.action == "opened"
   end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -74,7 +74,6 @@ describe StyleChecker do
       file_content: "",
       head_commit: stubbed_head_commit,
       commit_files: [],
-      repository_owner_name: "some_org"
     }
 
     double("PullRequest", defaults.merge(options))

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -243,7 +243,6 @@ describe BuildRunner do
         config: double(:config),
         opened?: true,
         head_commit: head_commit,
-        repository_owner_name: "test",
       )
       allow(PullRequest).to receive(:new).and_return(pull_request)
 


### PR DESCRIPTION
Looks like `PullRequest#repository_owner_name` was removed in 68e3136 and is no longer referenced.