### PR TITLE
Limit the number of builds ids for rebuild query

### DIFF
--- a/app/queries/recent_builds_by_repo_query.rb
+++ b/app/queries/recent_builds_by_repo_query.rb
@@ -1,5 +1,5 @@
 class RecentBuildsByRepoQuery
-  NUMBER_OF_BUILDS = 20
+  NUMBER_OF_BUILDS = 10
 
   static_facade :call
 
@@ -20,6 +20,7 @@ class RecentBuildsByRepoQuery
             ON repos.id = memberships.repo_id
         WHERE
           memberships.user_id = :user_id
+        LIMIT 1000
       ),
       recent_builds_by_pull_request AS (
         SELECT distinct ON (repo_id, pull_request_number)


### PR DESCRIPTION
10 unique latest builds seems like enough for most use-cases.
It's very likely that we can find 10 unique PR builds from the user's
last 1000 rebuilds, and this helps limit the first sub-query.