### PR TITLE
Don't delete Stripe subscription when creation fails

### DIFF
--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -35,13 +35,13 @@ class RepoSubscriber
       repo_id: repo.id,
     )
 
+    payment_gateway_subscription.subscribe(repo.id)
+
     repo.create_subscription!(
       user_id: user.id,
       stripe_subscription_id: payment_gateway_subscription.id,
       price: plan_selector.next_plan.price,
     )
-
-    payment_gateway_subscription.subscribe(repo.id)
   rescue => error
     report_exception(error)
     nil

--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -35,13 +35,13 @@ class RepoSubscriber
       repo_id: repo.id,
     )
 
-    payment_gateway_subscription.subscribe(repo.id)
-
     repo.create_subscription!(
       user_id: user.id,
       stripe_subscription_id: payment_gateway_subscription.id,
       price: plan_selector.next_plan.price,
     )
+
+    payment_gateway_subscription.subscribe(repo.id)
   rescue => error
     report_exception(error)
     nil

--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -44,7 +44,6 @@ class RepoSubscriber
     )
   rescue => error
     report_exception(error)
-    payment_gateway_subscription.try(:delete)
     nil
   end
 

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -140,7 +140,7 @@ describe RepoSubscriber do
     end
 
     context "when repo subscription fails to create" do
-      it "deleted the stripe subscription" do
+      it "doesn't raise and returns falsy" do
         repo = create(:repo)
         user = create(:user, repos: [repo])
         stub_customer_create_request(user)
@@ -152,13 +152,11 @@ describe RepoSubscriber do
           plan: user.next_plan.id,
           repo_ids: repo.id,
         )
-        stripe_delete_request = stub_subscription_delete_request
         allow(repo).to receive(:create_subscription!).and_raise(StandardError)
 
         result = RepoSubscriber.subscribe(repo, user, "cardtoken")
 
         expect(result).to be_falsy
-        expect(stripe_delete_request).to have_been_requested
       end
     end
 


### PR DESCRIPTION
A uniqueness constraint prevented a `subscriptions` record from being created, which lead to the Stripe subscription being deleted. This change adjusts the way we deal with cleaning up Stripe subscriptions if there's an issue on our side (uniqueness constraint, etc.). Now we don't attempt to clean up the Stripe subscription when there's an exception.