### PR TITLE
fix migrations

### DIFF
--- a/db/migrate/20121229003013_create_diesel_clearance_users.rb
+++ b/db/migrate/20121229003013_create_diesel_clearance_users.rb
@@ -1,4 +1,4 @@
-class CreateDieselClearanceUsers < ActiveRecord::Migration
+class CreateDieselClearanceUsers < ActiveRecord::Migration[4.2]
   def self.up
     create_table(:users) do |t|
       t.string   :email

--- a/db/migrate/20121229180151_add_github_username_to_users.rb
+++ b/db/migrate/20121229180151_add_github_username_to_users.rb
@@ -1,4 +1,4 @@
-class AddGithubUsernameToUsers < ActiveRecord::Migration
+class AddGithubUsernameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :github_username, :string
   end

--- a/db/migrate/20130104231409_remove_clearance_columns_from_user.rb
+++ b/db/migrate/20130104231409_remove_clearance_columns_from_user.rb
@@ -1,4 +1,4 @@
-class RemoveClearanceColumnsFromUser < ActiveRecord::Migration
+class RemoveClearanceColumnsFromUser < ActiveRecord::Migration[4.2]
   def up
     remove_columns(
       :users,

--- a/db/migrate/20130105203331_add_remember_token_to_users.rb
+++ b/db/migrate/20130105203331_add_remember_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddRememberTokenToUsers < ActiveRecord::Migration
+class AddRememberTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :remember_token, :string, null: false
   end

--- a/db/migrate/20130105203459_change_github_username_null_constraint.rb
+++ b/db/migrate/20130105203459_change_github_username_null_constraint.rb
@@ -1,4 +1,4 @@
-class ChangeGithubUsernameNullConstraint < ActiveRecord::Migration
+class ChangeGithubUsernameNullConstraint < ActiveRecord::Migration[4.2]
   def up
     change_column :users, :github_username, :string, null: false
   end

--- a/db/migrate/20130121230036_add_repos.rb
+++ b/db/migrate/20130121230036_add_repos.rb
@@ -1,4 +1,4 @@
-class AddRepos < ActiveRecord::Migration
+class AddRepos < ActiveRecord::Migration[4.2]
   def up
     create_table :repos do |t|
       t.integer :github_id, null: false

--- a/db/migrate/20130123030036_add_user_id_to_repos.rb
+++ b/db/migrate/20130123030036_add_user_id_to_repos.rb
@@ -1,4 +1,4 @@
-class AddUserIdToRepos < ActiveRecord::Migration
+class AddUserIdToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :user_id, :integer, null: false
   end

--- a/db/migrate/20130123030453_add_github_token_to_users.rb
+++ b/db/migrate/20130123030453_add_github_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddGithubTokenToUsers < ActiveRecord::Migration
+class AddGithubTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :github_token, :string
   end

--- a/db/migrate/20130228235811_add_hook_id_to_repos.rb
+++ b/db/migrate/20130228235811_add_hook_id_to_repos.rb
@@ -1,4 +1,4 @@
-class AddHookIdToRepos < ActiveRecord::Migration
+class AddHookIdToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :hook_id, :integer
   end

--- a/db/migrate/20130322200146_add_name_to_repos.rb
+++ b/db/migrate/20130322200146_add_name_to_repos.rb
@@ -1,4 +1,4 @@
-class AddNameToRepos < ActiveRecord::Migration
+class AddNameToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :name, :string, null: false
   end

--- a/db/migrate/20130322220351_add_full_github_name_to_repos.rb
+++ b/db/migrate/20130322220351_add_full_github_name_to_repos.rb
@@ -1,4 +1,4 @@
-class AddFullGithubNameToRepos < ActiveRecord::Migration
+class AddFullGithubNameToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :full_github_name, :string, null: false
   end

--- a/db/migrate/20130524154558_create_delayed_jobs.rb
+++ b/db/migrate/20130524154558_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, :force => true do |table|
       table.integer  :priority, :default => 0

--- a/db/migrate/20130614194012_add_uniqueness_constraint_to_repos.rb
+++ b/db/migrate/20130614194012_add_uniqueness_constraint_to_repos.rb
@@ -1,4 +1,4 @@
-class AddUniquenessConstraintToRepos < ActiveRecord::Migration
+class AddUniquenessConstraintToRepos < ActiveRecord::Migration[4.2]
   def up
     remove_index :repos, :github_id
     add_index :repos, [:user_id, :github_id], unique: true

--- a/db/migrate/20130621203400_create_builds.rb
+++ b/db/migrate/20130621203400_create_builds.rb
@@ -1,4 +1,4 @@
-class CreateBuilds < ActiveRecord::Migration
+class CreateBuilds < ActiveRecord::Migration[4.2]
   def change
     create_table :builds do |t|
       t.text :violations

--- a/db/migrate/20131212190854_create_memberships.rb
+++ b/db/migrate/20131212190854_create_memberships.rb
@@ -1,4 +1,4 @@
-class CreateMemberships < ActiveRecord::Migration
+class CreateMemberships < ActiveRecord::Migration[4.2]
   def change
     create_table :memberships do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20131212192202_remove_user_id_from_repos.rb
+++ b/db/migrate/20131212192202_remove_user_id_from_repos.rb
@@ -1,4 +1,4 @@
-class RemoveUserIdFromRepos < ActiveRecord::Migration
+class RemoveUserIdFromRepos < ActiveRecord::Migration[4.2]
   def up
     remove_column :repos, :user_id
   end

--- a/db/migrate/20140120165453_add_uuid_to_builds.rb
+++ b/db/migrate/20140120165453_add_uuid_to_builds.rb
@@ -1,4 +1,4 @@
-class AddUuidToBuilds < ActiveRecord::Migration
+class AddUuidToBuilds < ActiveRecord::Migration[4.2]
   def change
     add_column :builds, :uuid, :string
   end

--- a/db/migrate/20140120234919_add_unique_index_for_uuid.rb
+++ b/db/migrate/20140120234919_add_unique_index_for_uuid.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexForUuid < ActiveRecord::Migration
+class AddUniqueIndexForUuid < ActiveRecord::Migration[4.2]
   def change
     change_column_null :builds, :uuid, false
     add_index :builds, :uuid, unique: true

--- a/db/migrate/20140327142505_remove_github_token_from_users.rb
+++ b/db/migrate/20140327142505_remove_github_token_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveGithubTokenFromUsers < ActiveRecord::Migration
+class RemoveGithubTokenFromUsers < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :github_token
   end

--- a/db/migrate/20140417231853_add_timestamps_to_repo.rb
+++ b/db/migrate/20140417231853_add_timestamps_to_repo.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToRepo < ActiveRecord::Migration
+class AddTimestampsToRepo < ActiveRecord::Migration[4.2]
   def change
     add_timestamps :repos
   end

--- a/db/migrate/20140417232711_add_timestamps_to_memberships.rb
+++ b/db/migrate/20140417232711_add_timestamps_to_memberships.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToMemberships < ActiveRecord::Migration
+class AddTimestampsToMemberships < ActiveRecord::Migration[4.2]
   def change
     add_timestamps :memberships
   end

--- a/db/migrate/20140418142740_add_index_for_remember_token_to_users.rb
+++ b/db/migrate/20140418142740_add_index_for_remember_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddIndexForRememberTokenToUsers < ActiveRecord::Migration
+class AddIndexForRememberTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_index :users, :remember_token
   end

--- a/db/migrate/20140418144357_add_index_for_github_id_to_repos.rb
+++ b/db/migrate/20140418144357_add_index_for_github_id_to_repos.rb
@@ -1,4 +1,4 @@
-class AddIndexForGithubIdToRepos < ActiveRecord::Migration
+class AddIndexForGithubIdToRepos < ActiveRecord::Migration[4.2]
   def change
     add_index :repos, :github_id
   end

--- a/db/migrate/20140419160756_add_refreshing_repos_to_users.rb
+++ b/db/migrate/20140419160756_add_refreshing_repos_to_users.rb
@@ -1,4 +1,4 @@
-class AddRefreshingReposToUsers < ActiveRecord::Migration
+class AddRefreshingReposToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :refreshing_repos, :boolean, default: false
   end

--- a/db/migrate/20140419235609_add_index_for_active_to_repos.rb
+++ b/db/migrate/20140419235609_add_index_for_active_to_repos.rb
@@ -1,4 +1,4 @@
-class AddIndexForActiveToRepos < ActiveRecord::Migration
+class AddIndexForActiveToRepos < ActiveRecord::Migration[4.2]
   def change
     add_index :repos, :active
   end

--- a/db/migrate/20140421183905_add_email_address_to_users.rb
+++ b/db/migrate/20140421183905_add_email_address_to_users.rb
@@ -1,4 +1,4 @@
-class AddEmailAddressToUsers < ActiveRecord::Migration
+class AddEmailAddressToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :email_address, :string
   end

--- a/db/migrate/20140421191318_remove_name_from_repos.rb
+++ b/db/migrate/20140421191318_remove_name_from_repos.rb
@@ -1,4 +1,4 @@
-class RemoveNameFromRepos < ActiveRecord::Migration
+class RemoveNameFromRepos < ActiveRecord::Migration[4.2]
   def self.up
     remove_column :repos, :name
   end

--- a/db/migrate/20140425212732_add_private_to_repos.rb
+++ b/db/migrate/20140425212732_add_private_to_repos.rb
@@ -1,4 +1,4 @@
-class AddPrivateToRepos < ActiveRecord::Migration
+class AddPrivateToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :private, :boolean
   end

--- a/db/migrate/20140425235458_add_in_organization_to_repos.rb
+++ b/db/migrate/20140425235458_add_in_organization_to_repos.rb
@@ -1,4 +1,4 @@
-class AddInOrganizationToRepos < ActiveRecord::Migration
+class AddInOrganizationToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :in_organization, :boolean
   end

--- a/db/migrate/20140711223828_create_subscriptions.rb
+++ b/db/migrate/20140711223828_create_subscriptions.rb
@@ -1,4 +1,4 @@
-class CreateSubscriptions < ActiveRecord::Migration
+class CreateSubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :subscriptions do |t|
       t.timestamps

--- a/db/migrate/20140711223913_add_stripe_customer_id_to_users.rb
+++ b/db/migrate/20140711223913_add_stripe_customer_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddStripeCustomerIdToUsers < ActiveRecord::Migration
+class AddStripeCustomerIdToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :stripe_customer_id, :string
   end

--- a/db/migrate/20140711223957_add_stripe_subscription_id_to_subscriptions.rb
+++ b/db/migrate/20140711223957_add_stripe_subscription_id_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddStripeSubscriptionIdToSubscriptions < ActiveRecord::Migration
+class AddStripeSubscriptionIdToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :stripe_subscription_id, :string, null: false
   end

--- a/db/migrate/20140808163844_add_null_constraint_to_subscriptions_for_timestamps.rb
+++ b/db/migrate/20140808163844_add_null_constraint_to_subscriptions_for_timestamps.rb
@@ -1,4 +1,4 @@
-class AddNullConstraintToSubscriptionsForTimestamps < ActiveRecord::Migration
+class AddNullConstraintToSubscriptionsForTimestamps < ActiveRecord::Migration[4.2]
   def change
     change_column_null :subscriptions, :created_at, false
     change_column_null :subscriptions, :updated_at, false

--- a/db/migrate/20140808164104_add_index_for_user_id.rb
+++ b/db/migrate/20140808164104_add_index_for_user_id.rb
@@ -1,4 +1,4 @@
-class AddIndexForUserId < ActiveRecord::Migration
+class AddIndexForUserId < ActiveRecord::Migration[4.2]
   def change
     add_index :subscriptions, :user_id
   end

--- a/db/migrate/20140808195409_add_deleted_at_and_price_to_subscriptions.rb
+++ b/db/migrate/20140808195409_add_deleted_at_and_price_to_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddDeletedAtAndPriceToSubscriptions < ActiveRecord::Migration
+class AddDeletedAtAndPriceToSubscriptions < ActiveRecord::Migration[4.2]
   def change
     add_column :subscriptions, :deleted_at, :datetime
     add_column :subscriptions, :price, :decimal, null: false, precision: 8, scale: 2, default: 0

--- a/db/migrate/20140808202140_remove_unique_index_from_subscriptions_for_repo_id.rb
+++ b/db/migrate/20140808202140_remove_unique_index_from_subscriptions_for_repo_id.rb
@@ -1,4 +1,4 @@
-class RemoveUniqueIndexFromSubscriptionsForRepoId < ActiveRecord::Migration
+class RemoveUniqueIndexFromSubscriptionsForRepoId < ActiveRecord::Migration[4.2]
   def change
     remove_index :subscriptions, column: :repo_id
     add_index :subscriptions, :repo_id

--- a/db/migrate/20140926163029_add_pull_request_info_to_builds.rb
+++ b/db/migrate/20140926163029_add_pull_request_info_to_builds.rb
@@ -1,4 +1,4 @@
-class AddPullRequestInfoToBuilds < ActiveRecord::Migration
+class AddPullRequestInfoToBuilds < ActiveRecord::Migration[4.2]
   def change
     add_column :builds, :pull_request_number, :integer
     add_column :builds, :commit_sha, :string

--- a/db/migrate/20141107174021_create_violations.rb
+++ b/db/migrate/20141107174021_create_violations.rb
@@ -1,4 +1,4 @@
-class CreateViolations < ActiveRecord::Migration
+class CreateViolations < ActiveRecord::Migration[4.2]
   def up
     create_violations_table
     rename_column :builds, :violations, :violations_archive

--- a/db/migrate/20141210070831_drop_delayed_jobs_table.rb
+++ b/db/migrate/20141210070831_drop_delayed_jobs_table.rb
@@ -1,4 +1,4 @@
-class DropDelayedJobsTable < ActiveRecord::Migration
+class DropDelayedJobsTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :delayed_jobs
   end

--- a/db/migrate/20141211224528_create_owners.rb
+++ b/db/migrate/20141211224528_create_owners.rb
@@ -1,4 +1,4 @@
-class CreateOwners < ActiveRecord::Migration
+class CreateOwners < ActiveRecord::Migration[4.2]
   def change
     create_table :owners do |t|
       t.timestamps null: false

--- a/db/migrate/20141219224840_inactivate_repos_without_privacy_or_org_info.rb
+++ b/db/migrate/20141219224840_inactivate_repos_without_privacy_or_org_info.rb
@@ -1,4 +1,4 @@
-class InactivateReposWithoutPrivacyOrOrgInfo < ActiveRecord::Migration
+class InactivateReposWithoutPrivacyOrOrgInfo < ActiveRecord::Migration[4.2]
   def up
     sql = <<-SQL
       UPDATE "repos"

--- a/db/migrate/20150108003045_add_uniqueness_on_full_github_name_to_repos.rb
+++ b/db/migrate/20150108003045_add_uniqueness_on_full_github_name_to_repos.rb
@@ -1,4 +1,4 @@
-class AddUniquenessOnFullGithubNameToRepos < ActiveRecord::Migration
+class AddUniquenessOnFullGithubNameToRepos < ActiveRecord::Migration[4.2]
   def change
     add_index :repos, :full_github_name, unique: true
   end

--- a/db/migrate/20150123224104_add_owner_to_repos.rb
+++ b/db/migrate/20150123224104_add_owner_to_repos.rb
@@ -1,4 +1,4 @@
-class AddOwnerToRepos < ActiveRecord::Migration
+class AddOwnerToRepos < ActiveRecord::Migration[4.2]
   def change
     add_reference :repos, :owner, index: true
     add_foreign_key :repos, :owners

--- a/db/migrate/20150130051749_add_index_to_memberships_for_user_id.rb
+++ b/db/migrate/20150130051749_add_index_to_memberships_for_user_id.rb
@@ -1,4 +1,4 @@
-class AddIndexToMembershipsForUserId < ActiveRecord::Migration
+class AddIndexToMembershipsForUserId < ActiveRecord::Migration[4.2]
   def change
     remove_index :memberships, column: [:repo_id, :user_id]
     add_index :memberships, :repo_id

--- a/db/migrate/20150213132248_backfill_timestamps_add_null_constraints.rb
+++ b/db/migrate/20150213132248_backfill_timestamps_add_null_constraints.rb
@@ -1,4 +1,4 @@
-class BackfillTimestampsAddNullConstraints < ActiveRecord::Migration
+class BackfillTimestampsAddNullConstraints < ActiveRecord::Migration[4.2]
   def up
     updates_sql = <<-SQL
       UPDATE memberships

--- a/db/migrate/20150217090319_add_foreign_key_memberships.rb
+++ b/db/migrate/20150217090319_add_foreign_key_memberships.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyMemberships < ActiveRecord::Migration
+class AddForeignKeyMemberships < ActiveRecord::Migration[4.2]
   def change
     add_foreign_key :memberships, :users
     add_foreign_key :memberships, :repos

--- a/db/migrate/20150220174603_create_style_config.rb
+++ b/db/migrate/20150220174603_create_style_config.rb
@@ -1,4 +1,4 @@
-class CreateStyleConfig < ActiveRecord::Migration
+class CreateStyleConfig < ActiveRecord::Migration[4.2]
   def change
     create_table :style_configs do |t|
       t.boolean :enabled, default: true, null: false

--- a/db/migrate/20150225001118_add_unique_index_on_subscription_repo_id.rb
+++ b/db/migrate/20150225001118_add_unique_index_on_subscription_repo_id.rb
@@ -1,4 +1,4 @@
-class AddUniqueIndexOnSubscriptionRepoId < ActiveRecord::Migration
+class AddUniqueIndexOnSubscriptionRepoId < ActiveRecord::Migration[4.2]
   def change
     remove_index :subscriptions, column: :repo_id
     add_index :subscriptions, :repo_id,

--- a/db/migrate/20150303212157_add_unique_constraint_to_memberships.rb
+++ b/db/migrate/20150303212157_add_unique_constraint_to_memberships.rb
@@ -1,4 +1,4 @@
-class AddUniqueConstraintToMemberships < ActiveRecord::Migration
+class AddUniqueConstraintToMemberships < ActiveRecord::Migration[4.2]
   def self.up
     transaction do
       remove_duplicate_memberships

--- a/db/migrate/20150306184045_add_token_to_users.rb
+++ b/db/migrate/20150306184045_add_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddTokenToUsers < ActiveRecord::Migration
+class AddTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :token, :string
   end

--- a/db/migrate/20150425204143_create_file_reviews.rb
+++ b/db/migrate/20150425204143_create_file_reviews.rb
@@ -1,4 +1,4 @@
-class CreateFileReviews < ActiveRecord::Migration
+class CreateFileReviews < ActiveRecord::Migration[4.2]
   def change
     create_table :file_reviews do |t|
       t.belongs_to :build, index: true, foreign_key: true, null: false

--- a/db/migrate/20150526214750_associate_violations_with_file_reviews.rb
+++ b/db/migrate/20150526214750_associate_violations_with_file_reviews.rb
@@ -1,4 +1,4 @@
-class AssociateViolationsWithFileReviews < ActiveRecord::Migration
+class AssociateViolationsWithFileReviews < ActiveRecord::Migration[4.2]
   class Violation < ActiveRecord::Base
     belongs_to :file_review
   end

--- a/db/migrate/20150612231322_add_utm_source_to_users.rb
+++ b/db/migrate/20150612231322_add_utm_source_to_users.rb
@@ -1,4 +1,4 @@
-class AddUtmSourceToUsers < ActiveRecord::Migration
+class AddUtmSourceToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :utm_source, :string
   end

--- a/db/migrate/20150619222741_add_payload_to_builds.rb
+++ b/db/migrate/20150619222741_add_payload_to_builds.rb
@@ -1,4 +1,4 @@
-class AddPayloadToBuilds < ActiveRecord::Migration
+class AddPayloadToBuilds < ActiveRecord::Migration[4.2]
   def change
     add_column :builds, :payload, :text
   end

--- a/db/migrate/20150710220040_associate_user_to_build.rb
+++ b/db/migrate/20150710220040_associate_user_to_build.rb
@@ -1,4 +1,4 @@
-class AssociateUserToBuild < ActiveRecord::Migration
+class AssociateUserToBuild < ActiveRecord::Migration[4.2]
   def change
     add_column :builds, :user_id, :integer
   end

--- a/db/migrate/20150725013530_create_bulk_customers.rb
+++ b/db/migrate/20150725013530_create_bulk_customers.rb
@@ -1,4 +1,4 @@
-class CreateBulkCustomers < ActiveRecord::Migration
+class CreateBulkCustomers < ActiveRecord::Migration[4.2]
   def change
     create_table :bulk_customers do |t|
       t.timestamps null: false

--- a/db/migrate/20150728154011_add_token_scopes_to_users.rb
+++ b/db/migrate/20150728154011_add_token_scopes_to_users.rb
@@ -1,4 +1,4 @@
-class AddTokenScopesToUsers < ActiveRecord::Migration
+class AddTokenScopesToUsers < ActiveRecord::Migration[4.2]
   def up
     add_column :users, :token_scopes, :string
     execute "UPDATE users SET token_scopes = 'repo,user:email' WHERE token IS NOT NULL"

--- a/db/migrate/20150731212842_remove_repo_limit_constraint_on_bulk_customers.rb
+++ b/db/migrate/20150731212842_remove_repo_limit_constraint_on_bulk_customers.rb
@@ -1,4 +1,4 @@
-class RemoveRepoLimitConstraintOnBulkCustomers < ActiveRecord::Migration
+class RemoveRepoLimitConstraintOnBulkCustomers < ActiveRecord::Migration[4.2]
   def change
     change_column_null :bulk_customers, :repo_limit, true
   end

--- a/db/migrate/20151019123908_remove_style_config.rb
+++ b/db/migrate/20151019123908_remove_style_config.rb
@@ -1,4 +1,4 @@
-class RemoveStyleConfig < ActiveRecord::Migration
+class RemoveStyleConfig < ActiveRecord::Migration[4.2]
   def up
     drop_table :style_configs
   end

--- a/db/migrate/20151204174817_add_admin_to_memberships.rb
+++ b/db/migrate/20151204174817_add_admin_to_memberships.rb
@@ -1,4 +1,4 @@
-class AddAdminToMemberships < ActiveRecord::Migration
+class AddAdminToMemberships < ActiveRecord::Migration[4.2]
   def up
     add_column :memberships, :admin, :boolean
 

--- a/db/migrate/20151216235118_add_violations_count_to_builds.rb
+++ b/db/migrate/20151216235118_add_violations_count_to_builds.rb
@@ -1,4 +1,4 @@
-class AddViolationsCountToBuilds < ActiveRecord::Migration
+class AddViolationsCountToBuilds < ActiveRecord::Migration[4.2]
   def change
     add_column :builds, :violations_count, :integer
   end

--- a/db/migrate/20160314122828_add_linter_name_to_file_reviews.rb
+++ b/db/migrate/20160314122828_add_linter_name_to_file_reviews.rb
@@ -1,4 +1,4 @@
-class AddLinterNameToFileReviews < ActiveRecord::Migration
+class AddLinterNameToFileReviews < ActiveRecord::Migration[4.2]
   def up
     add_column :file_reviews, :linter_name, :string
   end

--- a/db/migrate/20160430171015_backfill_linter_names_add_null_constraint.rb
+++ b/db/migrate/20160430171015_backfill_linter_names_add_null_constraint.rb
@@ -1,4 +1,4 @@
-class BackfillLinterNamesAddNullConstraint < ActiveRecord::Migration
+class BackfillLinterNamesAddNullConstraint < ActiveRecord::Migration[4.2]
   def up
     sql = <<-SQL
       UPDATE file_reviews

--- a/db/migrate/20160513002940_add_github_id_uniqueness_on_repos.rb
+++ b/db/migrate/20160513002940_add_github_id_uniqueness_on_repos.rb
@@ -1,4 +1,4 @@
-class AddGithubIdUniquenessOnRepos < ActiveRecord::Migration
+class AddGithubIdUniquenessOnRepos < ActiveRecord::Migration[4.2]
   def up
     remove_uniqueness(:full_github_name)
     add_uniqueness(:github_id)

--- a/db/migrate/20160513205551_add_index_for_builds_pull_request_number_and_commit_sha.rb
+++ b/db/migrate/20160513205551_add_index_for_builds_pull_request_number_and_commit_sha.rb
@@ -1,4 +1,4 @@
-class AddIndexForBuildsPullRequestNumberAndCommitSha < ActiveRecord::Migration
+class AddIndexForBuildsPullRequestNumberAndCommitSha < ActiveRecord::Migration[4.2]
   def change
     add_index :builds, [:commit_sha, :pull_request_number]
   end

--- a/db/migrate/20160608183021_add_config_to_owner.rb
+++ b/db/migrate/20160608183021_add_config_to_owner.rb
@@ -1,4 +1,4 @@
-class AddConfigToOwner < ActiveRecord::Migration
+class AddConfigToOwner < ActiveRecord::Migration[4.2]
   def up
     add_column :owners, :config_enabled, :boolean, null: false, default: false
     add_column :owners, :config_repo, :string

--- a/db/migrate/20160624165658_update_thoughtbot_owner_configs.rb
+++ b/db/migrate/20160624165658_update_thoughtbot_owner_configs.rb
@@ -1,4 +1,4 @@
-class UpdateThoughtbotOwnerConfigs < ActiveRecord::Migration
+class UpdateThoughtbotOwnerConfigs < ActiveRecord::Migration[4.2]
   def up
     execute <<~SQL
       UPDATE

--- a/db/migrate/20160712203443_create_blacklisted_pull_requests.rb
+++ b/db/migrate/20160712203443_create_blacklisted_pull_requests.rb
@@ -1,4 +1,4 @@
-class CreateBlacklistedPullRequests < ActiveRecord::Migration
+class CreateBlacklistedPullRequests < ActiveRecord::Migration[4.2]
   def change
     create_table :blacklisted_pull_requests do |t|
       t.string :full_repo_name, null: false

--- a/db/migrate/20161021212135_add_default_to_violations_count_on_builds.rb
+++ b/db/migrate/20161021212135_add_default_to_violations_count_on_builds.rb
@@ -1,4 +1,4 @@
-class AddDefaultToViolationsCountOnBuilds < ActiveRecord::Migration
+class AddDefaultToViolationsCountOnBuilds < ActiveRecord::Migration[4.2]
   def up
     change_column :builds, :violations_count, :integer, default: 0, null: false
   end

--- a/db/migrate/20161021231021_rename_columns_on_repos_and_users.rb
+++ b/db/migrate/20161021231021_rename_columns_on_repos_and_users.rb
@@ -1,4 +1,4 @@
-class RenameColumnsOnReposAndUsers < ActiveRecord::Migration
+class RenameColumnsOnReposAndUsers < ActiveRecord::Migration[4.2]
   def change
     rename_column :repos, :full_github_name, :name
 


### PR DESCRIPTION
StandardError: Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateDieselClearanceUsers < ActiveRecord::Migration[4.2]
/app/vendor/bundle/ruby/2.4.0/gems/activerecord-5.1.4/lib/active_record/migration.rb:525:in `inherited'