### PR TITLE
Remove database_cleaner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,7 +55,6 @@ end
 group :test do
   gem "capybara", ">= 2.4.0"
   gem "capybara-webkit", "~> 1.6"
-  gem "database_cleaner"
   gem "factory_girl_rails"
   gem "launchy"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,6 @@ GEM
     concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    database_cleaner (1.6.1)
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     debugger-linecache (1.2.0)
@@ -375,7 +374,6 @@ DEPENDENCIES
   capybara (>= 2.4.0)
   capybara-webkit (~> 1.6)
   coffee-rails
-  database_cleaner
   dotenv-rails
   email_validator
   factory_girl_rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,6 @@ RSpec.configure do |config|
   Analytics.backend = FakeAnalyticsRuby.new
 
   config.before do
-    DatabaseCleaner.clean
     stub_request(:any, /api.github.com/).to_rack(FakeGithub)
   end
 
@@ -19,6 +18,7 @@ RSpec.configure do |config|
 
   config.infer_base_class_for_anonymous_controllers = false
   config.infer_spec_type_from_file_location!
+  config.use_transactional_fixtures = true
   config.include AnalyticsHelper
   config.include AuthenticationHelper
   config.include CommitFileHelper
@@ -26,7 +26,6 @@ RSpec.configure do |config|
   config.include HttpsHelper
   config.include OauthHelper
   config.include FactoryGirl::Syntax::Methods
-  DatabaseCleaner.strategy = :truncation
   ActiveJob::Base.queue_adapter = :resque
 end
 


### PR DESCRIPTION
You want faster tests?
This is how you get faster tests!

P.S. Rails 5.1 now shares the database connection with test threads.