### PR TITLE
Default LintersJob as the default job for linters

### DIFF
--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -55,12 +55,8 @@ module Linter
       Resque.enqueue(job_class, attributes)
     end
 
-    def job_name
-      "#{name.classify}ReviewJob"
-    end
-
     def job_class
-      job_name.constantize
+      LintersJob
     end
 
     def owner

--- a/app/models/linter/coffeelint.rb
+++ b/app/models/linter/coffeelint.rb
@@ -3,11 +3,5 @@
 module Linter
   class Coffeelint < Base
     FILE_REGEXP = /.+\.coffee(\.js)?(\.erb)?\z/
-
-    private
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/credo.rb
+++ b/app/models/linter/credo.rb
@@ -1,5 +1,11 @@
 module Linter
   class Credo < Base
     FILE_REGEXP = /.+(\.ex|\.exs)\z/
+
+    private
+
+    def job_class
+      CredoReviewJob
+    end
   end
 end

--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -9,6 +9,10 @@ module Linter
 
     private
 
+    def job_class
+      EslintReviewJob
+    end
+
     def ignore_file
       @_ignore_file ||= IgnoreFile.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/app/models/linter/flog.rb
+++ b/app/models/linter/flog.rb
@@ -5,5 +5,11 @@ module Linter
     def file_included?(commit_file)
       commit_file.filename !~ /^(spec|test)\//
     end
+
+    private
+
+    def job_class
+      FlogReviewJob
+    end
   end
 end

--- a/app/models/linter/golint.rb
+++ b/app/models/linter/golint.rb
@@ -14,9 +14,5 @@ module Linter
       path_components.include?("vendor") ||
         path_components.take(2) == ["Godeps", "_workspace"]
     end
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/haml_lint.rb
+++ b/app/models/linter/haml_lint.rb
@@ -1,11 +1,5 @@
 module Linter
   class HamlLint < Base
     FILE_REGEXP = /.+\.haml\z/
-
-    private
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -9,6 +9,10 @@ module Linter
 
     private
 
+    def job_class
+      JshintReviewJob
+    end
+
     def ignore_file
       @_ignore_file ||= IgnoreFile.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/app/models/linter/reek.rb
+++ b/app/models/linter/reek.rb
@@ -3,4 +3,10 @@ module Linter
   class Reek < Base
     FILE_REGEXP = /.+\.r(b|ake)\z/
   end
+
+  private
+
+  def job_class
+    ReekReviewJob
+  end
 end

--- a/app/models/linter/remark.rb
+++ b/app/models/linter/remark.rb
@@ -1,11 +1,5 @@
 module Linter
   class Remark < Base
     FILE_REGEXP = /.+\.(?:md|markdown)\z/
-
-    private
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/rubocop.rb
+++ b/app/models/linter/rubocop.rb
@@ -1,11 +1,5 @@
 module Linter
   class Rubocop < Base
     FILE_REGEXP = /.+(\.rb|\.rake|\.jbuilder)|(Gemfile|Rakefile)\z/
-
-    private
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/sass_lint.rb
+++ b/app/models/linter/sass_lint.rb
@@ -1,9 +1,5 @@
 module Linter
   class SassLint < Base
     FILE_REGEXP = /.+\.s(a|c)ss\z/
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/scss_lint.rb
+++ b/app/models/linter/scss_lint.rb
@@ -1,11 +1,5 @@
 module Linter
   class ScssLint < Base
     FILE_REGEXP = /.+\.scss\z/
-
-    private
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/shellcheck.rb
+++ b/app/models/linter/shellcheck.rb
@@ -1,9 +1,5 @@
 module Linter
   class Shellcheck < Base
     FILE_REGEXP = /.+(\.sh|\.zsh|\.bash)\z/
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/slim_lint.rb
+++ b/app/models/linter/slim_lint.rb
@@ -1,9 +1,5 @@
 module Linter
   class SlimLint < Base
     FILE_REGEXP = /.slim\z/
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/stylelint.rb
+++ b/app/models/linter/stylelint.rb
@@ -8,10 +8,6 @@ module Linter
       ignore_file.file_included?(commit_file.filename)
     end
 
-    def job_class
-      LintersJob
-    end
-
     private
 
     def ignore_file

--- a/app/models/linter/swiftlint.rb
+++ b/app/models/linter/swiftlint.rb
@@ -1,11 +1,5 @@
 module Linter
   class Swiftlint < Base
     FILE_REGEXP = /.+\.swift\z/
-
-    private
-
-    def job_class
-      LintersJob
-    end
   end
 end

--- a/app/models/linter/tslint.rb
+++ b/app/models/linter/tslint.rb
@@ -1,5 +1,11 @@
 module Linter
   class Tslint < Base
     FILE_REGEXP = /.+\.ts[x]?\z/
+
+    private
+
+    def job_class
+      TslintReviewJob
+    end
   end
 end

--- a/spec/models/linter/base_spec.rb
+++ b/spec/models/linter/base_spec.rb
@@ -6,7 +6,6 @@ module Linter
   end
 end
 
-class TestReviewJob; end
 
 describe Linter::Test do
   it_behaves_like "a linter" do
@@ -31,7 +30,7 @@ describe Linter::Test do
         linter.file_review(commit_file)
 
         expect(Resque).to have_received(:enqueue).with(
-          TestReviewJob,
+          LintersJob,
           hash_including(linter_version: nil),
         )
       end
@@ -53,7 +52,7 @@ describe Linter::Test do
         linter.file_review(commit_file)
 
         expect(Resque).to have_received(:enqueue).with(
-          TestReviewJob,
+          LintersJob,
           hash_including(linter_version: 1.0),
         )
       end


### PR DESCRIPTION
Only a handful of linters still queue to their specific queues.
Everything else is moving to the `linters` queue.