### PR TITLE
Use non-predicate attributes for Administrate

### DIFF
--- a/app/dashboards/owner_dashboard.rb
+++ b/app/dashboards/owner_dashboard.rb
@@ -10,11 +10,11 @@ class OwnerDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
-    organization?: Field::Boolean,
-    whitelisted?: Field::Boolean,
-    config_enabled?: Field::Boolean,
+    organization: Field::Boolean,
+    whitelisted: Field::Boolean,
+    config_enabled: Field::Boolean,
     config_repo: Field::String,
-    private_active_repos_count: Field::Number,
+    active_private_repos_count: Field::Number,
   }
 
   # COLLECTION_ATTRIBUTES
@@ -24,9 +24,9 @@ class OwnerDashboard < Administrate::BaseDashboard
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = [
     :name,
-    :private_active_repos_count,
-    :whitelisted?,
-    :config_enabled?,
+    :active_private_repos_count,
+    :whitelisted,
+    :config_enabled,
     :config_repo,
   ]
 
@@ -39,8 +39,8 @@ class OwnerDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :name,
-    :whitelisted?,
-    :config_enabled?,
+    :whitelisted,
+    :config_enabled,
     :config_repo,
   ]
 

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -20,8 +20,8 @@ class Owner < ApplicationRecord
     raise exception
   end
 
-  def private_active_repos_count
-    repos.active.where(private: true).count
+  def active_private_repos_count
+    repos.active.private.count
   end
 
   def has_config_repo?

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -11,6 +11,10 @@ class Repo < ApplicationRecord
     where(active: true)
   end
 
+  def self.private
+    where(private: true)
+  end
+
   def self.find_or_create_with(attributes)
     repo = find_by(github_id: attributes[:github_id]) ||
       find_by(name: attributes[:name]) ||

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@ en:
   helpers:
     label:
       owner:
-        private_active_repos_count: Private active repos
+        active_private_repos_count: Active private repos
 
   sync_repos: "Refresh repo list"
   include_private_repos: "Include private repos"


### PR DESCRIPTION
The predicate version of attributes don't sort or update properly.

Also, `active_private_repos_count` reads slighly more natural than
`private_active_repos_count`.