### PR TITLE
Handle parsing empty JSON config

### DIFF
--- a/app/models/config/parser.rb
+++ b/app/models/config/parser.rb
@@ -5,7 +5,11 @@ module Config
     end
 
     def self.json(content)
-      JSON.parse(content)
+      if content.present?
+        JSON.parse(content)
+      else
+        {}
+      end
     end
 
     def self.ini(content)

--- a/spec/models/config/jshint_spec.rb
+++ b/spec/models/config/jshint_spec.rb
@@ -7,25 +7,35 @@ require "app/models/missing_owner"
 
 describe Config::Jshint do
   describe "#content" do
-    it "parses the configuration using JSON" do
-      raw_config = <<~EOS
-        {
-          "maxlen": 80
-        }
-      EOS
-      config = build_config(raw_config)
+    context "when configuration is valid JSON" do
+      it "parses the configuration using JSON" do
+        raw_config = <<~JSON
+          {
+            "maxlen": 80
+          }
+        JSON
+        config = build_config(raw_config)
 
-      expect(config.content).to eq("maxlen" => 80)
+        expect(config.content).to eq("maxlen" => 80)
+      end
+    end
+
+    context "when configuration is blank" do
+      it "returns empty hash" do
+        config = build_config("")
+
+        expect(config.content).to eq({})
+      end
     end
   end
 
   describe "#serialize" do
     it "serializes the parsed content into JSON" do
-      raw_config = <<~EOS
+      raw_config = <<~JSON
         {
           "maxlen": 80
         }
-      EOS
+      JSON
       config = build_config(raw_config)
 
       expect(config.serialize).to eq "{\"maxlen\":80}"


### PR DESCRIPTION
This can happen if a user provided a `config_file` entry, but the file
cannot be found at that path (in the repo on the branch).
Hound shouldn't error in such a case.

Addresses: https://sentry.io/hound-1/production/issues/400232909