### PR TITLE
Delete outdated comments

### DIFF
--- a/app/policies/commenting_policy.rb
+++ b/app/policies/commenting_policy.rb
@@ -9,19 +9,36 @@ class CommentingPolicy
     unreported_violation_messages(violation).any?
   end
 
+  def outdated_comments(found_violations)
+    comments.select do |comment|
+      comment.user.type == "Bot" && outdated_comment?(comment, found_violations)
+    end
+  end
+
   private
 
+  def outdated_comment?(comment, violations)
+    violations.none? do |violation|
+      matches_location?(violation, comment) &&
+        matches_messages?(violation, comment)
+    end
+  end
+
   def unreported_violation_messages(violation)
-    violation.messages - existing_violation_messages(violation)
+    violation.messages - existing_comment_messages(violation)
   end
 
-  def existing_violation_messages(violation)
-    previous_comments_on_line(violation).
-      map(&:body).
-      flat_map { |body| body.split(COMMENT_LINE_DELIMITER) }
+  def existing_comment_messages(violation)
+    existing_comments_on_line(violation).flat_map do |comment|
+      comment_messages(comment)
+    end
   end
 
-  def previous_comments_on_line(violation)
+  def comment_messages(comment)
+    comment.body.split(COMMENT_LINE_DELIMITER)
+  end
+
+  def existing_comments_on_line(violation)
     comments.select do |comment|
       matches_location?(violation, comment)
     end
@@ -37,5 +54,9 @@ class CommentingPolicy
     else
       comment.original_position == violation.patch_position
     end
+  end
+
+  def matches_messages?(violation, comment)
+    (comment_messages(comment) & violation.messages).any?
   end
 end

--- a/app/services/submit_review.rb
+++ b/app/services/submit_review.rb
@@ -8,6 +8,10 @@ class SubmitReview
     if new_violations.any? || build.review_errors.any?
       comments = new_violations.map { |violation| build_comment(violation) }
 
+      if build.repo.installation_id
+        remove_resolved_violations
+      end
+
       send_review(comments)
     end
   end
@@ -21,6 +25,12 @@ class SubmitReview
       comments,
       ReviewBody.new(build.review_errors).to_s,
     )
+  end
+
+  def remove_resolved_violations
+    commenting_policy.outdated_comments(build.violations).each do |comment|
+      github.delete_pull_request_comment(build.repo_name, comment)
+    end
   end
 
   def new_violations

--- a/lib/github_api.rb
+++ b/lib/github_api.rb
@@ -68,6 +68,10 @@ class GitHubApi
     )
   end
 
+  def delete_pull_request_comment(full_repo_name, comment)
+    client.delete_pull_request_comment(full_repo_name, comment.id)
+  end
+
   def pull_request_files(full_repo_name, number)
     client.pull_request_files(full_repo_name, number)
   end

--- a/spec/requests/github_events_spec.rb
+++ b/spec/requests/github_events_spec.rb
@@ -1,0 +1,68 @@
+require "rails_helper"
+
+RSpec.describe "POST /github_events" do
+  it "makes new and deletes outdated comments" do
+    payload = File.read("spec/support/fixtures/pull_request_opened_event.json")
+    parsed_payload = JSON.parse(payload)
+    new_violation = { line: 3, message: "Trailing whitespace detected." }
+    repo = create(
+      :repo,
+      :active,
+      github_id: parsed_payload["repository"]["id"],
+      name: "test/org",
+      installation_id: 12345,
+    )
+    outdated_comment = build_comment(repo, "Some outdated comment")
+    stub_review_job(violations: [new_violation], error: "invalid config syntax")
+    FakeGitHub.comments = [outdated_comment]
+    headers = {
+      "X-Hub-Signature": "sha1=5864ad853cfc35c5b20349dabd18a815325515c7",
+      "X-GitHub-Event": "pull_request",
+    }
+
+    post(github_events_path, params: payload, headers: headers)
+
+    expect(FakeGitHub.review_body).to eq <<~GITHUB.chomp
+      Some files could not be reviewed due to errors:
+      <details>
+      <summary>invalid config syntax</summary>
+      <pre>invalid config syntax</pre>
+      </details>
+    GITHUB
+    expect(FakeGitHub.comments).to match_array [
+      {
+        body: new_violation[:message],
+        path: "path/to/test_github_file.rb",
+        position: new_violation[:line],
+        pr_number: "1",
+        repo: "Hello-World",
+      },
+    ]
+  end
+
+  def build_comment(repo, message)
+    {
+      id: "abc123",
+      body: message,
+      path: "path/to/test_github_file.rb",
+      position: 3,
+      pr_number: "1",
+      repo: repo.name,
+      user: { type: "Bot" },
+    }
+  end
+
+  def stub_review_job(violations:, error:)
+    allow(LintersJob).to receive(:perform_async) do |attributes|
+      CompleteFileReview.call(
+        commit_sha: attributes.fetch(:commit_sha),
+        filename: attributes.fetch(:filename),
+        linter_name: attributes.fetch(:linter_name),
+        patch: attributes.fetch(:patch),
+        pull_request_number: attributes.fetch(:pull_request_number),
+        violations: violations,
+        error: error,
+      )
+    end
+  end
+end

--- a/spec/support/fake_github.rb
+++ b/spec/support/fake_github.rb
@@ -66,16 +66,12 @@ class FakeGitHub < Sinatra::Base
 
   get "/repos/:owner/:repo/pulls/:number/comments" do
     content_type :json
-    [
-      {
-        body: "Line is too long.",
-        commit_id: "TEST_GITHUB_COMMIT_ID",
-        path: "path/to/test_github_file.rb",
-        position: 5,
-        pull_id: params[:number],
-        repo: params[:repo],
-      },
-    ].to_json
+    comments.to_json
+  end
+
+  delete "/repos/:owner/:repo/pulls/comments/:id" do
+    comments.reject! { |comment| comment[:id] == params[:id] }
+    status 204
   end
 
   post "/repos/:owner/:repo/pulls/:number/reviews" do


### PR DESCRIPTION
To clean up the violation comments that have been addressed/outdated,
we will delete them from the PR. This will only be done for GitHub app
users, since each installation gets its own pool of API limits.