### PR TITLE
Redirect to root when user is not authorized

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate
     unless signed_in?
-      redirect_to "/auth/github"
+      redirect_to root_path
     end
   end
 


### PR DESCRIPTION
We no longer have a `GET /auth/github`, so we should instead redirect
the user to the landing page.