### PR TITLE
Handle Stripe hook for deleted subscription events

### DIFF
--- a/app/controllers/deleted_subscriptions_controller.rb
+++ b/app/controllers/deleted_subscriptions_controller.rb
@@ -1,0 +1,9 @@
+class DeletedSubscriptionsController < ApplicationController
+  skip_before_action :authenticate, only: :create
+
+  def create
+    DeleteSubscriptions.call(params)
+
+    head :ok
+  end
+end

--- a/app/services/delete_subscriptions.rb
+++ b/app/services/delete_subscriptions.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class DeleteSubscriptions
+  DELETED_EVENT_TYPE = "customer.subscription.deleted"
+
+  def initialize(params)
+    @params = params
+  end
+
+  def self.call(*args)
+    new(*args).call
+  end
+
+  def call
+    if event_type == DELETED_EVENT_TYPE
+      subscriptions.each do |subscription|
+        deactivate_repo(subscription) && subscription.destroy
+      end
+    end
+  end
+
+  private
+
+  attr_reader :params
+
+  def deactivate_repo(subscription)
+    RepoActivator.
+      new(repo: subscription.repo, github_token: subscription.user.token).
+      deactivate
+  end
+
+  def subscriptions
+    Subscription.where(stripe_subscription_id: subscription_id)
+  end
+
+  def subscription_id
+    params.dig("data", "object", "id")
+  end
+
+  def event_type
+    params.dig("type")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Houndapp::Application.routes.draw do
   resources :builds, only: [:create, :index]
   resources :owners, only: [:update]
   resources :plans, only: [:index]
+  resources :deleted_subscriptions, only: [:create]
 
   resources :repos, only: [:index] do
     with_options(defaults: { format: :json }) do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -73,13 +73,12 @@ FactoryGirl.define do
   end
 
   factory :subscription do
-    trait(:active) { association :repo, :active }
     trait(:inactive) { deleted_at { 1.day.ago } }
 
     sequence(:stripe_subscription_id) { |n| "stripesubscription#{n}" }
 
+    association :repo, :active, :private
     price Plan::PLANS[1][:price]
-    repo
     user
   end
 

--- a/spec/features/user_activates_a_repo_spec.rb
+++ b/spec/features/user_activates_a_repo_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "User activates a repo", :js do
     user = create(:user, :with_github_scopes, :stripe)
     repo = create(:repo, :private)
     create(:membership, :admin, repo: repo, user: user)
-    create(:subscription, :active, user: user)
+    create(:subscription, user: user)
     current_plan = user.current_plan.id
     upgraded_plan = user.next_plan.id
     stub_customer_find_request

--- a/spec/features/user_deactivates_a_repo_spec.rb
+++ b/spec/features/user_deactivates_a_repo_spec.rb
@@ -35,8 +35,8 @@ feature "user deactivates a repo", js: true do
 
   scenario "user deactivates within a plan" do
     user = create(:user, :with_github_scopes, :stripe)
-    first_subscription = create(:subscription, :active, user: user)
-    second_subscription = create(:subscription, :active, user: user)
+    first_subscription = create(:subscription, user: user)
+    second_subscription = create(:subscription, user: user)
     stub_customer_find_request
     stub_subscription_find_request(first_subscription)
     stub_subscription_find_request(second_subscription)
@@ -51,7 +51,7 @@ feature "user deactivates a repo", js: true do
   scenario "user downgrades to lower plan" do
     user = create(:user, :with_github_scopes, :stripe)
     5.times do
-      subscription = create(:subscription, :active, user: user)
+      subscription = create(:subscription, user: user)
       stub_subscription_find_request(subscription)
     end
     stub_customer_find_request
@@ -65,7 +65,7 @@ feature "user deactivates a repo", js: true do
 
   scenario "user downgrades to free tier" do
     user = create(:user, :with_github_scopes, :stripe)
-    subscription = create(:subscription, :active, user: user)
+    subscription = create(:subscription, user: user)
     stub_subscription_find_request(subscription)
     stub_customer_find_request
     stub_subscription_update_request(plan: "basic", repo_ids: "")

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,12 +8,11 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   Analytics.backend = FakeAnalyticsRuby.new
 
-  config.before do
-    stub_request(:any, /api.github.com/).to_rack(FakeGithub)
-  end
-
-  config.before :each, type: :request do
-    FakeGithub.comments = []
+  %i(request feature).each do |type|
+    config.before :each, type: type do
+      stub_request(:any, /api.github.com/).to_rack(FakeGithub)
+      FakeGithub.comments = []
+    end
   end
 
   config.infer_base_class_for_anonymous_controllers = false

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Subscriptions" do
+  context "when event is for subscription deleted" do
+    it "deletes all subscription records and deactivates their repos" do
+      user = create(:user, token: "foobar")
+      subscription = create(:subscription, user: user)
+      create(:membership, user: user, repo: subscription.repo)
+      params = {
+        "type": "customer.subscription.deleted",
+        "object": "event",
+        "data": {
+          "object": {
+            "id": subscription.stripe_subscription_id,
+            "object": "subscription",
+          },
+        },
+      }
+
+      post "/deleted_subscriptions", params: params
+
+      subscription.reload
+      expect(response).to be_ok
+      expect(subscription).to be_deleted
+      expect(subscription.repo).not_to be_active
+    end
+  end
+end

--- a/spec/services/delete_subscriptions_spec.rb
+++ b/spec/services/delete_subscriptions_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe DeleteSubscriptions do
+  describe ".call" do
+    context "when event is for deleted Stripe subscription" do
+      it "deletes all subscription records and deactivates their repos" do
+        subscription = create(:subscription)
+        another_subscription = create(
+          :subscription,
+          stripe_subscription_id: subscription.stripe_subscription_id,
+        )
+        params = {
+          "type" => described_class::DELETED_EVENT_TYPE,
+          "object" => "event",
+          "data" => {
+            "object" => {
+              "id" => subscription.stripe_subscription_id,
+              "object" => "subscription",
+            },
+          },
+        }
+
+        described_class.call(params)
+
+        expect(subscription.reload).to be_deleted
+        expect(another_subscription.reload).to be_deleted
+        expect(subscription.repo).not_to be_active
+        expect(another_subscription.repo).not_to be_active
+      end
+    end
+
+    context "when event is not for deleted Stripe subscription" do
+      it "does not delete subscription" do
+        subscription = create(:subscription)
+        params = {
+          "type" => "customer.subscription.updated",
+          "data" => {
+            "object" => {
+              "id" => subscription.stripe_subscription_id,
+              "object" => "subscription",
+            },
+          },
+        }
+
+        described_class.call(params)
+
+        expect(subscription.reload).not_to be_deleted
+        expect(subscription.repo).to be_active
+      end
+    end
+  end
+end


### PR DESCRIPTION
We sometimes delete/cancel user subscriptions directly from Stripe.
Stripe is nice enough to notify us of this via a webhook.
This ensures we cleanup properly on our end -- delete all the
subscriptions by the give stripe token and deactivate the related repos.