### PR TITLE
Update .rubocop.yml for trailing comma

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -299,8 +299,10 @@ Style/SymbolProc:
   IgnoredMethods:
   - respond_to
 Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
   Enabled: true
 Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
   Enabled: true
 Style/TrailingCommaInArguments:
   Description: Checks for trailing comma in parameter lists and literals.


### PR DESCRIPTION
This was lost in the recent RuboCop upgrade.
Maybe they changed defaults?