### PR TITLE
Inherit .hound.yml from org-level repo

### DIFF
--- a/app/models/missing_owner.rb
+++ b/app/models/missing_owner.rb
@@ -2,4 +2,8 @@ class MissingOwner
   def config_content(*)
     {}
   end
+
+  def hound_config_content
+    {}
+  end
 end

--- a/app/models/style_checker.rb
+++ b/app/models/style_checker.rb
@@ -25,6 +25,9 @@ class StyleChecker
   end
 
   def hound_config
-    @_hound_config ||= HoundConfig.new(pull_request.head_commit)
+    @_hound_config ||= HoundConfig.new(
+      commit: pull_request.head_commit,
+      owner: build.repo.owner,
+    )
   end
 end

--- a/app/services/build_owner_hound_config.rb
+++ b/app/services/build_owner_hound_config.rb
@@ -11,9 +11,9 @@ class BuildOwnerHoundConfig
   def call
     if owner.has_config_repo? && config_repo_reachable?
       commit = Commit.new(config_repo.name, LATEST_SHA, github)
-      HoundConfig.new(commit)
+      HoundConfig.new(commit: commit, owner: MissingOwner.new)
     else
-      HoundConfig.new(EmptyCommit.new)
+      HoundConfig.new(commit: EmptyCommit.new, owner: MissingOwner.new)
     end
   end
 

--- a/app/services/complete_build.rb
+++ b/app/services/complete_build.rb
@@ -50,7 +50,7 @@ class CompleteBuild
   end
 
   def hound_config
-    HoundConfig.new(pull_request.head_commit)
+    HoundConfig.new(commit: pull_request.head_commit, owner: build.repo.owner)
   end
 
   def commit_status

--- a/spec/services/build_owner_hound_config_spec.rb
+++ b/spec/services/build_owner_hound_config_spec.rb
@@ -77,6 +77,6 @@ describe BuildOwnerHoundConfig do
   end
 
   def default_hound_config
-    HoundConfig.new(EmptyCommit.new).content
+    HoundConfig.new(commit: EmptyCommit.new, owner: MissingOwner.new).content
   end
 end

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -164,10 +164,15 @@ describe CompleteBuild do
           messages: [violation_message],
         )
       end
+      repo = instance_double(
+        "Repo",
+        subscription: false,
+        owner: MissingOwner.new,
+      )
       default_attributes = {
         completed?: true,
         review_errors: [],
-        repo: instance_double("Repo", subscription: false),
+        repo: repo,
         repo_name: "foo/bar",
         commit_sha: "abc123",
         violations: violations,

--- a/spec/support/helpers/linter_helper.rb
+++ b/spec/support/helpers/linter_helper.rb
@@ -1,9 +1,10 @@
 module LinterHelper
   def build_linter(build = build(:build), extra_files = {})
-    head_commit = double("Commit", file_content: "{}")
+    head_commit = instance_double("Commit", file_content: "{}")
     stub_commit_to_return_hound_config(head_commit)
     stub_commit_to_return_extra_files(head_commit, extra_files)
-    described_class.new hound_config: HoundConfig.new(head_commit), build: build
+    hound_config = HoundConfig.new(commit: head_commit, owner: MissingOwner.new)
+    described_class.new(hound_config: hound_config, build: build)
   end
 
   def raw_hound_config


### PR DESCRIPTION
If org-level configuration is enabled, then all enabled repos that fall
under that org should respect and use its `.hound.yml` file.