### PR TITLE
Add more doc for ERB-Lint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,9 @@ as well as any default configuration they might use:
     * [HAML-Lint](https://github.com/brigade/haml-lint)
     * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/haml_lint)
     * [default config](https://raw.githubusercontent.com/houndci/linters/master/config/haml.yml)
+1. ERB
+    * [ERB Lint](https://github.com/Shopify/erb-lint)
+    * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/erb_lint)
 1. Elixir
     * [Credo](https://github.com/rrrene/credo)
     * [houndci/linters](https://github.com/houndci/linters/tree/master/lib/linters/credo)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Supported languages:
 - Swift
 - SCSS
 - HAML
+- ERB
 - Markdown
-- Bash 
+- Bash
 
 If you have questions about the service,
 see [Help] or email [hello@houndci.com].


### PR DESCRIPTION
👋 Hey there,

This PR completes @aldesantis and @gylaz work done into #1641 to allow linting ERB files by adding some documentation around this new addition. 

Since I have no access to the `houndci/linters` repo, in the PR I assumed that:

- ERB linting is done with [this tool](https://github.com/Shopify/erb-lint)
- linter code is located into `lib/linters/erb_lint`
- ~default config is located into `config/erb.yml`~

Let me know if I should change something.

Also, I think you should add an ERB help page (similar to [this one](https://intercom.help/hound/configuration/haml)) and update the [supported-linters](http://help.houndci.com/configuration/supported-linters) page as well. Let me know if I can be of help here.
