### PR TITLE
List Python and PHP in "Supported Languages"

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,20 @@ that reviews GitHub pull requests
 for style guide violations.
 
 Supported languages:
-- JavaScript
-- TypeScript
-- CoffeeScript
-- Go
-- Ruby
-- Elixir
-- Swift
-- SCSS
-- HAML
-- ERB
-- Markdown
 - Bash
+- Elixir
+- Go
+- HAML
+- JavaScript
+  - CoffeeScript
+  - TypeScript
+- Markdown
+- PHP
+- Python
+- Ruby
+  - ERB
+- Sass / SCSS
+- Swift
 
 If you have questions about the service,
 see [Help] or email [hello@houndci.com].


### PR DESCRIPTION
- Python support added in #853 ~Aug 2015
- PHP support added in #1638 ~Jan 2019

I also alphabetized the core languages and indented the "dialects" like TypeScript and CoffeeScript to make scanning the list easier.