### PR TITLE
Pull avatars from GitHub instead of Gravatar

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,6 @@
 module ApplicationHelper
   def avatar_url(user)
-    gravatar_id = Digest::MD5::hexdigest(user.email.downcase)
-    "https://www.gravatar.com/avatar/#{gravatar_id}"
+    "https://github.com/#{user.username}.png?size=64"
   end
 
   def display_onboarding?

--- a/app/views/application/_app_nav.haml
+++ b/app/views/application/_app_nav.haml
@@ -46,7 +46,7 @@
         = link_to account_path, class: "app-nav__item app-nav__account-link" do
           - if current_user.email.present?
             .avatar.margin-right-x-small
-              = image_tag avatar_url(current_user), alt: ""
+              = image_tag avatar_url(current_user), alt: "", size: "64"
           = current_user.username
 
         - if masquerading?

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -4,6 +4,7 @@
     %meta{ content: "width=device-width,initial-scale=1", name: "viewport" }
     %title
       = [content_for(:page_title), "Hound"].compact.uniq.join(" - ")
+    %link{ rel: "preconnect", href: "https://github.com" }
     - if content_for? :meta_description
       %meta{ content: content_for(:meta_description) }
     = stylesheet_link_tag    "application", :media => "all"


### PR DESCRIPTION
`https://github.com/<username>.png` will return a user or organization’s
avatar. It’s been written about on the GitHub Blog:
https://github.blog/2020-04-16-github-protips-tips-tricks-hacks-and-secrets-from-jason-etcovitch/#get-a-user-or-organizations-avatar

The `preconnect` is added to establish a connection to github.com
early, increasing perceived image loading performance.

No visual changes (beyond the fact that someone’s avatar will switch to their 
GitHub one, if it’s not the same as their Gravatar)