### PR TITLE
Remove the private class method on Repo

### DIFF
--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -21,7 +21,7 @@ class Owner < ApplicationRecord
   end
 
   def active_private_repos_count
-    repos.active.private.count
+    repos.active.where(private: true).count
   end
 
   def has_config_repo?

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -11,10 +11,6 @@ class Repo < ApplicationRecord
     where(active: true)
   end
 
-  def self.private
-    where(private: true)
-  end
-
   def self.find_or_create_with(attributes)
     repo = find_by(github_id: attributes[:github_id]) ||
       find_by(name: attributes[:name]) ||


### PR DESCRIPTION
This clashes with Ruby's built-in `private`.
In stead of calling the `private` keyword, we effectively are calling
our class method and not hiding our methods.

Addresses #1442