### PR TITLE
Set `font-display` to `swap`

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -129,6 +129,7 @@ linters:
   PropertySpelling:
     enabled: true
     extra_properties:
+      - font-display
       - font-variant-numeric
       - text-decoration-skip
 

--- a/app/assets/stylesheets/base/_fonts.scss
+++ b/app/assets/stylesheets/base/_fonts.scss
@@ -5,6 +5,7 @@ $_font-host-url: "https://font.thoughtbot.com/hound/";
   "#{$_font-host-url}Tofino-Book",
   $asset-pipeline: false
 ) {
+  font-display: swap;
   font-style: normal;
   font-weight: $font-weight-book;
 }
@@ -14,6 +15,7 @@ $_font-host-url: "https://font.thoughtbot.com/hound/";
   "#{$_font-host-url}Tofino-BookItalic",
   $asset-pipeline: false
 ) {
+  font-display: swap;
   font-style: italic;
   font-weight: $font-weight-book;
 }
@@ -23,6 +25,7 @@ $_font-host-url: "https://font.thoughtbot.com/hound/";
   "#{$_font-host-url}Tofino-Regular",
   $asset-pipeline: false
 ) {
+  font-display: swap;
   font-style: normal;
   font-weight: $font-weight-regular;
 }
@@ -32,6 +35,7 @@ $_font-host-url: "https://font.thoughtbot.com/hound/";
   "#{$_font-host-url}Tofino-RegularItalic",
   $asset-pipeline: false
 ) {
+  font-display: swap;
   font-style: italic;
   font-weight: $font-weight-regular;
 }
@@ -41,6 +45,7 @@ $_font-host-url: "https://font.thoughtbot.com/hound/";
   "#{$_font-host-url}Tofino-Medium",
   $asset-pipeline: false
 ) {
+  font-display: swap;
   font-style: normal;
   font-weight: $font-weight-medium;
 }
@@ -50,6 +55,7 @@ $_font-host-url: "https://font.thoughtbot.com/hound/";
   "#{$_font-host-url}Tofino-MediumItalic",
   $asset-pipeline: false
 ) {
+  font-display: swap;
   font-style: italic;
   font-weight: $font-weight-medium;
 }


### PR DESCRIPTION
The CSS `font-display` property was added in the CSS Fonts Module
Level 4 specification and is used to "…determine how a font face is
displayed, based on whether and when it is downloaded and ready to use."

By setting `font-display` to `swap`, we're telling the browser to render
the next availabel system fallback font until the custom font loads.
This fully removes the "Flash of Invisible Text," or FOIT.

Spec: https://www.w3.org/TR/css-fonts-4/#font-display-desc
MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display
Support: https://caniuse.com/#feat=css-font-rendering-controls