### PR TITLE
Configure OmniAuth to get the GitHub user's email

### DIFF
--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -1,5 +1,10 @@
 OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :github, Hound::GITHUB_CLIENT_ID, Hound::GITHUB_CLIENT_SECRET
+  provider(
+    :github,
+    Hound::GITHUB_CLIENT_ID,
+    Hound::GITHUB_CLIENT_SECRET,
+    scope: "user:email",
+  )
 end


### PR DESCRIPTION
GitHub Apps don't use scopes, but OmniAuth GitHub library still needs
this option, to know to hit the GitHub API to fetch the email for the
user that is logging in.