### PR TITLE
Remove package.json engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
     "test:watch": "jest --watch app/javascript/__tests__/*-test.jsx",
     "test:coverage": "jest --coverage app/javascript/__tests__/*-test.jsx"
   },
-  "engines": {
-    "node": "^8.4.0",
-    "yarn": "^1.0.1"
-  },
   "dependencies": {
     "@rails/webpacker": "^3.0.1",
     "autoprefixer": "^7.1.2",


### PR DESCRIPTION
Declaring Node as an engine is causing Yarn to error when running
`bin/setup`.

https://docs.npmjs.com/files/package.json#engines