### PR TITLE
Switch to chrome webdriver for JS feature tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 
 group :test do
   gem "capybara", ">= 2.4.0"
-  gem "capybara-webkit", "~> 1.6"
+  gem "selenium-webdriver"
   gem "factory_girl_rails"
   gem "launchy"
   gem "shoulda-matchers"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,9 +77,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.14.0)
-      capybara (>= 2.3.0, < 2.14.0)
-      json
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -294,6 +293,7 @@ GEM
     rspec-support (3.5.0)
     ruby_parser (3.10.1)
       sexp_processor (~> 4.9)
+    rubyzip (1.2.1)
     rufus-scheduler (3.3.1)
       tzinfo
     safe_yaml (1.0.4)
@@ -312,6 +312,9 @@ GEM
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
     selectize-rails (0.12.4)
+    selenium-webdriver (3.9.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.2.0)
       faraday (>= 0.7.6, < 1.0)
     sexp_processor (4.10.0)
@@ -374,7 +377,6 @@ DEPENDENCIES
   bundler-audit
   byebug
   capybara (>= 2.4.0)
-  capybara-webkit (~> 1.6)
   coffee-rails
   dotenv-rails
   email_validator
@@ -405,6 +407,7 @@ DEPENDENCIES
   rest-client (>= 2.0.1)
   rspec-rails (>= 3.4)
   sass-rails
+  selenium-webdriver
   sentry-raven (>= 0.12.2)
   shoulda-matchers
   sinatra (= 2.0.0)

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/hound
     docker:
-      - image: circleci/ruby:2.5.0-node
+      - image: circleci/ruby:2.5.0-node-browsers
         environment:
           RAILS_ENV: test
           CIRCLECI: true
@@ -26,16 +26,6 @@ jobs:
         name: Restore yarn cache
         key: houndci-yarn-{{ checksum "yarn.lock" }}
 
-      - type: cache-restore
-        name: Restore apt cache
-        key: houndci-apt-{{ checksum "Gemfile.lock" }}
-
-      # Install System Dependencies from cache (for capybara-webkit)
-      - run: sudo dpkg -i /home/circleci/.cache/apt/archives/*.deb || true
-
-      # Install System Dependencies (for capybara-webkit)
-      - run: mkdir -p /home/circleci/.cache/apt/archives/partial && touch /home/circleci/.cache/apt/archives/lock && chmod 640 /home/circleci/.cache/apt/archives/lock && sudo apt-get update && sudo apt-get install -o=dir::cache=/home/circleci/.cache/apt qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
-
       # Bundle install dependencies
       - run: bundle install --path vendor/bundle
 
@@ -53,12 +43,6 @@ jobs:
         key: houndci-yarn-{{ checksum "yarn.lock" }}
         paths:
           - ~/.cache/yarn
-
-      - type: cache-save
-        name: Store apt cache
-        key: houndci-apt-{{ checksum "Gemfile.lock" }}
-        paths:
-          - ~/.cache/apt
 
       # Wait for DB
       - run: dockerize -wait tcp://localhost:5432 -timeout 1m

--- a/spec/features/repo_list_spec.rb
+++ b/spec/features/repo_list_spec.rb
@@ -166,9 +166,5 @@ feature "Repo list", js: true do
 
   def select_config_repo(repo_name)
     find(".organization-header-select").select(repo_name)
-    # this expect is needed to make sure the saved check mark is hidden when
-    # the option is chosen from the dropdown.
-    # Then we can re-assert the checkmark is visible again after AJAX completes.
-    expect(page).not_to have_css("[data-role='config-saved']")
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -28,13 +28,24 @@ RSpec.configure do |config|
   ActiveJob::Base.queue_adapter = :resque
 end
 
-Capybara.configure do |config|
-  config.javascript_driver = :webkit
-  config.default_max_wait_time = 4
-end
-
-Capybara::Webkit.configure(&:block_unknown_urls)
-
 OmniAuth.configure do |config|
   config.test_mode = true
 end
+
+Capybara.register_driver :chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
+end
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w(headless) },
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities,
+  )
+end
+
+Capybara.javascript_driver = :headless_chrome

--- a/spec/support/helpers/authentication_helper.rb
+++ b/spec/support/helpers/authentication_helper.rb
@@ -7,6 +7,15 @@ module AuthenticationHelper
   def sign_in_as(user, token = "letmein")
     stub_oauth(username: user.username, email: user.email, token: token)
     visit root_path
-    click_link(I18n.t('authenticate'), match: :first)
+    find("[role=navigation]").click_on I18n.t("authenticate")
+    ensure_repos_load_via_ajax
+  end
+
+  private
+
+  def ensure_repos_load_via_ajax
+    if Capybara.current_driver != :rack_test
+      expect(page).to have_css(".organizations")
+    end
   end
 end


### PR DESCRIPTION
The future of QT and capybara-webkit is unknown.
Selenium with Chrome (headless) seems like a great alternative.

Ensure the repos list landing page (after sign in) finishes loading the
list of repose (via Ajax) for JS tests. Otherwise, a JS alert popup with
a failure causes tests to fail. This actually happens in Chrome on
production when navigating from the repos page before the AJAX request
 to get the repos finishes (the `Your repos failed to load.` alert).