### PR TITLE
Rename StyleChecker to ReviewFiles

### DIFF
--- a/app/services/review_files.rb
+++ b/app/services/review_files.rb
@@ -1,7 +1,7 @@
-class StyleChecker
+class ReviewFiles
   pattr_initialize :pull_request, :build
 
-  def review_files
+  def call
     pull_request.commit_files.each { |commit_file| review_file(commit_file) }
   end
 

--- a/app/services/start_build.rb
+++ b/app/services/start_build.rb
@@ -39,7 +39,7 @@ class StartBuild
   end
 
   def review_files(build)
-    StyleChecker.new(pull_request, build).review_files
+    ReviewFiles.new(pull_request, build).call
   end
 
   def create_build

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -183,11 +183,11 @@ REST API to get the pull request's patch and file contents.
 Hound never fetches a complete version of your codebase.
 
 In Ruby memory,
-`StartBuild` passes your pull request's contents to [`StyleChecker`],
+`StartBuild` passes your pull request's contents to [`ReviewFiles`],
 which loops through the changed files and delegates to the appropriate
 [`Linter`] Ruby classes based on file extension (`.rb`, `.js`, etc.).
 
-[`StyleChecker`]: ../app/models/style_checker.rb
+[`ReviewFiles`]: ../app/services/review_files.rb
 [`Linter`]: ../app/models/linter/
 
 The `Linter` classes schedule a job on a queue with all the necessary
@@ -227,7 +227,7 @@ receiving and processing pull request notifications,
 try `grep`ing for the following terms:
 
 ```bash
-grep -R StyleChecker app
+grep -R ReviewFiles app
 grep -R CompleteFileReview app
 grep -R SubmitReview app
 ```

--- a/spec/services/review_files_spec.rb
+++ b/spec/services/review_files_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
-describe StyleChecker do
-  describe "#review_files" do
+RSpec.describe ReviewFiles do
+  describe "#call" do
     it "returns a collection of incomplete file reviews" do
       stylish_commit_file = stub_commit_file("good.rb", "def good; end")
       violated_commit_file = stub_commit_file("bad.rb", "def bad(a ); a; end  ")
@@ -54,7 +54,7 @@ describe StyleChecker do
     repo = build(:repo, owner: build(:owner, config_enabled: false))
     build = build(:build, repo: repo)
 
-    StyleChecker.new(pull_request, build).review_files
+    described_class.new(pull_request, build).call
 
     build.file_reviews
   end
@@ -64,7 +64,8 @@ describe StyleChecker do
       :build,
       repo: build(:repo, owner: build(:owner, config_enabled: false)),
     )
-    StyleChecker.new(pull_request, build).review_files
+
+    described_class.new(pull_request, build).call
 
     build.violations.flat_map(&:messages)
   end

--- a/spec/services/start_build_spec.rb
+++ b/spec/services/start_build_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe StartBuild do
           full_repo_name: repo.name,
         )
         service = described_class.new(payload)
-        stubbed_style_checker(violations: [build(:violation)])
+        stub_review_files(violations: [build(:violation)])
         stubbed_github_api
 
         service.call
@@ -32,7 +32,7 @@ RSpec.describe StartBuild do
         payload = stubbed_payload(github_repo_id: repo.github_id)
         service = described_class.new(payload)
         stubbed_pull_request
-        stubbed_style_checker(violations: [build(:violation)])
+        stub_review_files(violations: [build(:violation)])
         stubbed_github_api
 
         service.call
@@ -53,7 +53,7 @@ RSpec.describe StartBuild do
           build(:violation),
           build(:violation, messages: ["wrong", "bad"]),
         ]
-        stubbed_style_checker(violations: violations)
+        stub_review_files(violations: violations)
         github_api = stubbed_github_api
 
         service.call
@@ -75,7 +75,7 @@ RSpec.describe StartBuild do
           repository_owner_is_organization?: true,
         )
         service = described_class.new(payload)
-        stubbed_style_checker(violations: [build(:violation)])
+        stub_review_files(violations: [build(:violation)])
         stubbed_github_api
 
         service.call
@@ -122,7 +122,7 @@ RSpec.describe StartBuild do
           full_repo_name: repo.name,
         )
         service = described_class.new(payload)
-        stubbed_style_checker(violations: [build(:violation)])
+        stub_review_files(violations: [build(:violation)])
         stubbed_pull_request
         stubbed_github_api
 
@@ -245,15 +245,15 @@ RSpec.describe StartBuild do
       end
     end
 
-    def stubbed_style_checker(violations: [])
+    def stub_review_files(violations: [])
       file_review = build(:file_review, :completed, violations: violations)
-      style_checker = double("StyleChecker", review_files: nil)
-      allow(StyleChecker).to receive(:new) do |*args|
+      review_files = instance_double("ReviewFiles", call: nil)
+      allow(ReviewFiles).to receive(:new) do |*args|
         build = args[1]
         build.file_reviews << file_review
-      end.and_return(style_checker)
+      end.and_return(review_files)
 
-      style_checker
+      review_files
     end
 
     def stubbed_pull_request(files = [double("CommitFile")])


### PR DESCRIPTION
To follow the convention of naming our services with verb/action first.
`ReviewFiles` describes what this class does well.