### PR TITLE
Allow GET request for omniauth gem

### DIFF
--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -1,4 +1,5 @@
 OmniAuth.config.logger = Rails.logger
+OmniAuth.config.allowed_request_methods = [:post, :get]
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider(


### PR DESCRIPTION
Logins are failing on Chrome and it seems due to receiving `GET`
requests. This is an attempt to get our logins working again.