### PR TITLE
Added .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ public/packs-test
 /public/packs
 /public/packs-test
 /node_modules
+
+.DS_Store


### PR DESCRIPTION
This prevents Mac users from accidentally adding .DS_Store to the source code.  (Yes, I've been on a project that had several instances of the .DS_Store file.)