### PR TITLE
Update apt before installing from it.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -34,7 +34,7 @@ jobs:
       - run: sudo dpkg -i /home/circleci/.cache/apt/archives/*.deb || true
 
       # Install System Dependencies (for capybara-webkit)
-      - run: mkdir -p /home/circleci/.cache/apt/archives/partial && touch /home/circleci/.cache/apt/archives/lock && chmod 640 /home/circleci/.cache/apt/archives/lock && sudo apt-get install -o=dir::cache=/home/circleci/.cache/apt qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+      - run: mkdir -p /home/circleci/.cache/apt/archives/partial && touch /home/circleci/.cache/apt/archives/lock && chmod 640 /home/circleci/.cache/apt/archives/lock && sudo apt-get update && sudo apt-get install -o=dir::cache=/home/circleci/.cache/apt qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
 
       # Bundle install dependencies
       - run: bundle install --path vendor/bundle


### PR DESCRIPTION
CI builds are breaking because we're trying to fetch apt packages which no longer exist. Updating the apt-cache first stops this from happening.