### PR TITLE
Use Rubocop 0.62.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -2,7 +2,7 @@ fail_on_violations: true
 
 rubocop:
   config_file: .rubocop.yml
-  version: 0.59.2
+  version: 0.62.0
 
 scss:
   config_file: .scss-lint.yml


### PR DESCRIPTION
Ruby 2.6.0 [requires Rubocop version 0.60.0](https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md) or greater.