### PR TITLE
Update websocket-extensions to v0.1.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,7 @@ GEM
     websocket (1.2.8)
     websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.4)
+    websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.3.0)


### PR DESCRIPTION
This resolves CVE-2020-7663