### PR TITLE
Improve detection of first repo for user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,7 +74,11 @@ class User < ApplicationRecord
   end
 
   def first_available_repo
-    repos.order(:active).first
+    if subscriptions.any?
+      subscriptions.first.repo
+    else
+      repos.order(:active).first
+    end
   end
 
   def marketplace_user?


### PR DESCRIPTION
Look for first user's subscription first, then look for any active repo.
Sometimes a user may still have a subscription, but it doesn't show up
in the list of user's repos.