### PR TITLE
Rename Go to Golint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,10 +183,10 @@ as well as any default configuration they might use:
     * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/credo)
 1. Go
     * [Golint](https://github.com/golang/lint)
-    * [houndci/go](https://github.com/houndci/go)
+    * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/golint)
 1. Markdown
     * [Remark](https://github.com/wooorm/remark)
-    * [houndci/remark](https://github.com/houndci/remark)
+    * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/remark)
 1. Swift
     * [SwiftLint](https://github.com/realm/SwiftLint)
     * [houndci/swift](https://github.com/houndci/swift)

--- a/app/jobs/go_review_job.rb
+++ b/app/jobs/go_review_job.rb
@@ -1,3 +1,0 @@
-class GoReviewJob
-  @queue = :go_review
-end

--- a/app/models/config/golint.rb
+++ b/app/models/config/golint.rb
@@ -1,4 +1,4 @@
 module Config
-  class Go < Base
+  class Golint < Base
   end
 end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -6,7 +6,7 @@ class HoundConfig
     Linter::Credo => { default: false },
     Linter::Eslint => { default: false },
     Linter::Flog => { default: false },
-    Linter::Go => { default: true },
+    Linter::Golint => { default: true },
     Linter::Haml => { default: true },
     Linter::Jshint => { default: true },
     Linter::Flake8 => { default: false },

--- a/app/models/linter/golint.rb
+++ b/app/models/linter/golint.rb
@@ -1,5 +1,5 @@
 module Linter
-  class Go < Base
+  class Golint < Base
     FILE_REGEXP = /.+\.go\z/
 
     def file_included?(commit_file)
@@ -13,6 +13,10 @@ module Linter
 
       path_components.include?("vendor") ||
         path_components.take(2) == ["Godeps", "_workspace"]
+    end
+
+    def job_class
+      LintersJob
     end
   end
 end

--- a/app/services/resolve_config_aliases.rb
+++ b/app/services/resolve_config_aliases.rb
@@ -1,6 +1,7 @@
 class ResolveConfigAliases
   ALIASES = {
     "coffeescript" => "coffee_script",
+    "go" => "golint",
     "java_script" => "jshint",
     "javascript" => "jshint",
     "python" => "flake8",

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -16,7 +16,7 @@
       %li
         = link_to "Haml", "#haml", class: "docs-nav-link"
       %li
-        = link_to "Go", "#go", class: "docs-nav-link"
+        = link_to "Golint", "#golint", class: "docs-nav-link"
       %li
         = link_to "Swift", "#swift", class: "docs-nav-link"
       %li
@@ -306,8 +306,8 @@
             haml:
               enabled: false
 
-    %article.docs-article#go
-      %h2 Go
+    %article.docs-article#golint
+      %h2 Golint
 
       %p
         Hound uses
@@ -322,7 +322,7 @@
 
         %code.code-block
           :preserve
-            go:
+            golint:
               enabled: false
 
     %article.docs-article#swift

--- a/spec/models/config/golint_spec.rb
+++ b/spec/models/config/golint_spec.rb
@@ -1,15 +1,15 @@
 require "spec_helper"
 require "app/models/config/base"
-require "app/models/config/go"
+require "app/models/config/golint"
 require "app/models/config/parser"
 require "app/models/config_content"
 require "app/models/missing_owner"
 
-describe Config::Go do
+describe Config::Golint do
   describe "#content" do
     it "returns an empty hash" do
       config_content = instance_double("ConfigContent", load: {})
-      content = { go: { enabled: true } }
+      content = { golint: { enabled: true } }
       raw_content = <<~EOS
         go:
           enabled: true
@@ -22,7 +22,7 @@ describe Config::Go do
       )
       owner = instance_double("Owner", config_content: {})
       allow(ConfigContent).to receive(:new).and_return(config_content)
-      config = Config::Go.new(hound_config, owner: owner)
+      config = Config::Golint.new(hound_config, owner: owner)
 
       expect(config.content).to eq({})
     end

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe Linter::Go do
+describe Linter::Golint do
   it_behaves_like "a linter" do
     let(:lintable_files) { %w(foo.go) }
     let(:not_lintable_files) { %w(foo.rb) }
@@ -26,10 +26,10 @@ describe Linter::Go do
       linter.file_review(commit_file)
 
       expect(Resque).to have_received(:enqueue).with(
-        GoReviewJob,
+        LintersJob,
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
-        linter_name: "go",
+        linter_name: "golint",
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,

--- a/spec/support/linters.rb
+++ b/spec/support/linters.rb
@@ -1,7 +1,7 @@
 require "app/models/linter/base"
 require "app/models/linter/coffee_script"
 require "app/models/linter/eslint"
-require "app/models/linter/go"
+require "app/models/linter/golint"
 require "app/models/linter/haml"
 require "app/models/linter/jshint"
 require "app/models/linter/flake8"


### PR DESCRIPTION
Point Golint at the `linters` queue, which is handled by the `linters`
service.

This is a companion to https://github.com/houndci/linters/pull/188