### PR TITLE
Capitalize the h in GitHub

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -50,7 +50,7 @@ class SessionsController < ApplicationController
   end
 
   def github
-    GithubApi.new(github_token)
+    GitHubApi.new(github_token)
   end
 
   def username

--- a/app/models/commit_status.rb
+++ b/app/models/commit_status.rb
@@ -47,6 +47,6 @@ class CommitStatus
   end
 
   def github
-    @github ||= GithubApi.new(token)
+    @github ||= GitHubApi.new(token)
   end
 end

--- a/app/models/github_auth_options.rb
+++ b/app/models/github_auth_options.rb
@@ -1,4 +1,4 @@
-class GithubAuthOptions
+class GitHubAuthOptions
   def initialize(env)
     @request = Rack::Request.new(env)
   end

--- a/app/models/payload.rb
+++ b/app/models/payload.rb
@@ -46,7 +46,7 @@ class Payload
   end
 
   def repository_owner_is_organization?
-    repository["owner"]["type"] == GithubApi::ORGANIZATION_TYPE
+    repository["owner"]["type"] == GitHubApi::ORGANIZATION_TYPE
   end
 
   def build_data

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -64,11 +64,11 @@ class PullRequest
   end
 
   def user_github
-    @user_github ||= GithubApi.new(token)
+    @user_github ||= GitHubApi.new(token)
   end
 
   def hound_github
-    @hound_github ||= GithubApi.new(Hound::GITHUB_TOKEN)
+    @hound_github ||= GitHubApi.new(Hound::GITHUB_TOKEN)
   end
 
   def number

--- a/app/models/user_token.rb
+++ b/app/models/user_token.rb
@@ -14,7 +14,7 @@ class UserToken
   private
 
   def can_reach_repository?(user)
-    if GithubApi.new(user.token).repository?(repo.name)
+    if GitHubApi.new(user.token).repository?(repo.name)
       true
     else
       repo.remove_membership(user)

--- a/app/services/build_owner_hound_config.rb
+++ b/app/services/build_owner_hound_config.rb
@@ -22,7 +22,7 @@ class BuildOwnerHoundConfig
   attr_reader :owner
 
   def github
-    @_github ||= GithubApi.new(user_token)
+    @_github ||= GitHubApi.new(user_token)
   end
 
   def user_token

--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -67,11 +67,11 @@ class RepoActivator
   end
 
   def hound_github
-    @hound_github ||= GithubApi.new(Hound::GITHUB_TOKEN)
+    @hound_github ||= GitHubApi.new(Hound::GITHUB_TOKEN)
   end
 
   def github
-    @github ||= GithubApi.new(github_token)
+    @github ||= GitHubApi.new(github_token)
   end
 
   def create_webhook

--- a/app/services/repo_synchronization.rb
+++ b/app/services/repo_synchronization.rb
@@ -29,7 +29,7 @@ class RepoSynchronization
   end
 
   def api
-    @api ||= GithubApi.new(user.token)
+    @api ||= GitHubApi.new(user.token)
   end
 
   def repo_attributes(attributes)
@@ -39,7 +39,7 @@ class RepoSynchronization
       private: attributes[:private],
       github_id: attributes[:id],
       name: attributes[:full_name],
-      in_organization: attributes[:owner][:type] == GithubApi::ORGANIZATION_TYPE,
+      in_organization: attributes[:owner][:type] == GitHubApi::ORGANIZATION_TYPE,
       owner: owner,
     }
   end
@@ -48,7 +48,7 @@ class RepoSynchronization
     Owner.upsert(
       github_id: owner_attributes[:id],
       name: owner_attributes[:login],
-      organization: owner_attributes[:type] == GithubApi::ORGANIZATION_TYPE
+      organization: owner_attributes[:type] == GitHubApi::ORGANIZATION_TYPE
     )
   end
 end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -11,6 +11,6 @@
 # end
 
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'GitHub'
+end

--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -2,7 +2,7 @@ OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   setup = ->(env) do
-    options = GithubAuthOptions.new(env)
+    options = GitHubAuthOptions.new(env)
     env["omniauth.strategy"].options.merge!(options.to_hash)
   end
 

--- a/db/migrate/20121229180151_add_github_username_to_users.rb
+++ b/db/migrate/20121229180151_add_github_username_to_users.rb
@@ -1,4 +1,4 @@
-class AddGithubUsernameToUsers < ActiveRecord::Migration[4.2]
+class AddGitHubUsernameToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :github_username, :string
   end

--- a/db/migrate/20130105203459_change_github_username_null_constraint.rb
+++ b/db/migrate/20130105203459_change_github_username_null_constraint.rb
@@ -1,4 +1,4 @@
-class ChangeGithubUsernameNullConstraint < ActiveRecord::Migration[4.2]
+class ChangeGitHubUsernameNullConstraint < ActiveRecord::Migration[4.2]
   def up
     change_column :users, :github_username, :string, null: false
   end

--- a/db/migrate/20130123030453_add_github_token_to_users.rb
+++ b/db/migrate/20130123030453_add_github_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddGithubTokenToUsers < ActiveRecord::Migration[4.2]
+class AddGitHubTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :github_token, :string
   end

--- a/db/migrate/20130322220351_add_full_github_name_to_repos.rb
+++ b/db/migrate/20130322220351_add_full_github_name_to_repos.rb
@@ -1,4 +1,4 @@
-class AddFullGithubNameToRepos < ActiveRecord::Migration[4.2]
+class AddFullGitHubNameToRepos < ActiveRecord::Migration[4.2]
   def change
     add_column :repos, :full_github_name, :string, null: false
   end

--- a/db/migrate/20140327142505_remove_github_token_from_users.rb
+++ b/db/migrate/20140327142505_remove_github_token_from_users.rb
@@ -1,4 +1,4 @@
-class RemoveGithubTokenFromUsers < ActiveRecord::Migration[4.2]
+class RemoveGitHubTokenFromUsers < ActiveRecord::Migration[4.2]
   def up
     remove_column :users, :github_token
   end

--- a/db/migrate/20140418144357_add_index_for_github_id_to_repos.rb
+++ b/db/migrate/20140418144357_add_index_for_github_id_to_repos.rb
@@ -1,4 +1,4 @@
-class AddIndexForGithubIdToRepos < ActiveRecord::Migration[4.2]
+class AddIndexForGitHubIdToRepos < ActiveRecord::Migration[4.2]
   def change
     add_index :repos, :github_id
   end

--- a/db/migrate/20150108003045_add_uniqueness_on_full_github_name_to_repos.rb
+++ b/db/migrate/20150108003045_add_uniqueness_on_full_github_name_to_repos.rb
@@ -1,4 +1,4 @@
-class AddUniquenessOnFullGithubNameToRepos < ActiveRecord::Migration[4.2]
+class AddUniquenessOnFullGitHubNameToRepos < ActiveRecord::Migration[4.2]
   def change
     add_index :repos, :full_github_name, unique: true
   end

--- a/db/migrate/20160513002940_add_github_id_uniqueness_on_repos.rb
+++ b/db/migrate/20160513002940_add_github_id_uniqueness_on_repos.rb
@@ -1,4 +1,4 @@
-class AddGithubIdUniquenessOnRepos < ActiveRecord::Migration[4.2]
+class AddGitHubIdUniquenessOnRepos < ActiveRecord::Migration[4.2]
   def up
     remove_uniqueness(:full_github_name)
     add_uniqueness(:github_id)

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -3,7 +3,7 @@ require "attr_extras"
 require "octokit"
 require "base64"
 
-class GithubApi
+class GitHubApi
   ORGANIZATION_TYPE = "Organization"
   PREVIEW_API_HEADER = "application/vnd.github.black-cat-preview+json"
 

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -5,7 +5,7 @@ describe SessionsController do
     context "with valid new user" do
       it "creates new user" do
         github_api = instance_double(
-          "GithubApi",
+          "GitHubApi",
           scopes: "public_repo,user:email",
         )
         request.env["omniauth.auth"] = stub_oauth(
@@ -13,7 +13,7 @@ describe SessionsController do
           email: "jimtom@example.com",
           token: "letmein",
         )
-        allow(GithubApi).to receive(:new).and_return(github_api)
+        allow(GitHubApi).to receive(:new).and_return(github_api)
 
         expect { post :create }.to change { User.count }.by(1)
         user = User.last

--- a/spec/lib/github_api_spec.rb
+++ b/spec/lib/github_api_spec.rb
@@ -3,13 +3,13 @@ require "attr_extras"
 require "lib/github_api"
 require "json"
 
-describe GithubApi do
+describe GitHubApi do
   before { stub_const("Hound::GITHUB_TOKEN", "token") }
 
   describe "#repos" do
-    it "fetches all repos from Github" do
+    it "fetches all repos from GitHub" do
       token = "something"
-      api = GithubApi.new(token)
+      api = GitHubApi.new(token)
       stub_repos_requests(token)
 
       repos = api.repos
@@ -21,7 +21,7 @@ describe GithubApi do
   describe "#scopes" do
     it "returns scopes as a string" do
       token = "token"
-      api = GithubApi.new(token)
+      api = GitHubApi.new(token)
       stub_scopes_request(token: token, scopes: "repo,user:email")
 
       scopes = api.scopes
@@ -36,7 +36,7 @@ describe GithubApi do
         client = double("Octokit::Client", contents: "filecontent")
         allow(Octokit::Client).to receive(:new).and_return(client)
         token = "authtoken"
-        github = GithubApi.new(token)
+        github = GitHubApi.new(token)
         repo = "jimtom/wow"
         filename = ".hound.yml"
         sha = "abc123"
@@ -64,7 +64,7 @@ describe GithubApi do
       it "creates pull request web hook" do
         callback_endpoint = "http://example.com"
         token = "something"
-        api = GithubApi.new(token)
+        api = GitHubApi.new(token)
         request = stub_hook_creation_request(
           repo_name,
           callback_endpoint,
@@ -79,7 +79,7 @@ describe GithubApi do
       it "yields hook" do
         callback_endpoint = "http://example.com"
         token = "something"
-        api = GithubApi.new(token)
+        api = GitHubApi.new(token)
         request = stub_hook_creation_request(
           repo_name,
           callback_endpoint,
@@ -100,7 +100,7 @@ describe GithubApi do
       it "does not raise" do
         callback_endpoint = "http://example.com"
         stub_failed_hook_creation_request(repo_name, callback_endpoint)
-        api = GithubApi.new(Hound::GITHUB_TOKEN)
+        api = GitHubApi.new(Hound::GITHUB_TOKEN)
 
         expect do
           api.create_hook(repo_name, callback_endpoint)
@@ -110,7 +110,7 @@ describe GithubApi do
       it "returns true" do
         callback_endpoint = "http://example.com"
         stub_failed_hook_creation_request(repo_name, callback_endpoint)
-        api = GithubApi.new(Hound::GITHUB_TOKEN)
+        api = GitHubApi.new(Hound::GITHUB_TOKEN)
 
         expect(api.create_hook(repo_name, callback_endpoint)).to eq true
       end
@@ -121,7 +121,7 @@ describe GithubApi do
     it "removes pull request web hook" do
       hook_id = "123"
       stub_hook_removal_request(repo_name, hook_id)
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
 
       response = api.remove_hook(repo_name, hook_id)
 
@@ -131,7 +131,7 @@ describe GithubApi do
     it "yields given block" do
       hook_id = "123"
       stub_hook_removal_request(repo_name, hook_id)
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
       yielded = false
 
       api.remove_hook(repo_name, hook_id) do
@@ -144,7 +144,7 @@ describe GithubApi do
 
   describe "#pull_request_files" do
     it "returns changed files in a pull request" do
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
       pull_request = double("PullRequest", repo_name: repo_name)
       pr_number = 123
       stub_pull_request_files_request(pull_request.repo_name, pr_number)
@@ -158,7 +158,7 @@ describe GithubApi do
 
   describe "#create_pull_request_review" do
     it "adds review comments to GitHub pull request" do
-      api = GithubApi.new("authtoken")
+      api = GitHubApi.new("authtoken")
       pull_request_number = 2
       comments = [
         { path: "test/test.rb", position: 10, body: "test comment 1" },
@@ -185,7 +185,7 @@ describe GithubApi do
 
   describe "#pull_request_comments" do
     it "returns comments added to pull request" do
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
       pull_request = double("PullRequest", repo_name: repo_name)
       pull_request_id = 253
       expected_comment = "Line is too long."
@@ -207,7 +207,7 @@ describe GithubApi do
 
   describe "#create_pending_status" do
     it "makes request to GitHub for creating a pending status" do
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
       request = stub_status_request(
         "test/repo",
         "sha",
@@ -223,7 +223,7 @@ describe GithubApi do
 
   describe "#create_success_status" do
     it "makes request to GitHub for creating a success status" do
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
       request = stub_status_request(
         "test/repo",
         "sha",
@@ -239,7 +239,7 @@ describe GithubApi do
 
   describe "#create_error_status" do
     it "makes request to GitHub for creating an error status" do
-      api = GithubApi.new(Hound::GITHUB_TOKEN)
+      api = GitHubApi.new(Hound::GITHUB_TOKEN)
       request = stub_status_request(
         "test/repo",
         "sha",
@@ -256,7 +256,7 @@ describe GithubApi do
   describe "#add_collaborator" do
     it "makes a request to GitHub" do
       username = "houndci"
-      api = GithubApi.new(token)
+      api = GitHubApi.new(token)
       request = stub_add_collaborator_request(username, repo_name, token)
 
       api.add_collaborator(repo_name, username)
@@ -268,7 +268,7 @@ describe GithubApi do
   describe "#remove_collaborator" do
     it "makes a request to GitHub" do
       username = "houndci"
-      api = GithubApi.new(token)
+      api = GitHubApi.new(token)
       request = stub_remove_collaborator_request(username, repo_name, token)
 
       api.remove_collaborator(repo_name, username)

--- a/spec/models/commit_spec.rb
+++ b/spec/models/commit_spec.rb
@@ -65,7 +65,7 @@ describe Commit do
 
     context "when exception contains no errors" do
       it "raises the error" do
-        github = double("GithubApi")
+        github = double("GitHubApi")
         commit = Commit.new("test/test", "abc", github)
         error = Octokit::Forbidden.new(body: { errors: [] })
         allow(github).to receive(:file_contents).and_raise(error)

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe CommitStatus do
   describe "#set_pending" do
-    it "sets the pending status on GithubApi" do
+    it "sets the pending status on GitHubApi" do
       github_api = stubbed_github_api(:create_pending_status)
       repo_name = "houndci/hound"
       sha = "abc123"
@@ -24,7 +24,7 @@ describe CommitStatus do
   end
 
   describe "#set_success" do
-    it "sets the create success status on GithubApi" do
+    it "sets the create success status on GitHubApi" do
       github_api = stubbed_github_api(:create_success_status)
       repo_name = "houndci/hound"
       sha = "abc123"
@@ -47,7 +47,7 @@ describe CommitStatus do
   end
 
   describe "#set_failure" do
-    it "sets the error status for GithubApi" do
+    it "sets the error status for GitHubApi" do
       github_api = stubbed_github_api(:create_error_status)
       repo_name = "houndci/hound"
       sha = "abc123"
@@ -71,7 +71,7 @@ describe CommitStatus do
   end
 
   describe "#set_config_error" do
-    it "sets the error status for GithubApi" do
+    it "sets the error status for GitHubApi" do
       github_api = stubbed_github_api(:create_error_status)
       repo_name = "houndci/hound"
       sha = "abc123"
@@ -95,7 +95,7 @@ describe CommitStatus do
   end
 
   describe "#set_internal_error" do
-    it "sets the error status for GithubApi" do
+    it "sets the error status for GitHubApi" do
       github_api = stubbed_github_api(:create_error_status)
       repo_name = "houndci/hound"
       sha = "abc123"
@@ -118,8 +118,8 @@ describe CommitStatus do
   end
 
   def stubbed_github_api(*methods)
-    github_api = double("GithubApi")
-    allow(GithubApi).to receive(:new).and_return(github_api)
+    github_api = double("GitHubApi")
+    allow(GitHubApi).to receive(:new).and_return(github_api)
 
     methods.each do |method_name|
       allow(github_api).to receive(method_name)

--- a/spec/models/config/coffee_script_spec.rb
+++ b/spec/models/config/coffee_script_spec.rb
@@ -40,7 +40,7 @@ describe Config::CoffeeScript do
     end
 
     context "config with comments and trailing commas" do
-      it "returns the content from Github as a hash" do
+      it "returns the content from GitHub as a hash" do
         raw_config = <<~EOS
           {
             "arrow_spacing": {

--- a/spec/models/github_auth_options_spec.rb
+++ b/spec/models/github_auth_options_spec.rb
@@ -2,12 +2,12 @@ require "spec_helper"
 require "app/models/github_auth_options"
 require "rack"
 
-describe GithubAuthOptions do
+describe GitHubAuthOptions do
   describe "#to_hash" do
     context "when request access param is full" do
       it "returns expected scopes, sorted by name" do
         env = { Rack::QUERY_STRING => "access=full", "rack.input" => "whatevs" }
-        options = GithubAuthOptions.new(env)
+        options = GitHubAuthOptions.new(env)
 
         options_as_hash = options.to_hash
 
@@ -18,7 +18,7 @@ describe GithubAuthOptions do
     context "when request access param is not full" do
       it "returns expected scope" do
         env = { "rack.input" => "whatevs" }
-        options = GithubAuthOptions.new(env)
+        options = GitHubAuthOptions.new(env)
 
         options_as_hash = options.to_hash
 

--- a/spec/models/owner_spec.rb
+++ b/spec/models/owner_spec.rb
@@ -101,14 +101,14 @@ describe Owner do
       owner_hound_contents = owner_hound_config.to_yaml
       owner_ruby_contents = owner_ruby_config.to_yaml
       owner = create(:owner, config_repo: "foo/bar", config_enabled: true)
-      github_api = instance_double("GithubApi", repo: true)
+      github_api = instance_double("GitHubApi", repo: true)
       allow(github_api).to receive(:file_contents).
         with("foo/bar", ".hound.yml", "HEAD").
         and_return(double(content: Base64.encode64(owner_hound_contents)))
       allow(github_api).to receive(:file_contents).
         with("foo/bar", ".rubocop.yml", "HEAD").
         and_return(double(content: Base64.encode64(owner_ruby_contents)))
-      allow(GithubApi).to receive(:new).and_return(github_api)
+      allow(GitHubApi).to receive(:new).and_return(github_api)
 
       expect(owner.config_content("ruby")).to eq(owner_ruby_config)
     end

--- a/spec/models/pull_request_spec.rb
+++ b/spec/models/pull_request_spec.rb
@@ -62,7 +62,7 @@ describe PullRequest do
   describe "#make_comments" do
     it "posts a review with comments to GitHub as the Hound user" do
       payload = payload_stub
-      github = instance_double("GithubApi", create_pull_request_review: nil)
+      github = instance_double("GitHubApi", create_pull_request_review: nil)
       pull_request = pull_request_stub(github, payload)
       violation = violation_stub
       review_errors = ["invalid config", "foo\n  bar"]
@@ -148,7 +148,7 @@ describe PullRequest do
   end
 
   def pull_request_stub(api, payload = payload_stub)
-    allow(GithubApi).to receive(:new).and_return(api)
+    allow(GitHubApi).to receive(:new).and_return(api)
     PullRequest.new(payload, token)
   end
 end

--- a/spec/models/style_checker_spec.rb
+++ b/spec/models/style_checker_spec.rb
@@ -15,8 +15,8 @@ describe StyleChecker do
     end
 
     it "only fetches content for supported files" do
-      ruby_file = double("GithubFile", filename: "ruby.rb", patch: "foo")
-      bogus_file = double("GithubFile", filename: "[:facebook]", patch: "bar")
+      ruby_file = double("GitHubFile", filename: "ruby.rb", patch: "foo")
+      bogus_file = double("GitHubFile", filename: "[:facebook]", patch: "bar")
       config = <<~YAML
         ruby:
           enabled: true

--- a/spec/models/user_token_spec.rb
+++ b/spec/models/user_token_spec.rb
@@ -68,8 +68,8 @@ describe UserToken do
 
   def stub_github(token, options = {})
     default_options = { repository?: true }
-    github_stub = instance_double("GithubApi", default_options.merge(options))
-    allow(GithubApi).to receive(:new).with(token).and_return(github_stub)
+    github_stub = instance_double("GitHubApi", default_options.merge(options))
+    allow(GitHubApi).to receive(:new).with(token).and_return(github_stub)
     github_stub
   end
 end

--- a/spec/policies/commenting_policy_spec.rb
+++ b/spec/policies/commenting_policy_spec.rb
@@ -93,9 +93,9 @@ describe CommentingPolicy do
 
   def stub_comment(options = {})
     defaults = {
-      user: double("GithubUser", login: Hound::GITHUB_USERNAME),
+      user: double("GitHubUser", login: Hound::GITHUB_USERNAME),
     }
-    double("GithubComment", defaults.merge(options))
+    double("GitHubComment", defaults.merge(options))
   end
 
   def stub_violation(options = {})

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,8 +10,8 @@ RSpec.configure do |config|
 
   %i(request feature).each do |type|
     config.before :each, type: type do
-      stub_request(:any, /api.github.com/).to_rack(FakeGithub)
-      FakeGithub.comments = []
+      stub_request(:any, /api.github.com/).to_rack(FakeGitHub)
+      FakeGitHub.comments = []
     end
   end
 

--- a/spec/requests/builds_spec.rb
+++ b/spec/requests/builds_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe "POST /builds" do
 
       post builds_path, params: { payload: payload }
 
-      expect(FakeGithub.review_body).to eq <<~EOS.chomp
+      expect(FakeGitHub.review_body).to eq <<~EOS.chomp
         Some files could not be reviewed due to errors:
         <details>
         <summary>invalid config syntax</summary>
         <pre>invalid config syntax</pre>
         </details>
       EOS
-      expect(FakeGithub.comments).to match_array [
+      expect(FakeGitHub.comments).to match_array [
         {
           body: new_violation1[:message],
           path: "path/to/test_github_file.rb",
@@ -57,7 +57,7 @@ RSpec.describe "POST /builds" do
 
       post builds_path, params: { payload: payload }
 
-      expect(FakeGithub.comments).to be_empty
+      expect(FakeGitHub.comments).to be_empty
     end
   end
 

--- a/spec/services/build_owner_hound_config_spec.rb
+++ b/spec/services/build_owner_hound_config_spec.rb
@@ -4,7 +4,7 @@ describe BuildOwnerHoundConfig do
   describe "#call" do
     context "when the owner has a configuration set" do
       it "returns the owner's config merged with the default HoundConfig" do
-        github_api = instance_double("GithubApi", repo: "")
+        github_api = instance_double("GitHubApi", repo: "")
         owner = instance_double(
           "Owner",
           has_config_repo?: true,
@@ -17,7 +17,7 @@ describe BuildOwnerHoundConfig do
           EOS
         )
         allow(Commit).to receive(:new).and_return(commit)
-        allow(GithubApi).to receive(:new).and_return(github_api)
+        allow(GitHubApi).to receive(:new).and_return(github_api)
 
         owner_config = BuildOwnerHoundConfig.call(owner)
 
@@ -42,13 +42,13 @@ describe BuildOwnerHoundConfig do
 
     context "when the owner's configuration is unreachable" do
       it "returns the default HoundConfig" do
-        github_api = instance_double("GithubApi")
+        github_api = instance_double("GitHubApi")
         owner = instance_double(
           "Owner",
           has_config_repo?: true,
           config_repo: "organization/private_style_guides",
         )
-        allow(GithubApi).to receive(:new).and_return(github_api)
+        allow(GitHubApi).to receive(:new).and_return(github_api)
         allow(github_api).to receive(:repo).and_raise(Octokit::NotFound)
 
         owner_config = BuildOwnerHoundConfig.call(owner)
@@ -59,13 +59,13 @@ describe BuildOwnerHoundConfig do
 
     context "when the owner's configuration is improperly formatted" do
       it "returns the default HoundConfig" do
-        github_api = instance_double("GithubApi")
+        github_api = instance_double("GitHubApi")
         owner = instance_double(
           "Owner",
           has_config_repo?: true,
           config_repo: "not/a/valid/repo",
         )
-        allow(GithubApi).to receive(:new).and_return(github_api)
+        allow(GitHubApi).to receive(:new).and_return(github_api)
         allow(github_api).to receive(:repo).
           and_raise(Octokit::InvalidRepository)
 

--- a/spec/services/build_runner_spec.rb
+++ b/spec/services/build_runner_spec.rb
@@ -341,13 +341,13 @@ describe BuildRunner do
 
   def stubbed_github_api
     github_api = instance_double(
-      "GithubApi",
+      "GitHubApi",
       create_pending_status: nil,
       create_success_status: nil,
       create_error_status: nil,
       repository?: true,
     )
-    allow(GithubApi).to receive(:new).and_return(github_api)
+    allow(GitHubApi).to receive(:new).and_return(github_api)
 
     github_api
   end

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -139,11 +139,11 @@ describe CompleteBuild do
 
     def stubbed_github_api
       github_api = instance_double(
-        "GithubApi",
+        "GitHubApi",
         create_success_status: nil,
         create_error_status: nil,
       )
-      allow(GithubApi).to receive(:new).and_return(github_api)
+      allow(GitHubApi).to receive(:new).and_return(github_api)
 
       github_api
     end

--- a/spec/services/repo_activator_spec.rb
+++ b/spec/services/repo_activator_spec.rb
@@ -146,7 +146,7 @@ describe RepoActivator do
           )
           allow(github_api).to receive(:accept_invitation).
             and_raise("invitation not found")
-          allow(GithubApi).to receive(:new).and_return(github_api)
+          allow(GitHubApi).to receive(:new).and_return(github_api)
 
           result = activator.activate
 
@@ -338,7 +338,7 @@ describe RepoActivator do
     context "when repo deactivation fails" do
       it "returns false" do
         activator = build_activator
-        allow(GithubApi).to receive(:new).and_raise(Octokit::Error.new)
+        allow(GitHubApi).to receive(:new).and_raise(Octokit::Error.new)
 
         result = activator.deactivate
 
@@ -348,7 +348,7 @@ describe RepoActivator do
       it "only swallows Octokit errors" do
         error = StandardError.new("this should bubble through")
         activator = build_activator
-        expect(GithubApi).to receive(:new).and_raise(error)
+        expect(GitHubApi).to receive(:new).and_raise(error)
 
         expect { activator.deactivate }.to raise_error(error)
       end
@@ -380,10 +380,10 @@ describe RepoActivator do
       accept_invitation: true,
       repository?: false,
     }
-    api = instance_double("GithubApi", default_options.merge(options))
+    api = instance_double("GitHubApi", default_options.merge(options))
     hook = double(:hook, id: 1)
     allow(api).to receive(:create_hook).and_yield(hook)
-    allow(GithubApi).to receive(:new).and_return(api)
+    allow(GitHubApi).to receive(:new).and_return(api)
     api
   end
 end

--- a/spec/services/repo_synchronization_spec.rb
+++ b/spec/services/repo_synchronization_spec.rb
@@ -91,8 +91,8 @@ describe RepoSynchronization do
         create(:membership, user: user, repo: repo2)
         github_repo1 = build_github_repo(id: repo1.github_id, name: "backup")
         github_repo2 = build_github_repo(id: repo2.github_id, name: "site")
-        api = instance_double("GithubApi", repos: [github_repo1, github_repo2])
-        allow(GithubApi).to receive(:new).and_return(api)
+        api = instance_double("GitHubApi", repos: [github_repo1, github_repo2])
+        allow(GitHubApi).to receive(:new).and_return(api)
         synchronization = RepoSynchronization.new(user)
 
         synchronization.start
@@ -165,8 +165,8 @@ describe RepoSynchronization do
       repo[:owner][:id] = owner_id
       repo[:permissions][:admin] = admin
 
-      api = double("GithubApi", repos: [repo])
-      allow(GithubApi).to receive(:new).and_return(api)
+      api = double("GitHubApi", repos: [repo])
+      allow(GitHubApi).to receive(:new).and_return(api)
 
       repo
     end

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe ReportInvalidConfig do
   describe ".call" do
     context "given a custom message" do
-      it "reports the file as an invalid config file to Github" do
+      it "reports the file as an invalid config file to GitHub" do
         commit_status = stubbed_commit_status(:set_config_error)
         stubbed_build(repo_name: "houndci/hound")
         pull_request_number = "42"
@@ -27,7 +27,7 @@ describe ReportInvalidConfig do
     end
 
     context "not given a custom message" do
-      it "reports the file as an invalid config file to Github" do
+      it "reports the file as an invalid config file to GitHub" do
         commit_status = stubbed_commit_status(:set_config_error)
         stubbed_build(repo_name: "houndci/hound")
         pull_request_number = "42"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ Dir["spec/support/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.order = "random"
-  config.include GithubApiHelper
+  config.include GitHubApiHelper
   config.include StripeApiHelper
   WebMock.disable_net_connect!(allow_localhost: true)
 

--- a/spec/support/fake_github.rb
+++ b/spec/support/fake_github.rb
@@ -1,6 +1,6 @@
 require "sinatra"
 
-class FakeGithub < Sinatra::Base
+class FakeGitHub < Sinatra::Base
   cattr_accessor :comments, :review_body
   self.comments = []
 

--- a/spec/support/fixtures/patch.diff
+++ b/spec/support/fixtures/patch.diff
@@ -29,7 +29,7 @@
      valid_actions.include?(@pull_request.action)
 @@ -52,13 +48,4 @@ def repo
    def api
-     @api ||= GithubApi.new(repo.github_token)
+     @api ||= GitHubApi.new(repo.github_token)
    end
 
    def patch

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -1,4 +1,4 @@
-module GithubApiHelper
+module GitHubApiHelper
   def stub_add_collaborator_request(username, repo_name, user_token)
     stub_request(
       :put,


### PR DESCRIPTION
Ok so this a Pull Request full of pageantry. I'll totally understand if this change isn't something the project wants to make, as it touches a lot of files in a rather unnecessary way.

This adds `GitHub` as an acronym in the `config/initializers/inflections.rb` file so that a file like `github_api.rb` translates to `class GitHubApi`. 