### PR TITLE
Delete outdated comments without new violations

### DIFF
--- a/app/services/submit_review.rb
+++ b/app/services/submit_review.rb
@@ -8,11 +8,11 @@ class SubmitReview
     if new_violations.any? || build.review_errors.any?
       comments = new_violations.map { |violation| build_comment(violation) }
 
-      if build.repo.installation_id
-        remove_resolved_violations
-      end
-
       send_review(comments)
+    end
+
+    if build.repo.installation_id
+      remove_resolved_violations
     end
   end
 


### PR DESCRIPTION
Currently, we will only delete outdated violations if other violations
were found. Moving this logic out of that condition, will ensure we
cleanup outdated comments regardless of finding new violations.