### PR TITLE
Fix recent_builds and its count

### DIFF
--- a/app/presenters/account_page.rb
+++ b/app/presenters/account_page.rb
@@ -40,7 +40,7 @@ class AccountPage
   end
 
   def recent_builds
-    user.recent_builds.count
+    user.recent_builds
   end
 
   private

--- a/app/views/application/_app_nav.haml
+++ b/app/views/application/_app_nav.haml
@@ -34,7 +34,7 @@
               Recent Reviews
               %strong
                 %span{ "data-role" => "subscribed-repo-count" }
-                  #{number_with_delimiter(current_user.recent_builds.count)}
+                  #{number_with_delimiter(current_user.recent_builds)}
           - else
             .allowance{ "data-role" => "allowance-container" }
               Private Repos


### PR DESCRIPTION
We attempt to call `recent_builds.count` but the method itself returns the count.