### PR TITLE
Revert "Capitalize hound in GitHub status (#1512)"

### DIFF
--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -143,7 +143,7 @@ class GitHubApi
       repo,
       sha,
       state,
-      context: "Hound",
+      context: "hound",
       description: description,
       target_url: target_url
     )

--- a/spec/support/helpers/github_api_helper.rb
+++ b/spec/support/helpers/github_api_helper.rb
@@ -185,7 +185,7 @@ module GitHubApiHelper
 
   def status_request_body(description, state, target_url)
     {
-      context: "Hound",
+      context: "hound",
       description: description,
       state: state,
       target_url: target_url,


### PR DESCRIPTION
This reverts commit a2c7acc1694a49ef5202910e6b193e16137abfea.

Looks like there's a GitHub issue where the protected branch settings aren't providing the new context, so users are getting double statuses.

<img width="572" alt="screenshot 2018-04-05 19 03 38" src="https://user-images.githubusercontent.com/154463/38400276-3c78bbe0-3904-11e8-853e-2f43f7df94cf.png">
