### PR TITLE
Add .ts and .tsx support

### DIFF
--- a/app/models/linter/eslint.rb
+++ b/app/models/linter/eslint.rb
@@ -1,6 +1,6 @@
 module Linter
   class Eslint < Base
-    FILE_REGEXP = /.+(\.js|\.es6|\.jsx|\.vue)\z/
+    FILE_REGEXP = /.+(\.js|\.es6|\.jsx|\.vue|\.ts|\.tsx)\z/
     IGNORE_FILENAME = ".eslintignore".freeze
 
     def file_included?(commit_file)

--- a/spec/models/linter/eslint_spec.rb
+++ b/spec/models/linter/eslint_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe Linter::Eslint do
   it_behaves_like "a linter" do
-    let(:lintable_files) { %w(foo.es6 foo.js foo.jsx foo.vue) }
+    let(:lintable_files) { %w(foo.es6 foo.js foo.jsx foo.vue foo.ts foo.tsx) }
     let(:not_lintable_files) { %w(foo.js.coffee) }
   end
 


### PR DESCRIPTION
Add TS and TSX support to ESLint.

Typescript linting has been done in the past by TSLint, which is now being deprecated. The TSLint team [is pointing users to use @typescript-eslint ](https://medium.com/palantir/tslint-in-2019-1a144c2317a9)for typescript support; the Microsoft Typescript team, themselves, have been [transferring their linting capabilities to use ESLint](https://github.com/microsoft/TypeScript/issues/30553).

If users do not want their typescript files to be linted support they can simply add `*.ts` and `*.tsx` to their `.eslintignore` file. 
