### PR TITLE
Disable Reek and Flog

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -9,10 +9,3 @@ scss:
 
 eslint:
   version: 5.7.0
-
-reek:
-  enabled: true
-  config_file: .reek
-
-flog:
-  enabled: true

--- a/.reek
+++ b/.reek
@@ -1,9 +1,0 @@
-detectors:
-  IrresponsibleModule:
-    enabled: false
-
-  DuplicateMethodCall:
-    enabled: false
-
-  UtilityFunction:
-    public_methods_only: true


### PR DESCRIPTION
Our team didn't find the violations from them useful, but rather noisy.