### PR TITLE
 Remove handling of legacy config

### DIFF
--- a/app/models/config/rubocop.rb
+++ b/app/models/config/rubocop.rb
@@ -1,17 +1,5 @@
 module Config
   class Rubocop < Base
-    def content
-      if legacy?
-        Raven.capture_message(
-          "Legacy Hound config detected",
-          extra: { repo_name: hound_config.commit.repo_name },
-        )
-        hound_config.content
-      else
-        super
-      end
-    end
-
     def serialize
       Serializer.yaml(content)
     end
@@ -38,18 +26,6 @@ module Config
       parse(content)
     rescue Psych::Exception => exception
       raise_parse_error(exception.message)
-    end
-
-    def legacy?
-      (configured_languages & all_linter_names).empty?
-    end
-
-    def all_linter_names
-      HoundConfig::LINTERS.keys.map { |klass| klass.name.demodulize.underscore }
-    end
-
-    def configured_languages
-      hound_config.content.keys
     end
   end
 end

--- a/app/services/complete_file_review.rb
+++ b/app/services/complete_file_review.rb
@@ -49,17 +49,7 @@ class CompleteFileReview
   end
 
   def file_review_properties
-    if attributes.has_key?(:linter_name)
-      legacy_file_review_search_properties.merge(
-        linter_name: attributes.fetch(:linter_name),
-      )
-    else
-      legacy_file_review_search_properties
-    end
-  end
-
-  def legacy_file_review_search_properties
-    { filename: attributes.fetch(:filename) }
+    attributes.slice(:filename, :linter_name)
   end
 
   def commit_file

--- a/spec/models/config/coffeelint_spec.rb
+++ b/spec/models/config/coffeelint_spec.rb
@@ -9,37 +9,20 @@ require "app/models/missing_owner"
 
 RSpec.describe Config::Coffeelint do
   describe "#content" do
-    context "with a modern coffeelint config" do
-      it "returns the content from GitHub as a hash" do
-        raw_config = <<~EOS
-          { "arrow_spacing": { "level": "error" } }
-        EOS
-        config = build_config(raw_config)
+    it "returns the content from GitHub as a hash" do
+      raw_config = <<~JSON
+        { "arrow_spacing": { "level": "error" } }
+      JSON
+      config = build_config(raw_config)
 
-        result = config.content
+      result = config.content
 
-        expect(result).to eq(
-          "arrow_spacing" => { "level" => "error" },
-        )
-      end
+      expect(result).to eq(
+        "arrow_spacing" => { "level" => "error" },
+      )
     end
 
-    context "with a legacy coffeelint config" do
-      it "returns the content from GitHub as a hash" do
-        raw_config = <<~EOS
-          { "arrow_spacing": { "level": "error" } }
-        EOS
-        config = build_config(raw_config)
-
-        result = config.content
-
-        expect(result).to eq(
-          "arrow_spacing" => { "level" => "error" },
-        )
-      end
-    end
-
-    context "config with comments and trailing commas" do
+    context "when config has comments and trailing commas" do
       it "returns the content from GitHub as a hash" do
         raw_config = <<~EOS
           {


### PR DESCRIPTION
We haven't seen any captures of legacy Hound config,
so we can assume nobody is using it anymore and cleanup the code.

Cleanup additional legacy logic.