### PR TITLE
Don't cut off repo names

### DIFF
--- a/app/assets/stylesheets/pages/repos/_index.scss
+++ b/app/assets/stylesheets/pages/repos/_index.scss
@@ -28,7 +28,7 @@
   @include ellipsis;
   color: $medium-font-color;
   font-size: 1.5em;
-  line-height: 1;
+  line-height: 1.2;
   padding-bottom: 2px;
   transition: $base-transition;
 


### PR DESCRIPTION
Before
<img width="266" alt="screenshot 2018-03-17 18 01 19" src="https://user-images.githubusercontent.com/154463/37561511-5a712bec-2a0d-11e8-85cc-5da12625d519.png">

After
<img width="242" alt="screenshot 2018-03-17 18 01 35" src="https://user-images.githubusercontent.com/154463/37561512-5a89d4d0-2a0d-11e8-9f8e-7576dfbfa1d9.png">
