### PR TITLE
Serialize Reek config correctly for linters

### DIFF
--- a/app/models/config/reek.rb
+++ b/app/models/config/reek.rb
@@ -1,7 +1,7 @@
 module Config
   class Reek < Base
-    def content
-      ""
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/linter/reek.rb
+++ b/app/models/linter/reek.rb
@@ -3,10 +3,4 @@ module Linter
   class Reek < Base
     FILE_REGEXP = /.+\.r(b|ake)\z/
   end
-
-  private
-
-  def serialized_configuration
-    "--- {}\n"
-  end
 end

--- a/spec/models/linter/reek_spec.rb
+++ b/spec/models/linter/reek_spec.rb
@@ -1,44 +1,28 @@
 require "rails_helper"
 
-describe Linter::Reek do
+RSpec.describe Linter::Reek do
   it_behaves_like "a linter" do
     let(:lintable_files) { %w(foo.rb foo.rake) }
     let(:not_lintable_files) { %w(foo.js) }
   end
 
   describe "#file_review" do
-    it "is a new file review" do
-      repo = instance_double("Repo", owner: nil)
-      build = instance_double(
-        "Build",
-        commit_sha: "somesha",
-        pull_request_number: 123,
-        repo: repo,
-      )
-      commit_file = instance_double(
-        "CommitFile",
-        content: "code",
-        filename: "lib/ruby.rb",
-        patch: "patch",
-      )
-      file_review = instance_double("FileReview")
-      hound_config = instance_double("HoundConfig")
-      missing_owner = instance_double("MissingOwner")
-      allow(FileReview).to receive(:create!).and_return(file_review)
-      allow(MissingOwner).to receive(:new).and_return(missing_owner)
+    it "schedules a file review" do
+      commit_file = build_commit_file(filename: "lib/foo.rb")
+      linter = build_linter
       allow(Resque).to receive(:enqueue)
-      linter = Linter::Reek.new(build: build, hound_config: hound_config)
 
-      expect(linter.file_review(commit_file)).to eq file_review
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
       expect(Resque).to have_received(:enqueue)
     end
   end
 
   describe "#name" do
     it "is the class name converted to a config-friendly format" do
-      build = instance_double("Build")
-      hound_config = instance_double("HoundConfig")
-      linter = Linter::Reek.new(build: build, hound_config: hound_config)
+      linter = build_linter
 
       expect(linter.name).to eq "reek"
     end


### PR DESCRIPTION
Not sure why it was `""`, but that was preventing us from using Reek
config correctly.