### PR TITLE
Serialize empty configs as empty strings

### DIFF
--- a/app/models/config/base.rb
+++ b/app/models/config/base.rb
@@ -14,7 +14,7 @@ module Config
     end
 
     def serialize
-      content
+      raise NotImplementedError, "implement ##{method} in your config class"
     end
 
     def linter_name

--- a/app/models/config/credo.rb
+++ b/app/models/config/credo.rb
@@ -4,6 +4,10 @@ module Config
       @content ||= load_content
     end
 
+    def serialize
+      content
+    end
+
     private
 
     def load_content

--- a/app/models/config/flog.rb
+++ b/app/models/config/flog.rb
@@ -1,5 +1,5 @@
 module Config
-  class Golint < Base
+  class Flog < Base
     def serialize
       ""
     end

--- a/app/models/config/phpcs.rb
+++ b/app/models/config/phpcs.rb
@@ -4,11 +4,17 @@ module Config
       @content ||= load_content
     end
 
+    def serialize
+      content
+    end
+
     private
 
     def load_content
       if file_path
         commit.file_content(file_path)
+      else
+        ""
       end
     end
   end

--- a/spec/features/user_deactivates_a_repo_spec.rb
+++ b/spec/features/user_deactivates_a_repo_spec.rb
@@ -17,9 +17,9 @@ feature "user deactivates a repo", js: true do
           retrieve_subscription: gateway_subscription,
           email: user.email,
         )
-        allow(PaymentGatewayCustomer).to receive(:new).and_return(
-          payment_gateway_customer
-        )
+        allow(PaymentGatewayCustomer).
+          to receive(:new).
+          and_return(payment_gateway_customer)
 
         sign_in_as(user, token)
         find(".repo-toggle").click
@@ -28,7 +28,8 @@ feature "user deactivates a repo", js: true do
 
         visit current_path
 
-        expect(page).not_to have_selector(".repo")
+        expect(page).not_to have_css(".repos-syncing")
+        expect(page).not_to have_text(repo.name)
       end
     end
   end

--- a/spec/models/linter/go_spec.rb
+++ b/spec/models/linter/go_spec.rb
@@ -32,7 +32,7 @@ describe Linter::Golint do
         pull_request_number: build.pull_request_number,
         patch: commit_file.patch,
         content: commit_file.content,
-        config: {},
+        config: "",
         linter_version: nil,
       )
     end


### PR DESCRIPTION
Otherwise, the config was being serialized as a literal empty hash,
while most of the configs are servialized to text (then parsed on the
`linters` side).

This fixes an error reported by the `linters`.