### PR TITLE
Add aliases for ScssLint and SassLint

### DIFF
--- a/app/services/resolve_config_aliases.rb
+++ b/app/services/resolve_config_aliases.rb
@@ -1,9 +1,12 @@
 class ResolveConfigAliases
   ALIASES = {
-    "javascript" => "jshint",
-    "java_script" => "jshint",
     "coffeescript" => "coffee_script",
+    "java_script" => "jshint",
+    "javascript" => "jshint",
     "python" => "flake8",
+    "sass-lint" => "sass_lint",
+    "scss-lint" => "scss",
+    "scss_lint" => "scss",
   }.freeze
 
   static_facade :call


### PR DESCRIPTION
Sometimes users will use the actual linter names in the config file.
We should support these to avoid confusion for our users.