### PR TITLE
Show searchbar on its own line

### DIFF
--- a/app/assets/stylesheets/pages/repos/_organization.scss
+++ b/app/assets/stylesheets/pages/repos/_organization.scss
@@ -3,7 +3,6 @@ $dropdown-arrow: $white image-url("select-arrow.svg") no-repeat;
 .organization {
   border: 1px solid $base-border-color;
   border-radius: $base-border-radius;
-  margin-bottom: 1em;
   width: 100%;
 }
 

--- a/app/assets/stylesheets/pages/repos/_tools.scss
+++ b/app/assets/stylesheets/pages/repos/_tools.scss
@@ -1,23 +1,19 @@
 .repo-tools {
   background: $white;
-  display: table;
-  padding: 0 0 2em;
+  display: flex;
+  flex-wrap: wrap;
   vertical-align: middle;
-  width: 100%;
+
+  @include media($small-screen-only) {
+    flex-direction: column;
+  }
 }
 
 .repo-tools-search {
-  @include span-columns(5 of 12, table);
-  padding-right: 1em;
+  flex-basis: 100%;
+  margin: 0.5em 0;
   position: relative;
   vertical-align: top;
-
-  @include media($small-screen-only) {
-    display: block;
-    margin-bottom: 1em;
-    padding: 0;
-    width: 100%;
-  }
 }
 
 .repo-search-tools-input {
@@ -55,23 +51,16 @@
 
 .repo-tools-refresh,
 .repo-tools-private {
+  flex-grow: 1;
+  flex-shrink: 0;
   vertical-align: top;
 }
 
 .repo-tools-private {
-  @include span-columns(4 of 12, table);
-  padding-right: 1em;
+  margin-right: 0.5em;
 
-  @include media($medium-screen-down) {
-    display: none;
-  }
-}
-
-.repo-tools-refresh {
-  @include span-columns(3 of 12, table);
   @include media($small-screen-only) {
-    display: block;
-    width: 100%;
+    margin: 0 0 0.5em;
   }
 }
 

--- a/app/javascript/__tests__/__snapshots__/repo_tools-test.jsx.snap
+++ b/app/javascript/__tests__/__snapshots__/repo_tools-test.jsx.snap
@@ -4,13 +4,13 @@ exports[`renders appropriately with Show Private button (not syncing) 1`] = `
 <div
   className="repo-tools"
 >
-  <RepoToolsSearch
-    onSearchInput={[Function]}
-  />
   <RepoToolsPrivate />
   <RepoToolsRefresh
     isSyncing={false}
     onRefreshClicked={[Function]}
+  />
+  <RepoToolsSearch
+    onSearchInput={[Function]}
   />
 </div>
 `;
@@ -19,12 +19,12 @@ exports[`renders appropriately without Show Private button (not syncing) 1`] = `
 <div
   className="repo-tools"
 >
-  <RepoToolsSearch
-    onSearchInput={[Function]}
-  />
   <RepoToolsRefresh
     isSyncing={false}
     onRefreshClicked={[Function]}
+  />
+  <RepoToolsSearch
+    onSearchInput={[Function]}
   />
 </div>
 `;

--- a/app/javascript/components/ReposContainer/components/RepoTools.jsx
+++ b/app/javascript/components/ReposContainer/components/RepoTools.jsx
@@ -15,12 +15,12 @@ export default class RepoTools extends React.Component {
 
     return (
       <div className="repo-tools">
-        <RepoToolsSearch onSearchInput={onSearchInput} />
-        {showPrivateButton ? <RepoToolsPrivate /> : null}
+        {showPrivateButton && <RepoToolsPrivate />}
         <RepoToolsRefresh
           isSyncing={isSyncing}
           onRefreshClicked={onRefreshClicked}
         />
+        <RepoToolsSearch onSearchInput={onSearchInput} />
       </div>
     );
   }


### PR DESCRIPTION
The two buttons aren't related to the search, and they don't need to be
pressed for the search to happen. Thus, I think it makes sense to have
the searchbar live on its own line.

Also, don't hide "Include private repos" button on small screens
(phones).

![toolbar](https://user-images.githubusercontent.com/116327/45276498-8c22d100-b477-11e8-9531-02ec961f4276.gif)
