### PR TITLE
Don't get the email from Stripe on every page

### DIFF
--- a/app/views/application/_settings.haml
+++ b/app/views/application/_settings.haml
@@ -2,7 +2,6 @@
   Namespaced.declare("Hound.settings");
   Hound.settings = {
     stripePublishableKey: "#{Hound::STRIPE_PUBLISHABLE_KEY}",
-    userEmailAddress: "#{current_user.billable_email}",
     syncingButtonText: "#{I18n.t('syncing_repos')}",
     syncNowButtonText: "#{I18n.t('sync_repos')}",
     searchPlaceholder: "#{I18n.t('search_placeholder')}",

--- a/app/views/plans/index.html.haml
+++ b/app/views/plans/index.html.haml
@@ -1,4 +1,8 @@
 = render "settings"
+
+:javascript
+  Hound.settings.userEmailAddress = "#{current_user.billable_email}"
+
 = javascript_pack_tag("notify_tier_change")
 = react_component("NotifyTierChange",
   authenticity_token: form_authenticity_token,


### PR DESCRIPTION
We currently are calling Stripe on each page load/reload to fetch the
user billable email.

This email is only needed during Plan purchase/upgrade.

Currently, Stripe API is having issues and our pages won't load.