### PR TITLE
Process high jobs if medium and low queues are empty

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,7 +1,7 @@
 web: bundle exec puma -C config/puma.rb
 webpack_dev_server: ./bin/webpack-dev-server
-resque_high: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=8 QUEUE=high,medium bundle exec rake resque:work
-resque_medium: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=8 QUEUE=medium bundle exec rake resque:work
-resque_low: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=8 QUEUE=low,medium bundle exec rake resque:work
+resque_high: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=8 QUEUE=high bundle exec rake resque:work
+resque_medium: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=8 QUEUE=medium,high bundle exec rake resque:work
+resque_low: env TERM_CHILD=1 RESQUE_TERM_TIMEOUT=8 QUEUE=low,high,medium bundle exec rake resque:work
 resque_scheduler: bundle exec rake resque:scheduler
 release: bundle exec rake db:migrate


### PR DESCRIPTION
This should help keep up with spikes in `high` jobs.