### PR TITLE
Suppress error about failure to set GH status

### DIFF
--- a/app/jobs/buildable.rb
+++ b/app/jobs/buildable.rb
@@ -9,6 +9,14 @@ module Buildable
   end
 
   def after_retry_exhausted
+    unless $! && $!.message.match?(%r{/statuses/\w+: 404 - Not Found})
+      set_error_status
+    end
+  end
+
+  private
+
+  def set_error_status
     payload = Payload.new(*arguments)
     repo = Repo.active.find_by(github_id: payload.github_repo_id)
     github_auth = GitHubAuth.new(repo)
@@ -19,8 +27,6 @@ module Buildable
     )
     commit_status.set_internal_error
   end
-
-  private
 
   def blacklisted?(payload)
     BlacklistedPullRequest.where(

--- a/app/jobs/retryable.rb
+++ b/app/jobs/retryable.rb
@@ -7,10 +7,12 @@ module Retryable
     rescue_from(StandardError) do |exception|
       if attempts >= Retryable.retry_attempts
         after_retry_attempts
-        raise exception
+        unless exception.message.match?(%r{/statuses/\w+: 404 - Not Found})
+          raise exception
+        end
+      else
+        retry_job wait: Retryable.retry_delay
       end
-
-      retry_job wait: Retryable.retry_delay
     end
   end
 


### PR DESCRIPTION
This will reduce the noise of exceptions that we get.
We currently report a general Sentry notification when we can't set the
status.

Additionally, some open source repos cannot be reviewed if we don't have
a valid token for them (all user tokens have become invalid or expired),
because we can't set their status.
With this change, we'll be able to review them and make comments on
violations, even though we cannot set the status.