### PR TITLE
Activate repo when there is no invitation

### DIFF
--- a/app/services/repo_activator.rb
+++ b/app/services/repo_activator.rb
@@ -61,7 +61,9 @@ class RepoActivator
 
   def add_hound_to_repo
     github.add_collaborator(repo.name, Hound::GITHUB_USERNAME)
-    hound_github.accept_invitation(repo.name)
+
+    hound_github.repository?(repo.name) ||
+      hound_github.accept_invitation(repo.name)
   end
 
   def hound_github


### PR DESCRIPTION
If Hound already can access the repo, we don't need to accept an
invitation -- when invitation doesn't exist the activation process blows
up.