### PR TITLE
Don't run Flog on spec/test files

### DIFF
--- a/app/models/linter/flog.rb
+++ b/app/models/linter/flog.rb
@@ -1,5 +1,9 @@
 module Linter
   class Flog < Base
     FILE_REGEXP = /.+\.r(b|ake)\z/
+
+    def file_included?(commit_file)
+      commit_file.filename !~ /^(spec|test)\//
+    end
   end
 end

--- a/spec/models/linter/flog_spec.rb
+++ b/spec/models/linter/flog_spec.rb
@@ -6,6 +6,32 @@ RSpec.describe Linter::Flog do
     let(:not_lintable_files) { %w(foo.js) }
   end
 
+  describe "#file_included?" do
+    context "with test or spec file" do
+      it "returns false" do
+        spec_file = build_commit_file(filename: "spec/models/user_spec.rb")
+        test_file = build_commit_file(filename: "spec/models/user_spec.rb")
+        linter = build_linter
+
+        expect(linter.file_included?(spec_file)).to eq false
+        expect(linter.file_included?(test_file)).to eq false
+      end
+    end
+
+    context "with any other ruby file" do
+      it "returns true" do
+        file1 = build_commit_file(filename: "app/models/user.rb")
+        file2 = build_commit_file(filename: "lib/tasks/work.rake")
+        file3 = build_commit_file(filename: "app.rb")
+        linter = build_linter
+
+        expect(linter.file_included?(file1)).to eq true
+        expect(linter.file_included?(file2)).to eq true
+        expect(linter.file_included?(file3)).to eq true
+      end
+    end
+  end
+
   describe "#enabled?" do
     context "when Flog linting is enabled" do
       it "returns true" do
@@ -25,14 +51,6 @@ RSpec.describe Linter::Flog do
 
         expect(linter).not_to be_enabled
       end
-    end
-  end
-
-  describe "#file_included?" do
-    it "returns true" do
-      linter = build_linter
-
-      expect(linter.file_included?).to be(true)
     end
   end
 


### PR DESCRIPTION
It creates a lot of noise.
Generally, spec and test files are less concise due to verbosity of
them.