### PR TITLE
Group dead jobs that failed due to setting status

### DIFF
--- a/app/controllers/admin/job_failures_controller.rb
+++ b/app/controllers/admin/job_failures_controller.rb
@@ -1,9 +1,7 @@
 module Admin
   class JobFailuresController < Admin::ApplicationController
     def index
-      grouped_job_failures = JobFailure.all.group_by(&:error_message)
-
-      render locals: { resources: grouped_job_failures }
+      render locals: { resources: JobFailure.grouped }
     end
 
     def destroy

--- a/spec/models/job_failure_spec.rb
+++ b/spec/models/job_failure_spec.rb
@@ -3,29 +3,44 @@ require "active_model/naming"
 require "app/models/job_failure"
 
 RSpec.describe JobFailure do
-  describe ".all" do
-    it "returns an array of job failures" do
+  describe ".grouped" do
+    it "returns an array of grouped job failures" do
       failure1 = {
         "jid" => "abc123",
-        "error_message" => "foo",
+        "error_message" =>
+          "POST https://api.github.com/repos/joomla/joomla-cms/statuses/"\
+            "cd29f72ea924f5bfb3d08afa3b1ebe1f9afdfe86: 404 - Not Found // See:"\
+            " https://developer.github.com/v3/repos/statuses/#create-a-status",
         "wrapped" => "SomeJob",
       }
       failure2 = {
         "jid" => "def456",
-        "error_message" => "bar",
+        "error_message" => "Invalid character",
         "wrapped" => "SomeOtherJob",
+      }
+      failure3 = {
+        "jid" => "def456",
+        "error_message" =>
+          "POST https://api.github.com/repos/joomla/joomla-cms/statuses/"\
+            "2888102937852b84f9fbce58def0f5132b4a5002: 404 - Not Found // See:"\
+            " https://developer.github.com/v3/repos/statuses/#create-a-status",
+        "wrapped" => "SomeJob",
       }
       populate_failures [
         OpenStruct.new(item: failure1),
         OpenStruct.new(item: failure2),
+        OpenStruct.new(item: failure3),
       ]
 
-      job_failures = JobFailure.all
+      job_failures = JobFailure.grouped
 
-      expect(job_failures).to match [
-        JobFailure.new(failure1),
-        JobFailure.new(failure2),
-      ]
+      expect(job_failures).to eq(
+        "POST https://api.github.com/repos/joomla/joomla-cms/statuses/" => [
+          JobFailure.new(failure1),
+          JobFailure.new(failure3),
+        ],
+        "Invalid character" => [JobFailure.new(failure2)],
+      )
     end
   end
 


### PR DESCRIPTION
This reducers the noise on the `/admin/job_failures` page, and let's us
focus on more important failures.