### PR TITLE
Rename Sidekiq UI password variable

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ require "sidekiq/web"
 Sidekiq::Web.use Rack::Auth::Basic do |_, password|
   ActiveSupport::SecurityUtils.secure_compare(
     ::Digest::SHA256.hexdigest(password),
-    ::Digest::SHA256.hexdigest(ENV["QUEUE_ADMIN_PASSWORD"]),
+    ::Digest::SHA256.hexdigest(ENV["JOB_ADMIN_PASSWORD"]),
   )
 end
 


### PR DESCRIPTION
To follow the `/jobs` path and other variables that start with `JOB_`.