### PR TITLE
Don't delete subscriptions on exception

### DIFF
--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -29,22 +29,19 @@ class RepoSubscriber
 
   def create_subscription
     plan_selector = PlanSelector.new(user: user, repo: repo)
-
     payment_gateway_subscription = stripe_customer.find_or_create_subscription(
       plan: plan_selector.current_plan.id,
       repo_id: repo.id,
     )
-
-    payment_gateway_subscription.subscribe(repo.id)
 
     repo.create_subscription!(
       user_id: user.id,
       stripe_subscription_id: payment_gateway_subscription.id,
       price: plan_selector.next_plan.price,
     )
+    payment_gateway_subscription.subscribe(repo.id)
   rescue => error
     report_exception(error)
-    payment_gateway_subscription.try(:delete)
     nil
   end
 


### PR DESCRIPTION
There is a small chance this can delete a good existing subscription,
and not the new one that we think failed being created.