### PR TITLE
Rename BuilRunner to StartBuild

### DIFF
--- a/app/services/start_build.rb
+++ b/app/services/start_build.rb
@@ -1,4 +1,4 @@
-class BuildRunner
+class StartBuild
   static_facade :call
   pattr_initialize :payload
 
@@ -14,10 +14,6 @@ class BuildRunner
   rescue StandardError
     set_internal_error
     raise
-  end
-
-  def set_internal_error
-    commit_status.set_internal_error
   end
 
   private
@@ -109,5 +105,9 @@ class BuildRunner
 
   def set_no_violations_status
     commit_status.set_success(0)
+  end
+
+  def set_internal_error
+    commit_status.set_internal_error
   end
 end

--- a/spec/jobs/buildable_spec.rb
+++ b/spec/jobs/buildable_spec.rb
@@ -8,12 +8,12 @@ describe Buildable do
   describe "#perform" do
     it 'runs build runner' do
       payload = stub_payload(payload_data)
-      allow(BuildRunner).to receive(:call)
+      allow(StartBuild).to receive(:call)
 
       BuildableTestJob.perform_now(payload_data)
 
       expect(Payload).to have_received(:new).with(payload_data)
-      expect(BuildRunner).to have_received(:call).with(payload)
+      expect(StartBuild).to have_received(:call).with(payload)
     end
 
     it "runs repo updater" do
@@ -28,7 +28,7 @@ describe Buildable do
 
     context "when the pull request has been blacklisted" do
       it "does not set the status" do
-        payload_data = payload_data(full_name: "ignore/me", number: 42)
+        payload_data = payload_data(repo_name: "ignore/me", pr_number: 42)
         create(
           :blacklisted_pull_request,
           full_repo_name: "ignore/me",
@@ -42,49 +42,49 @@ describe Buildable do
       end
 
       it "does not run the build" do
-        payload_data = payload_data(full_name: "ignore/me", number: 42)
+        payload_data = payload_data(repo_name: "ignore/me", pr_number: 42)
         create(
           :blacklisted_pull_request,
           full_repo_name: "ignore/me",
           pull_request_number: 42,
         )
-        allow(BuildRunner).to receive(:new)
+        allow(StartBuild).to receive(:new)
 
         BuildableTestJob.perform_now(payload_data)
 
-        expect(BuildRunner).not_to have_received(:new)
+        expect(StartBuild).not_to have_received(:new)
       end
     end
   end
 
   describe "#after_retry_exhausted" do
     it "sets internal server error on github" do
-      build_runner = double("BuildRunner", set_internal_error: nil)
-      payload = double("Payload")
-      allow(Payload).to receive(:new).with(payload_data).and_return(payload)
-      allow(BuildRunner).to receive(:new).and_return(build_runner)
+      repo = create(:repo, :active)
+      raw_payload = payload_data(
+        repo_name: repo.name,
+        github_id: repo.github_id,
+      )
+      error_status_request = stub_status_request(
+        repo.name,
+        nil,
+        "error",
+        I18n.t(:hound_error_status),
+      )
 
-      BuildableTestJob.new(payload_data).after_retry_exhausted
+      BuildableTestJob.new(raw_payload).after_retry_exhausted
 
-      expect(Payload).to have_received(:new).with(payload_data)
-      expect(BuildRunner).to have_received(:new).with(payload)
-      expect(build_runner).to have_received(:set_internal_error)
+      expect(error_status_request).to have_been_made
     end
   end
 
-  def payload_data(
-    github_id: 1234,
-    name: "test",
-    full_name: "user/repo",
-    number: 1
-  )
+  def payload_data(github_id: 1234, repo_name: "user/repo", pr_number: 1)
     {
-      "number" => number,
+      "number" => pr_number,
       "repository" => {
-        "full_name" => full_name,
+        "id" => github_id,
+        "full_name" => repo_name,
         "owner" => {
-          "id" => github_id,
-          "login" => name,
+          "login" => "foo",
           "type" => "Organization"
         }
       }

--- a/spec/models/github_event_spec.rb
+++ b/spec/models/github_event_spec.rb
@@ -41,13 +41,13 @@ RSpec.describe GitHubEvent do
             type: GitHubEvent::PULL_REQUEST,
             body: body,
           )
-          allow(BuildRunner).to receive(:call)
+          allow(StartBuild).to receive(:call)
 
           run_background_jobs_immediately do
             event.process
           end
 
-          expect(BuildRunner).to have_received(:call)
+          expect(StartBuild).to have_received(:call)
         end
       end
     end


### PR DESCRIPTION
It follows more of our convestion of naming services after what they do,
using a verb first. For example, `CreateRepo` or `SubmitReview`.

`StartBuild` fits nicely with the `CompleteBuild` service that we have.