### PR TITLE
Remove repo memberships that can't set the status

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -8,14 +8,8 @@ class Build < ApplicationRecord
 
   validates :repo, presence: true
 
-  delegate :name, to: :repo, prefix: true
-
   def completed?
     file_reviews.where(completed_at: nil).empty?
-  end
-
-  def user_token
-    (user && user.token) || Hound::GITHUB_TOKEN
   end
 
   def review_errors

--- a/app/services/build_runner.rb
+++ b/app/services/build_runner.rb
@@ -85,9 +85,9 @@ class BuildRunner
 
   def commit_status
     @commit_status ||= CommitStatus.new(
-      repo_name: payload.full_repo_name,
+      repo: repo,
       sha: payload.head_sha,
-      token: user_token.token,
+      user: user_token.user,
     )
   end
 

--- a/app/services/complete_build.rb
+++ b/app/services/complete_build.rb
@@ -1,10 +1,9 @@
 class CompleteBuild
   static_facade :call
 
-  def initialize(pull_request:, build:, token:)
+  def initialize(pull_request:, build:)
     @build = build
     @pull_request = pull_request
-    @token = token
     @commenting_policy = CommentingPolicy.new(pull_request)
   end
 
@@ -23,7 +22,7 @@ class CompleteBuild
 
   private
 
-  attr_reader :build, :commenting_policy, :token, :pull_request
+  attr_reader :build, :commenting_policy, :pull_request
 
   def priority_violations
     build.violations.take(Hound::MAX_COMMENTS)
@@ -54,10 +53,6 @@ class CompleteBuild
   end
 
   def commit_status
-    CommitStatus.new(
-      repo_name: build.repo_name,
-      sha: build.commit_sha,
-      token: token,
-    )
+    CommitStatus.new(repo: build.repo, sha: build.commit_sha, user: build.user)
   end
 end

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -8,11 +8,7 @@ class CompleteFileReview
   def call
     complete_file_review
 
-    CompleteBuild.call(
-      pull_request: pull_request,
-      build: build,
-      token: build.user_token,
-    )
+    CompleteBuild.call(pull_request: pull_request, build: build)
   end
 
   private

--- a/app/services/report_invalid_config.rb
+++ b/app/services/report_invalid_config.rb
@@ -17,9 +17,9 @@ class ReportInvalidConfig
 
   def commit_status
     @commit_status ||= CommitStatus.new(
-      repo_name: build.repo_name,
+      repo: build.repo,
       sha: commit_sha,
-      token: build.user_token,
+      user: build.user,
     )
   end
 

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -19,25 +19,6 @@ describe Build do
     end
   end
 
-  describe "#user_token" do
-    context "when user is associated with a build" do
-      it "returns the user's token" do
-        user = build(:user, token: "sometoken")
-        build = build(:build, user: user)
-
-        expect(build.user_token).to eq user.token
-      end
-    end
-
-    context "when user is not associated" do
-      it "returns the houndci's token" do
-        build = build(:build)
-
-        expect(build.user_token).to eq Hound::GITHUB_TOKEN
-      end
-    end
-  end
-
   describe "#review_errors" do
     it "returns a list of unique linter errors" do
       file_review1 = create(:file_review, error: "invalid config\n some file1")

--- a/spec/models/commit_status_spec.rb
+++ b/spec/models/commit_status_spec.rb
@@ -1,22 +1,18 @@
 require "rails_helper"
 
-describe CommitStatus do
+RSpec.describe CommitStatus do
   describe "#set_pending" do
     it "sets the pending status on GitHubApi" do
       github_api = stubbed_github_api(:create_pending_status)
-      repo_name = "houndci/hound"
       sha = "abc123"
-      token = "token"
-      commit_status = CommitStatus.new(
-        repo_name: repo_name,
-        sha: sha,
-        token: token,
-      )
+      user = instance_double("User", token: "some-token")
+      repo = instance_double("Repo", name: "houndci/hound")
+      commit_status = CommitStatus.new(repo: repo, sha: sha, user: user)
 
       commit_status.set_pending
 
       expect(github_api).to have_received(:create_pending_status).with(
-        repo_name,
+        repo.name,
         sha,
         I18n.t(:pending_status),
       )
@@ -26,20 +22,16 @@ describe CommitStatus do
   describe "#set_success" do
     it "sets the create success status on GitHubApi" do
       github_api = stubbed_github_api(:create_success_status)
-      repo_name = "houndci/hound"
       sha = "abc123"
-      token = "token"
       violation_count = 5
-      commit_status = CommitStatus.new(
-        repo_name: repo_name,
-        sha: sha,
-        token: token,
-      )
+      user = instance_double("User", token: "some-token")
+      repo = instance_double("Repo", name: "houndci/hound")
+      commit_status = CommitStatus.new(repo: repo, sha: sha, user: user)
 
       commit_status.set_success(violation_count)
 
       expect(github_api).to have_received(:create_success_status).with(
-        repo_name,
+        repo.name,
         sha,
         I18n.t(:complete_status, count: violation_count),
       )
@@ -49,20 +41,16 @@ describe CommitStatus do
   describe "#set_failure" do
     it "sets the error status for GitHubApi" do
       github_api = stubbed_github_api(:create_error_status)
-      repo_name = "houndci/hound"
       sha = "abc123"
-      token = "token"
       violation_count = 5
-      commit_status = CommitStatus.new(
-        repo_name: repo_name,
-        sha: sha,
-        token: token,
-      )
+      user = instance_double("User", token: "some-token")
+      repo = instance_double("Repo", name: "houndci/hound")
+      commit_status = CommitStatus.new(repo: repo, sha: sha, user: user)
 
       commit_status.set_failure(violation_count)
 
       expect(github_api).to have_received(:create_error_status).with(
-        repo_name,
+        repo.name,
         sha,
         I18n.t(:complete_status, count: violation_count),
         nil,
@@ -75,13 +63,10 @@ describe CommitStatus do
       github_api = stubbed_github_api(:create_error_status)
       repo_name = "houndci/hound"
       sha = "abc123"
-      token = "token"
       message = "invalid config"
-      commit_status = CommitStatus.new(
-        repo_name: repo_name,
-        sha: sha,
-        token: token,
-      )
+      user = instance_double("User", token: "some-token")
+      repo = instance_double("Repo", name: "houndci/hound")
+      commit_status = CommitStatus.new(repo: repo, sha: sha, user: user)
 
       commit_status.set_config_error(message)
 
@@ -97,19 +82,15 @@ describe CommitStatus do
   describe "#set_internal_error" do
     it "sets the error status for GitHubApi" do
       github_api = stubbed_github_api(:create_error_status)
-      repo_name = "houndci/hound"
       sha = "abc123"
-      token = "token"
-      commit_status = CommitStatus.new(
-        repo_name: repo_name,
-        sha: sha,
-        token: token,
-      )
+      user = instance_double("User", token: "some-token")
+      repo = instance_double("Repo", name: "houndci/hound")
+      commit_status = CommitStatus.new(repo: repo, sha: sha, user: user)
 
       commit_status.set_internal_error
 
       expect(github_api).to have_received(:create_error_status).with(
-        repo_name,
+        repo.name,
         sha,
         I18n.t(:hound_error_status),
         nil,

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -11,11 +11,7 @@ describe CompleteBuild do
           pull_request = stub_pull_request([existing_comment])
           stubbed_github_api
 
-          CompleteBuild.call(
-            pull_request: pull_request,
-            build: build,
-            token: "abc123",
-          )
+          CompleteBuild.call(pull_request: pull_request, build: build)
 
           expect(pull_request).to have_received(:make_comments) do |arg|
             expect(arg.flat_map(&:messages)).to match_array ["bar"]
@@ -31,7 +27,7 @@ describe CompleteBuild do
             run_service(build)
 
             expect(github_api).to have_received(:create_success_status).with(
-              build.repo_name,
+              build.repo.name,
               build.commit_sha,
               "1 violation found.",
             )
@@ -47,7 +43,7 @@ describe CompleteBuild do
             run_service(build)
 
             expect(github_api).to have_received(:create_error_status).with(
-              build.repo_name,
+              build.repo.name,
               build.commit_sha,
               "1 violation found.",
               nil,
@@ -62,11 +58,7 @@ describe CompleteBuild do
           pull_request = stub_pull_request
           github_api = stubbed_github_api
 
-          CompleteBuild.call(
-            pull_request: pull_request,
-            build: build,
-            token: "abc123",
-          )
+          CompleteBuild.call(pull_request: pull_request, build: build)
 
           expect(pull_request).not_to have_received(:make_comments)
           expect(github_api).not_to have_received(:create_success_status)
@@ -83,7 +75,7 @@ describe CompleteBuild do
         run_service(build)
 
         expect(github_api).to have_received(:create_success_status).with(
-          build.repo_name,
+          build.repo.name,
           build.commit_sha,
           I18n.t(:complete_status, count: 0),
         )
@@ -95,11 +87,7 @@ describe CompleteBuild do
         pull_request = stub_pull_request([])
         stubbed_github_api
 
-        CompleteBuild.call(
-          pull_request: pull_request,
-          build: build,
-          token: "abc123",
-        )
+        CompleteBuild.call(pull_request: pull_request, build: build)
 
         expect(pull_request).not_to have_received(:make_comments)
       end
@@ -111,11 +99,7 @@ describe CompleteBuild do
         pull_request = stub_pull_request
         stubbed_github_api
 
-        CompleteBuild.call(
-          pull_request: pull_request,
-          build: build,
-          token: "abc123",
-        )
+        CompleteBuild.call(pull_request: pull_request, build: build)
 
         expect(pull_request).to have_received(:make_comments).
           with([], ["cannot parse config"])
@@ -168,15 +152,16 @@ describe CompleteBuild do
         "Repo",
         subscription: false,
         owner: MissingOwner.new,
+        name: "foo/bar",
       )
       default_attributes = {
         completed?: true,
         review_errors: [],
         repo: repo,
-        repo_name: "foo/bar",
         commit_sha: "abc123",
         violations: violations,
         violations_count: violations.size,
+        user: nil,
       }
       instance_double("Build", default_attributes.merge(attributes))
     end
@@ -196,11 +181,7 @@ describe CompleteBuild do
     end
 
     def run_service(build)
-      CompleteBuild.call(
-        pull_request: stub_pull_request,
-        build: build,
-        token: "abc123",
-      )
+      CompleteBuild.call(pull_request: stub_pull_request, build: build)
     end
   end
 end

--- a/spec/services/complete_file_review_spec.rb
+++ b/spec/services/complete_file_review_spec.rb
@@ -29,7 +29,6 @@ describe CompleteFileReview do
       expect(CompleteBuild).to have_received(:call).with(
         pull_request: pull_request,
         build: build,
-        token: Hound::GITHUB_TOKEN,
       )
       expect(Payload).to have_received(:new).with(build.payload)
       expect(PullRequest).
@@ -58,7 +57,6 @@ describe CompleteFileReview do
         expect(CompleteBuild).to have_received(:call).with(
           pull_request: pull_request,
           build: correct_build,
-          token: Hound::GITHUB_TOKEN,
         )
       end
     end

--- a/spec/services/report_invalid_config_spec.rb
+++ b/spec/services/report_invalid_config_spec.rb
@@ -5,7 +5,7 @@ describe ReportInvalidConfig do
     context "given a custom message" do
       it "reports the file as an invalid config file to GitHub" do
         commit_status = stubbed_commit_status(:set_config_error)
-        stubbed_build(repo_name: "houndci/hound")
+        stubbed_build
         pull_request_number = "42"
         commit_sha = "abc123"
         message = "Invalid ruby file, woff"
@@ -37,13 +37,10 @@ describe ReportInvalidConfig do
   end
 
   def stubbed_build(methods = {})
-    build = double("Build", user_token: "sekkrit")
+    repo = instance_double("Repo", name: "foo/bar")
+    default_build_methods = { repo: repo, user: nil }
+    build = instance_double("Build", default_build_methods.merge(methods))
     allow(Build).to receive(:find_by!).and_return(build)
-
-    methods.each do |method_name, return_value|
-      allow(build).to receive(method_name).and_return(return_value)
-    end
-
     build
   end
 end


### PR DESCRIPTION
Sometimes users get removed from the repos, and they can no longer set
the status (or access repo files), so we should remove them from the
repo on our side.

There is one thing worth considering, if the repo is public but the user
isn't part of that repo, then the user can still access the files
(everything needed to review a PR and make a comment), but they can't
set the status. Should we remove them in that case? On one side, we
can't set the status but continue reviewing -- if no violations are
found, it'll look like Hound never did anything since the status won't
have anything from Hound. On the other hand, if we remove that user,
then we'll have to use Hound's token, thus incurring more API hits.