### PR TITLE
Use linters queue for all linter jobs

### DIFF
--- a/app/jobs/credo_review_job.rb
+++ b/app/jobs/credo_review_job.rb
@@ -1,3 +1,0 @@
-class CredoReviewJob < ApplicationJob
-  sidekiq_options queue: :credo_review
-end

--- a/app/jobs/eslint_review_job.rb
+++ b/app/jobs/eslint_review_job.rb
@@ -1,3 +1,0 @@
-class EslintReviewJob < ApplicationJob
-  sidekiq_options queue: :eslint_review
-end

--- a/app/jobs/flog_review_job.rb
+++ b/app/jobs/flog_review_job.rb
@@ -1,3 +1,0 @@
-class FlogReviewJob < ApplicationJob
-  sidekiq_options queue: :flog_review
-end

--- a/app/jobs/jshint_review_job.rb
+++ b/app/jobs/jshint_review_job.rb
@@ -1,3 +1,0 @@
-class JshintReviewJob < ApplicationJob
-  sidekiq_options queue: :jshint_review
-end

--- a/app/jobs/reek_review_job.rb
+++ b/app/jobs/reek_review_job.rb
@@ -1,3 +1,0 @@
-class ReekReviewJob < ApplicationJob
-  sidekiq_options queue: :reek_review
-end

--- a/app/jobs/tslint_review_job.rb
+++ b/app/jobs/tslint_review_job.rb
@@ -1,3 +1,0 @@
-class TslintReviewJob < ApplicationJob
-  sidekiq_options queue: :tslint_review
-end

--- a/app/models/linter/base.rb
+++ b/app/models/linter/base.rb
@@ -52,11 +52,7 @@ module Linter
     end
 
     def enqueue_job(attributes)
-      job_class.perform_async(attributes)
-    end
-
-    def job_class
-      LintersJob
+      LintersJob.perform_async(attributes)
     end
 
     def owner

--- a/app/models/linter/credo.rb
+++ b/app/models/linter/credo.rb
@@ -1,11 +1,5 @@
 module Linter
   class Credo < Base
     FILE_REGEXP = /.+(\.ex|\.exs)\z/
-
-    private
-
-    def job_class
-      CredoReviewJob
-    end
   end
 end

--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -9,10 +9,6 @@ module Linter
 
     private
 
-    def job_class
-      EslintReviewJob
-    end
-
     def ignore_file
       @_ignore_file ||= IgnoreFile.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/app/models/linter/flog.rb
+++ b/app/models/linter/flog.rb
@@ -5,11 +5,5 @@ module Linter
     def file_included?(commit_file)
       commit_file.filename !~ /^(spec|test)\//
     end
-
-    private
-
-    def job_class
-      FlogReviewJob
-    end
   end
 end

--- a/app/models/linter/jshint.rb
+++ b/app/models/linter/jshint.rb
@@ -9,10 +9,6 @@ module Linter
 
     private
 
-    def job_class
-      JshintReviewJob
-    end
-
     def ignore_file
       @_ignore_file ||= IgnoreFile.new(name, hound_config, IGNORE_FILENAME)
     end

--- a/app/models/linter/reek.rb
+++ b/app/models/linter/reek.rb
@@ -3,10 +3,4 @@ module Linter
   class Reek < Base
     FILE_REGEXP = /.+\.r(b|ake)\z/
   end
-
-  private
-
-  def job_class
-    ReekReviewJob
-  end
 end

--- a/app/models/linter/tslint.rb
+++ b/app/models/linter/tslint.rb
@@ -1,11 +1,5 @@
 module Linter
   class Tslint < Base
     FILE_REGEXP = /.+\.ts[x]?\z/
-
-    private
-
-    def job_class
-      TslintReviewJob
-    end
   end
 end

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -22,11 +22,11 @@ describe Linter::Eslint do
       stub_eslint_config(content: {})
       commit_file = build_commit_file(filename: "lib/a.js")
       linter = build_linter(build)
-      allow(EslintReviewJob).to receive(:perform_async)
+      allow(LintersJob).to receive(:perform_async)
 
       linter.file_review(commit_file)
 
-      expect(EslintReviewJob).to have_received(:perform_async).with(
+      expect(LintersJob).to have_received(:perform_async).with(
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
         linter_name: "eslint",

--- a/spec/models/linter/flog_spec.rb
+++ b/spec/models/linter/flog_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe Linter::Flog do
     it "schedules a file review" do
       commit_file = build_commit_file(filename: "lib/foo.rb")
       linter = build_linter
-      allow(FlogReviewJob).to receive(:perform_async)
+      allow(LintersJob).to receive(:perform_async)
 
       result = linter.file_review(commit_file)
 
       expect(result).to be_persisted
       expect(result).not_to be_completed
-      expect(FlogReviewJob).to have_received(:perform_async)
+      expect(LintersJob).to have_received(:perform_async)
     end
   end
 

--- a/spec/models/linter/jshint_spec.rb
+++ b/spec/models/linter/jshint_spec.rb
@@ -59,11 +59,11 @@ describe Linter::Jshint do
         build = create(:build)
         linter = build_linter(build, stub_config_files(config))
         commit_file = build_commit_file(filename: "lib/a.js")
-        allow(JshintReviewJob).to receive(:perform_async)
+        allow(LintersJob).to receive(:perform_async)
 
         linter.file_review(commit_file)
 
-        expect(JshintReviewJob).to have_received(:perform_async).with(
+        expect(LintersJob).to have_received(:perform_async).with(
           commit_sha: build.commit_sha,
           config: '{"browser":true}',
           content: commit_file.content,
@@ -82,11 +82,11 @@ describe Linter::Jshint do
         linter = build_linter(build, stub_config_files('{"asi": true}'))
         commit_file = build_commit_file(filename: "lib/a.js")
         stub_owner_config('{"asi": false, "maxlen": 50}')
-        allow(JshintReviewJob).to receive(:perform_async)
+        allow(LintersJob).to receive(:perform_async)
 
         linter.file_review(commit_file)
 
-        expect(JshintReviewJob).to have_received(:perform_async).with(
+        expect(LintersJob).to have_received(:perform_async).with(
           commit_sha: build.commit_sha,
           config: '{"asi":true,"maxlen":50}',
           content: commit_file.content,

--- a/spec/models/linter/tslint_spec.rb
+++ b/spec/models/linter/tslint_spec.rb
@@ -22,11 +22,11 @@ describe Linter::Tslint do
       stub_tslint_config(content: {})
       commit_file = build_commit_file(filename: "lib/a.ts")
       linter = build_linter(build)
-      allow(TslintReviewJob).to receive(:perform_async)
+      allow(LintersJob).to receive(:perform_async)
 
       linter.file_review(commit_file)
 
-      expect(TslintReviewJob).to have_received(:perform_async).with(
+      expect(LintersJob).to have_received(:perform_async).with(
         filename: commit_file.filename,
         commit_sha: build.commit_sha,
         linter_name: "tslint",


### PR DESCRIPTION
We should be using the `linters` queue for all linters.