### PR TITLE
Show linter versions in the configuration docs

### DIFF
--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -20,6 +20,7 @@ $black: #000;
 $gold: rgb(226, 206, 0);
 $green: rgb(132, 240, 156);
 $light-gray: rgb(230, 230, 230);
+$gray: rgb(136, 136, 136);
 $purple: rgb(168, 115, 209);
 $red: rgb(255, 123, 123);
 $white: #fff;

--- a/app/assets/stylesheets/pages/_docs.scss
+++ b/app/assets/stylesheets/pages/_docs.scss
@@ -50,3 +50,8 @@
     color: $base-accent-color;
   }
 }
+
+.version-number {
+  color: $gray;
+  font-size: 0.95rem;
+}

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,4 +2,8 @@ class PagesController < ApplicationController
   include HighVoltage::StaticPage
 
   skip_before_action :authenticate
+
+  def configuration
+    @versions = LinterVersion.all
+  end
 end

--- a/app/models/linter_version.rb
+++ b/app/models/linter_version.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+class LinterVersion
+  LINTERS_REPO_NAME = "houndci/linters"
+  LOCKFILE_TO_LINTERS = {
+    gemfile: %i(
+      flog
+      haml_lint
+      reek
+      rubocop
+      scss_lint
+      slim_lint
+    ),
+    yarn: %i(
+      coffeelint
+      eslint
+      jshint
+      sass-lint
+      stylelint
+      tslint
+    ),
+  }.freeze
+
+  def self.all
+    new.all
+  end
+
+  def all
+    LOCKFILE_TO_LINTERS.flat_map do |lockfile, linters|
+      linters.map do |linter|
+        [linter, send("version_from_#{lockfile}", linter)]
+      end
+    end.to_h
+  end
+
+  private
+
+  def version_from_gemfile(linter_name)
+    gemfile_content.
+      scan(/^ {4}#{linter_name} \((.*)\)/).
+      flatten.first || "N/A"
+  end
+
+  def version_from_yarn(linter_name)
+    yarn_content.
+      scan(/^#{linter_name}@(?:[^\n]+)\s+version\s"([\d\.]+)/).
+      flatten.
+      map { |version| Gem::Version.new(version) }.
+      max&.version || "N/A"
+  end
+
+  def gemfile_content
+    @_gemfile_content ||= file_content("Gemfile.lock")
+  end
+
+  def yarn_content
+    @_yarn_content ||= file_content("yarn.lock")
+  end
+
+  def file_content(file_name)
+    file = client.file_contents(LINTERS_REPO_NAME, file_name, "master")
+    if file&.content
+      Base64.decode64(file.content).force_encoding("UTF-8")
+    else
+      ""
+    end
+  end
+
+  def client
+    @_client ||= GitHubApi.new(nil)
+  end
+end

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -6,29 +6,29 @@
       %li
         = link_to "Hound", "#configuration", class: "docs-nav-link"
       %li
-        = link_to "Ruby", "#ruby", class: "docs-nav-link"
+        = link_to "RuboCop", "#ruby", class: "docs-nav-link"
       %li
-        = link_to "CoffeeScript", "#coffeescript", class: "docs-nav-link"
-      %li
-        = link_to "JavaScript", "#javascript", class: "docs-nav-link"
-      %li
-        = link_to "SCSS-Lint", "#scss", class: "docs-nav-link"
-      %li
-        = link_to "Haml", "#haml", class: "docs-nav-link"
-      %li
-        = link_to "Go", "#go", class: "docs-nav-link"
-      %li
-        = link_to "Swift", "#swift", class: "docs-nav-link"
+        = link_to "JSHint", "#jshint", class: "docs-nav-link"
       %li
         = link_to "ESLint", "#eslint", class: "docs-nav-link"
       %li
-        = link_to "Python", "#python", class: "docs-nav-link"
+        = link_to "CoffeeLint", "#coffeescript", class: "docs-nav-link"
       %li
         = link_to "TSLint", "#tslint", class: "docs-nav-link"
       %li
-        = link_to "Elixir", "#elixir", class: "docs-nav-link"
+        = link_to "HAML-Lint", "#haml", class: "docs-nav-link"
+      %li
+        = link_to "SCSS-Lint", "#scss", class: "docs-nav-link"
       %li
         = link_to "Sass Lint", "#sass-lint", class: "docs-nav-link"
+      %li
+        = link_to "SwiftLint", "#swift", class: "docs-nav-link"
+      %li
+        = link_to "Flake8", "#flake8", class: "docs-nav-link"
+      %li
+        = link_to "Credo", "#credo", class: "docs-nav-link"
+      %li
+        = link_to "Golint", "#go", class: "docs-nav-link"
 
   %section.docs-content
     %article.docs-article
@@ -52,12 +52,12 @@
       %p
         %ul
           %li RuboCop (Ruby)
+          %li JSHint (JavaScript)
           %li CoffeeLint (CoffeeScript)
-          %li JavaScript (JSHint)
-          %li SCSS (SCSS-Lint)
-          %li Haml (HAMLLint)
-          %li Go (golint)
-          %li Swift (SwiftLint)
+          %li SCSS-Lint (Sass)
+          %li HAML-Lint (Haml)
+          %li SwiftLint (Swift)
+          %li Golint (Go)
       %p All other linters must be explicitly enabled.
 
       %p
@@ -106,7 +106,11 @@
           fail_on_violations: true
 
     %article.docs-article#ruby
-      %h2 Ruby
+      %h2
+        RuboCop
+        %span.version-number v#{@versions[:rubocop]}
+        (Ruby)
+
       %p
         Hound uses
         = link_to "RuboCop",
@@ -145,35 +149,11 @@
             ruby:
               enabled: false
 
-    %article.docs-article#coffeescript
-      %h2 CoffeeScript
-
-      %p
-        Hound uses
-        = link_to "CoffeeLint", "http://www.coffeelint.org", new_window_options
-        with the default configuration.
-
-      %p
-        To change the way CoffeeLint is configured, add a config file to your
-        project and reference it in your
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            coffeescript:
-              config_file: coffeelint.json
-
-      %p
-        To disable CoffeeScript style checking, add the following to your
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            coffeescript:
-              enabled: false
-
-    %article.docs-article#javascript
-      %h2 JavaScript
+    %article.docs-article#jshint
+      %h2
+        JSHint
+        %span.version-number v#{@versions[:jshint]}
+        (JavaScript)
 
       %p
         Hound uses
@@ -228,147 +208,11 @@
             jshint:
               enabled: false
 
-    %article.docs-article#scss
-      %h2 SCSS-Lint
-
-      %p
-        Hound uses
-        = link_to "SCSS-Lint",
-          "https://github.com/causes/scss-lint",
-          new_window_options
-        with this
-        = link_to "config", scss_config_url, new_window_options
-        by default.
-
-      %p
-        To change the way SCSS-Lint is configured, simply copy the
-        = link_to "default config file", scss_config_url, new_window_options
-        into your project, make changes and reference the file in your
-        %em.code-inline .hound.yml
-
-      %p
-        %code.code-block
-          :preserve
-            scss:
-              config_file: .scss-lint.yml
-
-      %p
-        To ignore certain SCSS files, add
-        %em.code-inline exclude:
-        directive to your
-        %em.code-inline .scss-lint.yml
-        file, like:
-
-        %code.code-block
-          :preserve
-            exclude:
-              - "app/assets/stylesheets/plugins/**"
-
-      %p
-        To disable SCSS style checking, add the following to your
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            scss:
-              enabled: false
-
-    %article.docs-article#haml
-      %h2 Haml
-
-      %p
-        Hound uses
-        = link_to "haml-lint",
-          "https://github.com/brigade/haml-lint",
-          new_window_options
-        with this
-        = link_to "config", haml_config_url, new_window_options
-        by default.
-
-      %p
-        To change the way haml-lint is configured, simply copy the
-        = link_to "default config file", haml_config_url, new_window_options
-        into your project, make changes and reference the file in your
-        %em.code-inline .hound.yml
-
-      %p
-        %code.code-block
-          :preserve
-            haml:
-              config_file: .haml-lint.yml
-
-      %p
-        To disable Haml style checking, add the following to your
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            haml:
-              enabled: false
-
-    %article.docs-article#go
-      %h2 Go
-
-      %p
-        Hound uses
-        = link_to "Golint",
-          "https://github.com/golang/lint",
-          new_window_options
-        to review Go code.
-
-      %p
-        To disable Go style checking, add the following to your
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            go:
-              enabled: false
-
-    %article.docs-article#swift
-      %h2 Swift
-
-      %p
-        Hound uses
-        = link_to "SwiftLint",
-          "https://github.com/realm/SwiftLint",
-          new_window_options
-        with this
-        = link_to "config", swift_config_url, new_window_options
-        by default.
-
-      %p
-        To change the way SwiftLint is configured, copy the
-        = link_to "default config file", swift_config_url, new_window_options
-        into your project, make changes and reference the file in your
-        %em.code-inline .hound.yml
-
-      %p
-        %code.code-block
-          :preserve
-            swift:
-              config_file: .swiftlint.yml
-
-      %p
-        To disable Swift style checking, add the following to your
-        %em.code-inline .hound.yml
-        file.
-
-        %code.code-block
-          :preserve
-            swift:
-              enabled: false
-
-      %p
-        For more information on the available configuration in your
-        %em.code-inline config_file
-        , you can read about it on the
-        = link_to "SwiftLint Configuration Documentation",
-          "https://github.com/realm/SwiftLint#configuration",
-          new_window_options
-
     %article.docs-article#eslint
-      %h2 ESLint
+      %h2
+        ESLint
+        %span.version-number v#{@versions[:eslint]}
+        (JavaScript)
 
       %p
         Hound uses
@@ -425,8 +269,247 @@
             eslint:
               ignore_file: .eslintignore
 
-    %article.docs-article#python
-      %h2 Python
+    %article.docs-article#coffeescript
+      %h2
+        CoffeeLint
+        %span.version-number v#{@versions[:coffeelint]}
+        (CoffeeScript)
+
+      %p
+        Hound uses
+        = link_to "CoffeeLint", "http://www.coffeelint.org", new_window_options
+        with the default configuration.
+
+      %p
+        To change the way CoffeeLint is configured, add a config file to your
+        project and reference it in your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            coffeescript:
+              config_file: coffeelint.json
+
+      %p
+        To disable CoffeeScript style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            coffeescript:
+              enabled: false
+
+    %article.docs-article#tslint
+      %h2
+        TSLint
+        %span.version-number v#{@versions[:tslint]}
+        (TypeScript)
+
+      %p
+        Hound uses
+        = link_to "TSLint",
+          "https://palantir.github.io/tslint/",
+          new_window_options
+        to review TypeScript code.
+
+      %p
+        To enable TypeScript style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            tslint:
+              enabled: true
+
+      %p
+        To change the way TSLint is configured, add a
+        %em.code-inline tslint.json
+        file to your project, configure it as desired
+        (see the
+        = succeed ")," do
+          = link_to "TSLint rules",
+            "https://palantir.github.io/tslint/rules/",
+            new_window_options
+        and reference it in
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            tslint:
+              config_file: tslint.json
+
+    %article.docs-article#haml
+      %h2
+        HAML-Lint
+        %span.version-number v#{@versions[:haml_lint]}
+        (Haml)
+
+      %p
+        Hound uses
+        = link_to "haml-lint",
+          "https://github.com/brigade/haml-lint",
+          new_window_options
+        with this
+        = link_to "config", haml_config_url, new_window_options
+        by default.
+
+      %p
+        To change the way haml-lint is configured, simply copy the
+        = link_to "default config file", haml_config_url, new_window_options
+        into your project, make changes and reference the file in your
+        %em.code-inline .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            haml:
+              config_file: .haml-lint.yml
+
+      %p
+        To disable Haml style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            haml:
+              enabled: false
+
+    %article.docs-article#scss
+      %h2
+        SCSS-Lint
+        %span.version-number v#{@versions[:scss_lint]}
+        (Sass)
+
+      %p
+        Hound uses
+        = link_to "SCSS-Lint",
+          "https://github.com/causes/scss-lint",
+          new_window_options
+        with this
+        = link_to "config", scss_config_url, new_window_options
+        by default.
+
+      %p
+        To change the way SCSS-Lint is configured, simply copy the
+        = link_to "default config file", scss_config_url, new_window_options
+        into your project, make changes and reference the file in your
+        %em.code-inline .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            scss:
+              config_file: .scss-lint.yml
+
+      %p
+        To ignore certain SCSS files, add
+        %em.code-inline exclude:
+        directive to your
+        %em.code-inline .scss-lint.yml
+        file, like:
+
+        %code.code-block
+          :preserve
+            exclude:
+              - "app/assets/stylesheets/plugins/**"
+
+      %p
+        To disable SCSS style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            scss:
+              enabled: false
+
+    %article.docs-article#sass-lint
+      %h2
+        Sass Lint
+        %span.version-number v#{@versions[:"sass-lint"]}
+        (Sass)
+
+      %p
+        Hound uses
+        = link_to "Sass Lint",
+          "https://github.com/sasstools/sass-lint",
+          new_window_options
+        with this
+        = link_to "config", sass_lint_config_url, new_window_options
+        by default.
+
+      %p
+        To enable Sass Lint style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            sass-lint:
+              enabled: true
+      %p
+        To change the way Sass Lint is configured, add
+        %em.code-inline .sass-lint.yml
+        file to your project,
+        specify your desired configuration
+        and refreence the file in your
+        %em.code-inline .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            sass-lint:
+              enabled: true
+              config_file: .sass-lint.yml
+
+    %article.docs-article#swift
+      %h2
+        SwiftLint
+        %span.version-number v0.25.0
+        (Swift)
+
+      %p
+        Hound uses
+        = link_to "SwiftLint",
+          "https://github.com/realm/SwiftLint",
+          new_window_options
+        with this
+        = link_to "config", swift_config_url, new_window_options
+        by default.
+
+      %p
+        To change the way SwiftLint is configured, copy the
+        = link_to "default config file", swift_config_url, new_window_options
+        into your project, make changes and reference the file in your
+        %em.code-inline .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            swift:
+              config_file: .swiftlint.yml
+
+      %p
+        To disable Swift style checking, add the following to your
+        %em.code-inline .hound.yml
+        file.
+
+        %code.code-block
+          :preserve
+            swift:
+              enabled: false
+
+      %p
+        For more information on the available configuration in your
+        %em.code-inline config_file
+        , you can read about it on the
+        = link_to "SwiftLint Configuration Documentation",
+          "https://github.com/realm/SwiftLint#configuration",
+          new_window_options
+
+    %article.docs-article#flake8
+      %h2
+        Flake8
+        %span.version-number v3.5.0
+        (Python)
 
       %p
         Hound uses
@@ -463,43 +546,12 @@
               enabled: true
               config_file: .flake8.ini
 
-    %article.docs-article#tslint
-      %h2 TSLint
-      %p
-        Hound uses
-        = link_to "TSLint",
-          "https://palantir.github.io/tslint/",
-          new_window_options
-        to review TypeScript code.
+    %article.docs-article#credo
+      %h2
+        Credo
+        %span.version-number v0.8.10
+        (Elixir)
 
-      %p
-        To enable TypeScript style checking, add the following to your
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            tslint:
-              enabled: true
-
-      %p
-        To change the way TSLint is configured, add a
-        %em.code-inline tslint.json
-        file to your project, configure it as desired
-        (see the
-        = succeed ")," do
-          = link_to "TSLint rules",
-            "https://palantir.github.io/tslint/rules/",
-            new_window_options
-        and reference it in
-        %em.code-inline .hound.yml
-
-        %code.code-block
-          :preserve
-            tslint:
-              config_file: tslint.json
-
-    %article.docs-article#elixir
-      %h2 Elixir
       %p
         Hound uses
         = link_to "Credo",
@@ -539,39 +591,24 @@
               enabled: true
               config_file: .credo.exs
 
-    %article.docs-article#sass-lint
-      %h2 Sass Lint
+    %article.docs-article#go
+      %h2 Golint (Go)
+
       %p
         Hound uses
-        = link_to "Sass Lint",
-          "https://github.com/sasstools/sass-lint",
+        = link_to "Golint",
+          "https://github.com/golang/lint",
           new_window_options
-        with this
-        = link_to "config", sass_lint_config_url, new_window_options
-        by default.
+        to review Go code.
 
       %p
-        To enable Sass Lint style checking, add the following to your
+        To disable Go style checking, add the following to your
         %em.code-inline .hound.yml
 
         %code.code-block
           :preserve
-            sass-lint:
-              enabled: true
-      %p
-        To change the way Sass Lint is configured, add
-        %em.code-inline .sass-lint.yml
-        file to your project,
-        specify your desired configuration
-        and refreence the file in your
-        %em.code-inline .hound.yml
-
-      %p
-        %code.code-block
-          :preserve
-            sass-lint:
-              enabled: true
-              config_file: .sass-lint.yml
+            go:
+              enabled: false
 
     %article.docs-article
       %h3 Didn't find what you where looking for?

--- a/spec/models/linter_version_spec.rb
+++ b/spec/models/linter_version_spec.rb
@@ -1,0 +1,63 @@
+require "lib/github_api"
+require "app/models/linter_version"
+
+RSpec.describe LinterVersion do
+  describe ".all" do
+    it "returns a hash of linter versions" do
+      linter_version = described_class.new
+      gemfile_content = <<~TEXT
+        GEM
+          spec:
+            haml_lint (0.25.1)
+              rubocop (>= 0.47.0)
+            ice_nine (0.11.2)
+            rubocop (0.51.0)
+      TEXT
+      yarn_content = <<~TEXT
+        eslint-plugin-standard@^3.0.1:
+          version "3.0.1"
+          dependencies:
+            commander "^2.8.1"
+            eslint "^2.7.0"
+
+        eslint@^2.7.0:
+          version "2.13.1"
+          dependencies:
+            chalk "^1.1.3"
+
+        eslint@^3.7.1:
+          version "3.7.1"
+
+        eslint@^3.19.1:
+          version "3.19.0"
+      TEXT
+      stub_file_requests(
+        "Gemfile.lock" => gemfile_content,
+        "yarn.lock" => yarn_content,
+      )
+
+      result = linter_version.all
+
+      expect(result).to include(
+        eslint: "3.19.0",
+        haml_lint: "0.25.1",
+        rubocop: "0.51.0",
+      )
+    end
+  end
+
+  def stub_file_requests(files)
+    github_client = instance_double("GitHubApi", file_contents: nil)
+    allow(GitHubApi).to receive(:new).and_return(github_client)
+
+    files.each do |filename, contents|
+      file_contents = Base64.encode64(contents)
+      file_response = OpenStruct.new(content: file_contents)
+      allow(github_client).to receive(:file_contents).with(
+        described_class::LINTERS_REPO_NAME,
+        filename,
+        "master",
+      ).and_return(file_response)
+    end
+  end
+end


### PR DESCRIPTION
Parsing most linter versions from `Gemfile.lock` and `yarn.lock`.

Golint has no semver-like version, so we don't display any version.
Credo, Flake8 and SwiftLint are hard-coded for now, because they don't
often change.

Re-ordered the linters on the configuration doc page for a better flow.