### PR TITLE
Ensure we handle a no/empty config file

### DIFF
--- a/app/models/config/parser.rb
+++ b/app/models/config/parser.rb
@@ -1,7 +1,11 @@
 module Config
   class Parser
     def self.yaml(content)
-      YAML.safe_load(content, [Regexp, Symbol])
+      if content.present?
+        YAML.safe_load(content, [Regexp, Symbol])
+      else
+        {}
+      end
     end
 
     def self.json(content)
@@ -14,10 +18,6 @@ module Config
 
     def self.ini(content)
       IniFile.new(content: content).to_h
-    end
-
-    def self.raw(content)
-      content
     end
   end
 end

--- a/spec/models/config_content_spec.rb
+++ b/spec/models/config_content_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe ConfigContent do
     end
 
     context "when there is no file path" do
-      it "is an empty hash" do
+      it "returns an empty hash" do
         commit = instance_double("Commit")
         parser = ->(_) {}
         config_content = ConfigContent.new(
@@ -106,6 +106,23 @@ RSpec.describe ConfigContent do
           ConfigContent::ContentError,
           %{"config-file.txt" must be a Hash},
         )
+      end
+    end
+
+    context "when the parsed YAML config is blank" do
+      it "returns empty hash" do
+        file_path = ".rubocop.yml"
+        parser = ->(content) { Config::Parser.yaml(content) }
+        commit = instance_double("Commit", file_content: "")
+        config_content = ConfigContent.new(
+          commit: commit,
+          file_path: file_path,
+          parser: parser,
+        )
+
+        result = config_content.load
+
+        expect(result).to eq({})
       end
     end
   end


### PR DESCRIPTION
If the config file isn't found, or it's blank, for some reason, we
should treat it as an empty config and continue.