### PR TITLE
Simplify linter's #serialize method

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -13,8 +13,8 @@ module Config
       raise_parse_error("#{file_path} format is invalid")
     end
 
-    def serialize(data = content)
-      data
+    def serialize
+      content
     end
 
     def linter_name

--- a/app/models/config/coffee_script.rb
+++ b/app/models/config/coffee_script.rb
@@ -1,7 +1,7 @@
 module Config
   class CoffeeScript < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize
+      Serializer.json(content)
     end
 
     private

--- a/app/models/config/eslint.rb
+++ b/app/models/config/eslint.rb
@@ -1,7 +1,7 @@
 module Config
   class Eslint < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize
+      Serializer.json(content)
     end
 
     private

--- a/app/models/config/flake8.rb
+++ b/app/models/config/flake8.rb
@@ -1,7 +1,7 @@
 module Config
   class Flake8 < Base
-    def serialize(data = content)
-      Serializer.ini(data)
+    def serialize
+      Serializer.ini(content)
     end
 
     private

--- a/app/models/config/haml.rb
+++ b/app/models/config/haml.rb
@@ -1,7 +1,7 @@
 module Config
   class Haml < Base
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/config/jshint.rb
+++ b/app/models/config/jshint.rb
@@ -1,7 +1,7 @@
 module Config
   class Jshint < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize
+      Serializer.json(content)
     end
 
     private

--- a/app/models/config/remark.rb
+++ b/app/models/config/remark.rb
@@ -1,7 +1,7 @@
 module Config
   class Remark < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize
+      Serializer.json(content)
     end
   end
 end

--- a/app/models/config/rubocop.rb
+++ b/app/models/config/rubocop.rb
@@ -8,8 +8,8 @@ module Config
       end
     end
 
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
 
     private

--- a/app/models/config/sass_lint.rb
+++ b/app/models/config/sass_lint.rb
@@ -1,7 +1,7 @@
 module Config
   class SassLint < Base
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/config/scss.rb
+++ b/app/models/config/scss.rb
@@ -1,7 +1,7 @@
 module Config
   class Scss < Base
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/config/shellcheck.rb
+++ b/app/models/config/shellcheck.rb
@@ -1,7 +1,7 @@
 module Config
   class Shellcheck < Base
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/config/slim_lint.rb
+++ b/app/models/config/slim_lint.rb
@@ -1,7 +1,7 @@
 module Config
   class SlimLint < Base
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/config/stylelint.rb
+++ b/app/models/config/stylelint.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module Config
   class Stylelint < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize
+      Serializer.json(content)
     end
 
     private

--- a/app/models/config/swift.rb
+++ b/app/models/config/swift.rb
@@ -1,7 +1,7 @@
 module Config
   class Swift < Base
-    def serialize(data = content)
-      Serializer.yaml(data)
+    def serialize
+      Serializer.yaml(content)
     end
   end
 end

--- a/app/models/config/tslint.rb
+++ b/app/models/config/tslint.rb
@@ -1,7 +1,7 @@
 module Config
   class Tslint < Base
-    def serialize(data = content)
-      Serializer.json(data)
+    def serialize
+      Serializer.json(content)
     end
 
     private

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -41,7 +41,7 @@ module Linter
     def build_review_job_attributes(commit_file)
       {
         commit_sha: build.commit_sha,
-        config: serialized_configuration,
+        config: config.serialize,
         content: commit_file.content,
         filename: commit_file.filename,
         linter_name: name,
@@ -72,10 +72,6 @@ module Linter
         name: name,
         owner: owner,
       )
-    end
-
-    def serialized_configuration
-      config.serialize
     end
   end
 end

--- a/app/models/linter/flog.rb
+++ b/app/models/linter/flog.rb
@@ -1,11 +1,5 @@
 module Linter
   class Flog < Base
     FILE_REGEXP = /.+\.r(b|ake)\z/
-
-    private
-
-    def serialized_configuration
-      "--- {}\n"
-    end
   end
 end

--- a/spec/models/config/base_spec.rb
+++ b/spec/models/config/base_spec.rb
@@ -8,7 +8,7 @@ require "faraday"
 require "yaml"
 
 class Config::Test < Config::Base
-  def serialize(content)
+  def serialize
     ensure_correct_type(content).to_yaml
   end
 

--- a/spec/models/linter/flog_spec.rb
+++ b/spec/models/linter/flog_spec.rb
@@ -1,85 +1,60 @@
 require "rails_helper"
 
-module Linter
-  RSpec.describe Flog do
-    describe ".can_lint?" do
-      context "when given a '.rb' file" do
-        it "is true" do
-          expect(Flog.can_lint?("foo.rb")).to be(true)
-        end
-      end
+RSpec.describe Linter::Flog do
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.rb foo.rake) }
+    let(:not_lintable_files) { %w(foo.js) }
+  end
 
-      context "when given a '.rake' file" do
-        it "is true" do
-          expect(Flog.can_lint?("foo.rake")).to be(true)
-        end
-      end
-
-      context "when given a non-Ruby file" do
-        it "is false" do
-          expect(Flog.can_lint?("foo.js")).to be(false)
-        end
-      end
-    end
-
-    describe "#enabled?" do
-      context "when Flog linting is enabled" do
-        it "is true" do
-          build = instance_double("Build")
-          hound_config = instance_double("HoundConfig", linter_enabled?: true)
-          linter = Flog.new(build: build, hound_config: hound_config)
-
-          expect(linter).to be_enabled
-        end
-      end
-    end
-
-    describe "#file_included?" do
-      it "is always true" do
+  describe "#enabled?" do
+    context "when Flog linting is enabled" do
+      it "returns true" do
         build = instance_double("Build")
         hound_config = instance_double("HoundConfig", linter_enabled?: true)
-        linter = Flog.new(build: build, hound_config: hound_config)
+        linter = described_class.new(build: build, hound_config: hound_config)
 
-        expect(linter.file_included?).to be(true)
+        expect(linter).to be_enabled
       end
     end
 
-    describe "#file_review" do
-      it "is a new file review" do
-        repo = instance_double("Repo", owner: nil)
-        build = instance_double(
-          "Build",
-          commit_sha: "somesha",
-          pull_request_number: 123,
-          repo: repo,
-        )
-        commit_file = instance_double(
-          "CommitFile",
-          content: "code",
-          filename: "lib/ruby.rb",
-          patch: "patch",
-        )
-        file_review = instance_double("FileReview")
-        hound_config = instance_double("HoundConfig")
-        missing_owner = instance_double("MissingOwner")
-        allow(FileReview).to receive(:create!).and_return(file_review)
-        allow(MissingOwner).to receive(:new).and_return(missing_owner)
-        allow(Resque).to receive(:enqueue)
-        linter = Flog.new(build: build, hound_config: hound_config)
-
-        expect(linter.file_review(commit_file)).to eq file_review
-        expect(Resque).to have_received(:enqueue)
-      end
-    end
-
-    describe "#name" do
-      it "is the class name converted to a config-friendly format" do
+    context "when Flog linting is disabled" do
+      it "returns false" do
         build = instance_double("Build")
-        hound_config = instance_double("HoundConfig")
-        linter = Flog.new(build: build, hound_config: hound_config)
+        hound_config = instance_double("HoundConfig", linter_enabled?: false)
+        linter = described_class.new(build: build, hound_config: hound_config)
 
-        expect(linter.name).to eq "flog"
+        expect(linter).not_to be_enabled
       end
+    end
+  end
+
+  describe "#file_included?" do
+    it "returns true" do
+      linter = build_linter
+
+      expect(linter.file_included?).to be(true)
+    end
+  end
+
+  describe "#file_review" do
+    it "schedules a file review" do
+      commit_file = build_commit_file(filename: "lib/foo.rb")
+      linter = build_linter
+      allow(Resque).to receive(:enqueue)
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+      expect(Resque).to have_received(:enqueue)
+    end
+  end
+
+  describe "#name" do
+    it "is the class name converted to a config-friendly format" do
+      linter = build_linter
+
+      expect(linter.name).to eq "flog"
     end
   end
 end


### PR DESCRIPTION
Nothing ever was passing a parameter to `#serialize`.