### PR TITLE
Simplify payment failure status

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
     one: "1 violation found."
     other: "%{count} violations found."
   hound_error_status: "We've encountered an error while reviewing your code."
-  past_due_status: "We're having trouble processing your Hound payment."
+  past_due_status: "We're having trouble processing your payment."
 
   account:
     billable_email:


### PR DESCRIPTION
Hound is redundant when used in the payment issue status message.

**Before**

![image](https://user-images.githubusercontent.com/154463/47511909-fa590280-d82f-11e8-985d-4790c67e1363.png)
