### PR TITLE
Replace Neat `media` mixin with vanilla CSS

### DIFF
--- a/app/assets/stylesheets/base/_variables.scss
+++ b/app/assets/stylesheets/base/_variables.scss
@@ -41,12 +41,7 @@ $medium-screen-size: 760px;
 $medium-large-screen-size: 57.5em;
 $large-screen-size: 920px;
 
-$small-screen-only: new-breakpoint(max-width $small-screen-size 2);
 $medium-screen-down: new-breakpoint(max-width ($medium-screen-size - 1px) 4);
-$medium-screen-up: new-breakpoint(min-width $medium-screen-size 12);
-$medium-large-screen-only: new-breakpoint(max-width $medium-large-screen-size 8);
-$large-screen-down: new-breakpoint(max-width ($large-screen-size - 1px) 8);
-$large-screen-up: new-breakpoint(min-width $large-screen-size 12);
 
 $base-border: 1px solid $base-border-color;
 $base-border-radius: 5px;

--- a/app/assets/stylesheets/components/_pricing.scss
+++ b/app/assets/stylesheets/components/_pricing.scss
@@ -18,7 +18,7 @@
   position: relative;
   text-align: left;
 
-  @include media($medium-large-screen-only) {
+  @media (max-width: $medium-large-screen-size) {
     padding-left: $medium-spacing;
   }
 
@@ -76,7 +76,7 @@
   font-size: 2.3em;
   line-height: 1;
 
-  @include media($medium-large-screen-only) {
+  @media (max-width: $medium-large-screen-size) {
     font-size: 2.1em;
   }
 

--- a/app/assets/stylesheets/pages/_docs.scss
+++ b/app/assets/stylesheets/pages/_docs.scss
@@ -4,11 +4,11 @@
   display: flex;
   padding: $medium-spacing;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     margin-top: 0;
   }
 
-  @include media($large-screen-up) {
+  @media (min-width: $large-screen-size) {
     flex-flow: row nowrap;
   }
 }
@@ -23,7 +23,7 @@
 }
 
 .docs-content {
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     border-left: $base-border;
     flex: 1;
     padding-left: $medium-spacing;
@@ -33,7 +33,7 @@
 .docs-nav {
   display: none;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     display: block;
     padding-right: $medium-spacing;
     width: 25%;

--- a/app/assets/stylesheets/pages/home/_home-configuration.scss
+++ b/app/assets/stylesheets/pages/home/_home-configuration.scss
@@ -4,7 +4,7 @@
   color: $white;
   padding: $medium-spacing;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     padding: $large-spacing;
   }
 }
@@ -12,7 +12,7 @@
 .configuration-image {
   margin-bottom: $medium-spacing;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     @include span-columns(4 of 12);
     @include shift(0);
     margin-bottom: 0;
@@ -22,7 +22,7 @@
 .configuration-text {
   text-align: center;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     @include span-columns(6 of 12);
     padding-left: $column;
     text-align: left;

--- a/app/assets/stylesheets/pages/home/_home-hero.scss
+++ b/app/assets/stylesheets/pages/home/_home-hero.scss
@@ -1,13 +1,13 @@
 .home-hero {
   padding: ($base-spacing * 2) $base-spacing $large-spacing;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     @include span-columns(10 of 12);
     @include shift(1);
     padding: $large-spacing $base-spacing ($large-spacing * 2);
   }
 
-  @include media($large-screen-up) {
+  @media (min-width: $large-screen-size) {
     @include span-columns(8 of 12);
     @include shift(2);
     padding: ($large-spacing * 1.5) 0 ($large-spacing * 2.5);
@@ -19,11 +19,11 @@
   font-size: $font-size-xxlarge;
   margin-bottom: $xsmall-spacing;
 
-  @include media($medium-screen-down) {
+  @media (max-width: $medium-screen-size) {
     font-size: $font-size-xlarge;
   }
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     font-size: $font-size-large;
   }
 }
@@ -32,7 +32,7 @@
   font-size: $font-size-base;
   margin-bottom: 0;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     font-size: $font-size-medium;
   }
 }
@@ -40,7 +40,7 @@
 .home-hero-cta {
   padding-top: $medium-spacing;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     padding-top: $large-spacing;
   }
 }

--- a/app/assets/stylesheets/pages/home/_home-importance.scss
+++ b/app/assets/stylesheets/pages/home/_home-importance.scss
@@ -4,7 +4,7 @@
   color: $white;
   padding: $large-spacing 1em ($large-spacing * 2);
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     padding: ($large-spacing * 2) $base-spacing ($large-spacing * 3);
   }
 }
@@ -20,12 +20,12 @@
   @include span-columns(10 of 12);
   @include shift(1);
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     @include span-columns(8 of 12);
     @include shift(2);
   }
 
-  @include media($large-screen-up) {
+  @media (min-width: $large-screen-size) {
     @include span-columns(4 of 12);
     @include shift(0);
   }
@@ -33,7 +33,7 @@
   &:not(:last-child) {
     margin-bottom: $large-spacing;
 
-    @include media($large-screen-up) {
+    @media (min-width: $large-screen-size) {
       margin-bottom: 0;
     }
   }
@@ -42,7 +42,7 @@
 .home-importance-text {
   text-shadow: $base-text-shadow;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     padding: 0 5%;
   }
 }

--- a/app/assets/stylesheets/pages/home/_home-languages.scss
+++ b/app/assets/stylesheets/pages/home/_home-languages.scss
@@ -5,7 +5,7 @@
   position: relative;
   text-align: center;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     margin-bottom: $large-spacing * 3;
     max-width: 100%;
   }
@@ -18,12 +18,12 @@
     width: 100%;
     z-index: 1;
 
-    @include media($medium-screen-up) {
+    @media (min-width: $medium-screen-size) {
       left: 10%;
       width: 80%;
     }
 
-    @include media($large-screen-up) {
+    @media (min-width: $large-screen-size) {
       left: 30%;
       width: 40%;
     }
@@ -40,7 +40,7 @@
   position: relative;
   z-index: 2;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     margin-bottom: $large-spacing;
   }
 }
@@ -52,7 +52,7 @@
   margin: 0;
   width: 100%;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     @include outer-container;
     width: 75%;
   }
@@ -62,7 +62,7 @@
   margin: ($base-spacing * 2) 0;
   text-align: center;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     margin-top: 0;
     width: 25%;
   }

--- a/app/assets/stylesheets/pages/home/_home-objects.scss
+++ b/app/assets/stylesheets/pages/home/_home-objects.scss
@@ -21,11 +21,11 @@
   font-size: 1.8em;
   margin-bottom: $xsmall-spacing;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     font-size: 2.2em;
   }
 
-  @include media($large-screen-up) {
+  @media (min-width: $large-screen-size) {
     font-size: $font-size-large;
   }
 }

--- a/app/assets/stylesheets/pages/home/_home-pricing.scss
+++ b/app/assets/stylesheets/pages/home/_home-pricing.scss
@@ -4,11 +4,11 @@
   padding: ($base-spacing * 2) $base-spacing;
   text-align: center;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     padding: $large-spacing $base-spacing ($large-spacing * 2);
   }
 
-  @include media($large-screen-up) {
+  @media (min-width: $large-screen-size) {
     padding: $large-spacing $base-spacing ($large-spacing * 3);
   }
 }

--- a/app/assets/stylesheets/pages/home/_home-value.scss
+++ b/app/assets/stylesheets/pages/home/_home-value.scss
@@ -1,7 +1,7 @@
 .value {
   padding: $large-spacing $base-spacing ($large-spacing * 2);
 
-  @include media($large-screen-up) {
+  @media (min-width: $large-screen-size) {
     padding: ($large-spacing * 2) 0 ($large-spacing * 3);
   }
 }
@@ -11,7 +11,7 @@
   @include shift(1);
   text-align: center;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     @include span-columns(8 of 12);
     @include shift(2);
   }
@@ -21,7 +21,7 @@
     margin-top: $large-spacing;
     padding-top: $large-spacing;
 
-    @include media($medium-screen-up) {
+    @media (min-width: $medium-screen-size) {
       margin-top: $large-spacing * 2;
       padding-top: $large-spacing * 2;
     }
@@ -31,7 +31,7 @@
 .value-text {
   margin-bottom: $large-spacing;
 
-  @include media($medium-screen-up) {
+  @media (min-width: $medium-screen-size) {
     margin-bottom: $large-spacing * 1.5;
   }
 

--- a/app/assets/stylesheets/pages/repos/_index.scss
+++ b/app/assets/stylesheets/pages/repos/_index.scss
@@ -5,7 +5,7 @@
   display: flex;
   padding: 1em;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     display: block;
     height: auto;
     padding: 1em 0;
@@ -32,7 +32,7 @@
   padding-bottom: 2px;
   transition: $base-transition;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     display: block;
     font-size: 1.2em;
     font-weight: $font-weight-regular;
@@ -48,7 +48,7 @@
   text-align: right;
   vertical-align: middle;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     display: block;
     padding: 0;
     text-align: left;
@@ -68,7 +68,7 @@
   user-select: none;
   vertical-align: middle;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     float: left;
     padding: 0.2em 0.8em;
   }

--- a/app/assets/stylesheets/pages/repos/_onboarding.scss
+++ b/app/assets/stylesheets/pages/repos/_onboarding.scss
@@ -13,7 +13,7 @@
     border-radius: 4px;
     padding: 1em 1.6em 1.8em;
 
-    @include media($medium-screen-down) {
+    @media (max-width: $medium-screen-size) {
       padding: 1em;
     }
   }
@@ -22,7 +22,7 @@
     color: $base-accent-color;
     margin-bottom: 0.6em;
 
-    @include media($medium-screen-down) {
+    @media (max-width: $medium-screen-size) {
       font-size: 2em;
     }
   }
@@ -37,7 +37,7 @@
     padding-left: 2em;
     position: relative;
 
-    @include media($medium-screen-down) {
+    @media (max-width: $medium-screen-size) {
       float: none;
       margin: 0;
       width: 100%;

--- a/app/assets/stylesheets/pages/repos/_organization.scss
+++ b/app/assets/stylesheets/pages/repos/_organization.scss
@@ -16,7 +16,7 @@ $dropdown-arrow: $white image-url("select-arrow.svg") no-repeat;
   justify-content: space-between;
   padding: 1em;
 
-  @include media($large-screen-down) {
+  @media (max-width: $large-screen-size) {
     flex-direction: column;
     padding: 1em;
   }
@@ -25,7 +25,7 @@ $dropdown-arrow: $white image-url("select-arrow.svg") no-repeat;
 .organization-header-config {
   display: flex;
 
-  @include media($medium-screen-down) {
+  @media (max-width: $medium-screen-size) {
     display: block;
   }
 }
@@ -74,11 +74,11 @@ $dropdown-arrow: $white image-url("select-arrow.svg") no-repeat;
   display: flex;
   padding: $xsmall-spacing;
 
-  @include media($large-screen-down) {
+  @media (max-width: $large-screen-size) {
     margin: 1em auto;
   }
 
-  @include media($medium-screen-down) {
+  @media (max-width: $medium-screen-size) {
     padding: $xsmall-spacing 0;
   }
 }

--- a/app/assets/stylesheets/pages/repos/_tools.scss
+++ b/app/assets/stylesheets/pages/repos/_tools.scss
@@ -4,7 +4,7 @@
   flex-wrap: wrap;
   vertical-align: middle;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     flex-direction: column;
   }
 }
@@ -59,7 +59,7 @@
 .repo-tools-add {
   margin-right: 0.5em;
 
-  @include media($small-screen-only) {
+  @media (max-width: $small-screen-size) {
     margin: 0 0 0.5em;
   }
 }


### PR DESCRIPTION
Neat is no longer maintained. This commit starts to remove Neat by
replacing almost all instances of its `media` mixin with vanilla CSS
syntax - there really is no need for a mixin here.