### PR TITLE
Add support for linting .erb.html files.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,8 @@ as well as any default configuration they might use:
 1. Shell scripts
     * [ShellCheck](https://github.com/koalaman/shellcheck)
     * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/shellcheck)
+1. ERB Lint
+    * [ERB Lint](https://github.com/Shopify/erb-lint)
 
 ### Writing a Linter
 

--- a/app/models/config/erblint.rb
+++ b/app/models/config/erblint.rb
@@ -1,0 +1,7 @@
+module Config
+  class Erblint < Base
+    def serialize(data = content)
+      Serializer.yaml(data)
+    end
+  end
+end

--- a/app/models/hound_config.rb
+++ b/app/models/hound_config.rb
@@ -4,6 +4,7 @@ class HoundConfig
   LINTERS = {
     Linter::CoffeeScript => { default: true },
     Linter::Credo => { default: false },
+    Linter::Erblint => { default: false },
     Linter::Eslint => { default: false },
     Linter::Flake8 => { default: false },
     Linter::Flog => { default: false },

--- a/app/models/linter/erblint.rb
+++ b/app/models/linter/erblint.rb
@@ -1,0 +1,9 @@
+module Linter
+  class Erblint < Base
+    FILE_REGEXP = /.+(.html.erb)\z/
+
+    def job_class
+      LintersJob
+    end
+  end
+end

--- a/app/views/pages/configuration.haml
+++ b/app/views/pages/configuration.haml
@@ -31,6 +31,8 @@
         = link_to "Sass Lint", "#sass-lint", class: "docs-nav-link"
       %li
         = link_to "ShellCheck", "#shellcheck", class: "docs-nav-link"
+      %li
+        = link_to "ERB Lint", "#erblint", class: "docs-nav-link"
 
   %section.docs-content
     %article.docs-article
@@ -619,6 +621,73 @@
           "https://github.com/koalaman/shellcheck/wiki",
           new_window_options
         for information on ShellCheck codes.
+
+    %article.docs-article#erblint
+      %h2 ERB Lint
+      %p
+        Hound uses
+        = link_to "ERB Lint",
+          "https://github.com/shopify/erb-lint",
+          new_window_options
+        to review erb templates.
+
+      %p
+        To enable ERB style checking, add the following to your
+        %em.code-inline .hound.yml
+
+        %code.code-block
+          :preserve
+            erblint:
+              enabled: true
+      %p
+        To tell erb-lint to ignore certain codes, add
+        %em.code-inline .erb-lint.yml
+        file to your project (or give it another name if you like),
+        include in it codes you want ignored, and reference the file in your
+        %em.code-inline .hound.yml
+
+      %p
+        %code.code-block
+          :preserve
+            erblint:
+              enabled: true
+              config_file: .erb-lint.yml
+
+      %p
+        Example config file:
+        %code.code-block
+          :preserve
+            linters:
+              Rubocop:
+                enabled: true
+                rubocop_config:
+                  inherit_from:
+                    - .rubocop.yml
+                  Layout/InitialIndentation:
+                    Enabled: false
+                  Layout/TrailingBlankLines:
+                    Enabled: false
+                  Layout/TrailingWhitespace:
+                    Enabled: false
+                  Naming/FileName:
+                    Enabled: false
+                  Style/FrozenStringLiteralComment:
+                    Enabled: false
+                  Metrics/LineLength:
+                    Enabled: false
+                  Lint/UselessAssignment:
+                    Enabled: false
+                  Rails/OutputSafety:
+                    Enabled: false
+              FinalNewline:
+                enabled: true
+
+        See
+        = link_to "ERB Lint README",
+          "https://github.com/shopify/erb-lint",
+          new_window_options
+        for information on ERB Lint codes.
+
 
     %article.docs-article
       %h3 Didn't find what you where looking for?

--- a/spec/models/linter/erblint_spec.rb
+++ b/spec/models/linter/erblint_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe Linter::Erblint do
+  it_behaves_like "a linter" do
+    let(:lintable_files) { %w(foo.html.erb) }
+    let(:not_lintable_files) { %w(foo.js.erb) }
+  end
+
+  describe "#file_review" do
+    it "returns a saved and incomplete file review" do
+      commit_file = build_commit_file(filename: "lib/a.html.erb")
+      linter = build_linter
+
+      result = linter.file_review(commit_file)
+
+      expect(result).to be_persisted
+      expect(result).not_to be_completed
+    end
+
+    it "schedules a review job" do
+      build = build(:build, commit_sha: "foo", pull_request_number: 123)
+      commit_file = build_commit_file(filename: "lib/a.html.erb")
+      allow(Resque).to receive(:enqueue)
+      linter = build_linter(build)
+
+      linter.file_review(commit_file)
+
+      expect(Resque).to have_received(:enqueue).with(
+        LintersJob,
+        filename: commit_file.filename,
+        commit_sha: build.commit_sha,
+        linter_name: "erblint",
+        pull_request_number: build.pull_request_number,
+        patch: commit_file.patch,
+        content: commit_file.content,
+        config: "--- {}\n",
+      )
+    end
+  end
+end


### PR DESCRIPTION
Note: Something that would greatly help developing new linters is to have a dry-run mode which doesn't require github integration. Something as simple as a raketask that you can invoke with a path to a gitrepo and a refspec/branch, and see that the integration work would be golden. Sadly I don't have enough understanding of this codebase to implement that.