### PR TITLE
Handle Rails deprecation warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    database_cleaner (1.3.0)
+    database_cleaner (1.6.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     debugger-linecache (1.2.0)

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/hound
     docker:
-      - image: circleci/ruby:2.4-node
+      - image: circleci/ruby:2.4.1-node
         environment:
           RAILS_ENV: test
           CIRCLECI: true

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -19,7 +19,3 @@ ActiveSupport.to_time_preserves_timezone = false
 
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = false
-
-# Do not halt callback chains when a callback returns false. Previous versions
-# had true.
-ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
* Upgrade DatabaseCleaner to remove on the the deprecation warnigns
* `halt_callback_chains_on_return_false` is deprecated and will be
removed in Rails 5.2