### PR TITLE
Ignore GitHub status update errors

### DIFF
--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -7,28 +7,38 @@ class CommitStatus
 
   def set_pending
     github.create_pending_status(repo_name, sha, I18n.t(:pending_status))
+  rescue Octokit::NotFound
+    # noop
   end
 
   def set_success(violation_count)
     message = I18n.t(:complete_status, count: violation_count)
     github.create_success_status(repo_name, sha, message)
+  rescue Octokit::NotFound
+    # noop
   end
 
   def set_failure(violation_count)
     message = I18n.t(:complete_status, count: violation_count)
-    github.create_error_status(repo_name, sha, message)
+    create_error_status(repo_name, sha, message)
   end
 
   def set_config_error(message)
-    github.create_error_status(repo_name, sha, message, configuration_url)
+    create_error_status(repo_name, sha, message, configuration_url)
   end
 
   def set_internal_error
     message = I18n.t(:hound_error_status)
-    github.create_error_status(repo_name, sha, message)
+    create_error_status(repo_name, sha, message)
   end
 
   private
+
+  def create_error_status(repo_name, sha, message, configuration_url = nil)
+    github.create_error_status(repo_name, sha, message, configuration_url)
+  rescue Octokit::NotFound
+    # noop
+  end
 
   attr_reader :repo_name, :sha, :token
 

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -65,6 +65,7 @@ describe CommitStatus do
         repo_name,
         sha,
         I18n.t(:complete_status, count: violation_count),
+        nil,
       )
     end
   end
@@ -111,6 +112,7 @@ describe CommitStatus do
         repo_name,
         sha,
         I18n.t(:hound_error_status),
+        nil,
       )
     end
   end

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -50,6 +50,7 @@ describe CompleteBuild do
               build.repo_name,
               build.commit_sha,
               "1 violation found.",
+              nil,
             )
           end
         end


### PR DESCRIPTION
Sometimes the user's or Hound's token isn't privileged to set the
GitHub PR status for a given repo. Status isn't critical, and shouldn't
fail the rest of the build -- as long as we can access the files and
make comments.

We're actually seeing a lot of status "Not Found" errors that prevent
builds from finishing, thus this is measure to mitigate that.
This will reduce the job failure noise and allow us to identify which
repos we can't _actually_ review.