### PR TITLE
Accept invitation when added as collaborator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     administrate (0.8.1)
       actionpack (>= 4.2, < 5.2)
       actionview (>= 4.2, < 5.2)
@@ -207,7 +207,7 @@ GEM
       activerecord (>= 4.0, < 5.1)
     pathspec (0.1.0)
     pg (0.19.0)
-    public_suffix (2.0.5)
+    public_suffix (3.0.0)
     puma (3.9.1)
     rack (2.0.3)
     rack-protection (2.0.0)
@@ -415,4 +415,4 @@ RUBY VERSION
    ruby 2.3.4p301
 
 BUNDLED WITH
-   1.15.3
+   1.15.4

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -61,6 +61,11 @@ class RepoActivator
 
   def add_hound_to_repo
     github.add_collaborator(repo.name, Hound::GITHUB_USERNAME)
+    hound_github.accept_invitation(repo.name)
+  end
+
+  def hound_github
+    @hound_github ||= GithubApi.new(Hound::GITHUB_TOKEN)
   end
 
   def github

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -108,21 +108,22 @@ class GithubApi
     )
   end
 
+  def accept_invitation(repo_name)
+    repo_invitation = find_invitation_for_repo(repo_name)
+
+    if repo_invitation
+      accept_repository_invitation(repo_invitation)
+    else
+      raise "Invitation for Hound to #{repo_name} not found"
+    end
+  end
+
   def add_collaborator(repo_name, username)
-    client.add_collaborator(
-      repo_name,
-      username,
-      accept: "application/vnd.github.ironman-preview+json",
-    )
+    client.add_collaborator(repo_name, username)
   end
 
   def remove_collaborator(repo_name, username)
-    # not sure if we need the accept header
-    client.remove_collaborator(
-      repo_name,
-      username,
-      accept: "application/vnd.github.ironman-preview+json",
-    )
+    client.remove_collaborator(repo_name, username)
   end
 
   def repository?(repo_name)
@@ -146,5 +147,22 @@ class GithubApi
       description: description,
       target_url: target_url
     )
+  end
+
+  def find_invitation_for_repo(repo_name)
+    invitations = client.user_repository_invitations(
+      accept: "application/vnd.github.swamp-thing-preview",
+    )
+    invitations.detect do |invitation|
+      invitation.repository.full_name == repo_name
+    end
+  end
+
+  def accept_repository_invitation(invitation)
+    response = client.accept_repository_invitation(
+      invitation.id,
+      accept: "application/vnd.github.swamp-thing-preview",
+    )
+    response == ""
   end
 end

--- a/spec/features/plans_spec.rb
+++ b/spec/features/plans_spec.rb
@@ -53,6 +53,7 @@ feature "Plans" do
 
     repo = create(:repo, private: true)
     create(:membership, admin: true, repo: repo, user: user)
+    stub_repository_invitations(repo.name)
     stub_customer_find_request
     stub_subscription_create_request(plan: "tier1", repo_ids: repo.id)
     stub_subscription_update_request(plan: "tier2", repo_ids: repo.id)

--- a/spec/features/user_activates_a_repo_spec.rb
+++ b/spec/features/user_activates_a_repo_spec.rb
@@ -6,6 +6,7 @@ RSpec.feature "User activates a repo", :js do
     repo = create(:repo, :private, name: "foo/bar")
     create(:bulk_customer, org: "foo")
     create(:membership, :admin, repo: repo, user: user)
+    stub_repository_invitations(repo.name)
 
     sign_in_as(user, "letmein")
     click_on "Activate"
@@ -39,6 +40,7 @@ RSpec.feature "User activates a repo", :js do
     stub_customer_find_request
     stub_subscription_create_request(plan: current_plan, repo_ids: repo.id)
     stub_subscription_update_request(plan: upgraded_plan, repo_ids: repo.id)
+    stub_repository_invitations(repo.name)
 
     sign_in_as(user, "letmein")
     click_on "Activate"

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -79,6 +79,8 @@ describe RepoActivator do
 
           expect(api).to have_received(:add_collaborator).
             with(repo.name, Hound::GITHUB_USERNAME)
+          expect(api).to have_received(:accept_invitation).
+            with(repo.name)
         end
 
         it "marks repo as active" do
@@ -224,7 +226,12 @@ describe RepoActivator do
       it "does not raise" do
         repo = build(:repo, private: true)
         activator = build_activator(repo: repo)
-        github = double("GithubApi", create_hook: nil, add_collaborator: true)
+        github = instance_double(
+          "GithubApi",
+          create_hook: nil,
+          add_collaborator: nil,
+          accept_invitation: true,
+        )
         allow(GithubApi).to receive(:new).and_return(github)
 
         expect { activator.activate }.not_to raise_error
@@ -354,11 +361,15 @@ describe RepoActivator do
   end
 
   def stub_github_api
+    api = instance_double(
+      "GithubApi",
+      remove_hook: true,
+      add_collaborator: nil,
+      remove_collaborator: true,
+      accept_invitation: true,
+    )
     hook = double(:hook, id: 1)
-    api = double(:github_api, remove_hook: true)
     allow(api).to receive(:create_hook).and_yield(hook)
-    allow(api).to receive(:add_collaborator).and_return(true)
-    allow(api).to receive(:remove_collaborator).and_return(true)
     allow(GithubApi).to receive(:new).and_return(api)
     api
   end

--- a/spec/support/fake_github.rb
+++ b/spec/support/fake_github.rb
@@ -4,6 +4,10 @@ class FakeGithub < Sinatra::Base
   cattr_accessor :comments, :review_body
   self.comments = []
 
+  patch "/user/repository_invitations/:invitation_id" do
+    status 204
+  end
+
   put "/repos/:owner/:repo/collaborators/:username" do
     status 204
   end

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -83,8 +83,6 @@ module GithubApiHelper
       )
   end
 
-  private
-
   def stub_repos_requests(token)
     repos_url = "https://api.github.com/user/repos"
 
@@ -165,6 +163,17 @@ module GithubApiHelper
       body: status_request_body(description, state, target_url),
     ).to_return(status_request_return_value)
   end
+
+  def stub_repository_invitations(repo_name)
+    url = "https://api.github.com/user/repository_invitations?per_page=100"
+    stub_request(:get, url).
+      to_return(
+        headers: { "Content-Type" => "application/json; charset=utf-8" },
+        body: [{ id: 1234, repository: { full_name: repo_name } }].to_json,
+      )
+  end
+
+  private
 
   def status_request_return_value
     {


### PR DESCRIPTION
When collaboratore is added to a repo, GitHub now requires the
collaborator to accept the invitation.

This is keeping us from allowing users to activate their repos.