### PR TITLE
Consolidate comments based on message

### DIFF
--- a/app/services/submit_review.rb
+++ b/app/services/submit_review.rb
@@ -24,13 +24,9 @@ class SubmitReview
   end
 
   def new_violations
-    @_new_violations ||= priority_violations.select do |violation|
+    @_new_violations ||= build.violations.select do |violation|
       commenting_policy.comment_on?(violation)
     end
-  end
-
-  def priority_violations
-    build.violations.take(Hound::MAX_COMMENTS)
   end
 
   def build_comment(violation)

--- a/spec/services/complete_build_spec.rb
+++ b/spec/services/complete_build_spec.rb
@@ -109,8 +109,7 @@ RSpec.describe CompleteBuild do
 
     def stub_build(violation_messages, attributes = {})
       violations = violation_messages.map do |violation_message|
-        instance_double(
-          "Violation",
+        OpenStruct.new(
           filename: "app/anything.rb",
           patch_position: 1,
           messages: [violation_message],

--- a/spec/services/submit_review_spec.rb
+++ b/spec/services/submit_review_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe SubmitReview do
   describe ".call" do
     it "posts a review to GitHub" do
-      stub_const("Hound::MAX_COMMENTS", 2)
       violation1 = stub_violation("foo comment")
       violation2 = stub_violation("bar comment")
       violation3 = stub_violation("baz comment")
@@ -50,6 +49,38 @@ RSpec.describe SubmitReview do
       )
     end
 
+    it "posts a consolidated review to GitHub" do
+      stub_const("Hound::MAX_COMMENTS", 2)
+      violation1 = stub_violation("foo comment")
+      violation2 = stub_violation("bar comment")
+      violation3 = stub_violation("bar comment")
+      violation4 = stub_violation("bar comment")
+      build = stub_build(
+        violations: [violation1, violation2, violation3, violation4],
+      )
+      github = stub_github
+
+      described_class.call(build)
+
+      expect(github).to have_received(:create_pull_request_review).with(
+        build.repo_name,
+        build.pull_request_number,
+        [
+          {
+            path: violation1.filename,
+            position: violation1.patch_position,
+            body: violation1.messages.join,
+          },
+          {
+            path: violation2.filename,
+            position: violation2.patch_position,
+            body: violation2.messages.join,
+          },
+        ],
+        ""
+      )
+    end
+
     context "with existing violations" do
       it "makes comments only for new violations" do
         violation1 = stub_violation("foo")
@@ -87,8 +118,7 @@ RSpec.describe SubmitReview do
   end
 
   def stub_violation(message)
-    instance_double(
-      "Violation",
+    OpenStruct.new(
       filename: "test.rb",
       messages: [message],
       patch_position: 1,

--- a/spec/services/submit_review_spec.rb
+++ b/spec/services/submit_review_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe SubmitReview do
   describe ".call" do
-    it "posts a review with max comments to GitHub" do
+    it "posts a review to GitHub" do
       stub_const("Hound::MAX_COMMENTS", 2)
       violation1 = stub_violation("foo comment")
       violation2 = stub_violation("bar comment")
@@ -28,6 +28,11 @@ RSpec.describe SubmitReview do
             path: violation2.filename,
             position: violation2.patch_position,
             body: violation2.messages.join,
+          },
+          {
+            path: violation3.filename,
+            position: violation3.patch_position,
+            body: violation3.messages.join,
           },
         ],
         <<~TEXT.chomp


### PR DESCRIPTION
This will group Hound comments when there are more than 16 similar messages using this format: `Line was too long (Hound found 3 similar cases)`.