### PR TITLE
Remove build stats from Account page

### DIFF
--- a/app/views/accounts/show.haml
+++ b/app/views/accounts/show.haml
@@ -68,18 +68,12 @@
           %thead
             %tr
               %th Repository
-              %th Reviews given
-              %th Violations caught
           %tbody
             - @account_page.repos.each do |repo|
               %tr.repo
                 %td
                   %span.repo-name
                     = repo.name
-                %td.reviews-given
-                  = repo.builds.count
-                %td.violations-caught
-                  = repo.total_violations
       - else
         None yet, go to your
         = link_to "repos", repos_path


### PR DESCRIPTION
These stats slow down the account page and occasionally time out. If customers find them useful we should cache the stats or deliver through a digest email or something similar.