### PR TITLE
Add support for RuboCop config pre-processing

### DIFF
--- a/app/models/config/rubocop.rb
+++ b/app/models/config/rubocop.rb
@@ -22,6 +22,10 @@ module Config
       end
     end
 
+    def parse(content)
+      super(ERB.new(content).result)
+    end
+
     def safe_parse(content)
       parse(content)
     rescue Psych::Exception => exception

--- a/spec/models/config/rubocop_spec.rb
+++ b/spec/models/config/rubocop_spec.rb
@@ -28,18 +28,18 @@ RSpec.describe Config::Rubocop do
 
     context "when the configuration uses pre-processing" do
       it "runs the config through ERB" do
-        raw_config = <<~EOS
+        raw_config = <<~CONFIG
           Style/Encoding:
             Enabled: <%= 1 + 1 == 2 %>
           <% 42 # This should be ignored and not cause an error %>
-        EOS
+        CONFIG
 
         config = build_config(raw_config)
 
         expect(config.content).to eq(
           "Style/Encoding" => {
-            "Enabled" => true
-          }
+            "Enabled" => true,
+          },
         )
       end
     end

--- a/spec/models/config/rubocop_spec.rb
+++ b/spec/models/config/rubocop_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe Config::Rubocop do
       end
     end
 
+    context "when the configuration uses pre-processing" do
+      it "runs the config through ERB" do
+        raw_config = <<~EOS
+          Style/Encoding:
+            Enabled: <%= 1 + 1 == 2 %>
+          <% 42 # This should be ignored and not cause an error %>
+        EOS
+
+        config = build_config(raw_config)
+
+        expect(config.content).to eq(
+          "Style/Encoding" => {
+            "Enabled" => true
+          }
+        )
+      end
+    end
+
     context "when the configuration uses `inherit_from`" do
       it "returns the merged configuration using `inherit_from`" do
         repo_config = <<~EOS


### PR DESCRIPTION
RuboCop [0.83.0 (2020-05-11)][1] [added support][2] for [configuration pre-processing][3] by
running the config through ERB.

This PR "fixes" the Hound CI RuboCop config parser to also run the config through ERB, although I'm
not familiar with the internals of Hound to know whether this will work in practice (eg what `pwd`
is used?).

An alternative/better approach for the future would be use RuboCop's own code (specifically
[`RuboCop::ConfigLoader`][4]) to parse the config? Obviously that would be a bigger change.

Thoughts?

[1]: https://github.com/rubocop-hq/rubocop/blob/master/CHANGELOG.md#0830-2020-05-11
[2]: https://github.com/rubocop-hq/rubocop/pull/7920
[3]: https://docs.rubocop.org/rubocop/configuration.html#pre-processing
[4]: https://github.com/rubocop-hq/rubocop/blob/4943d5005b44c61973910b77adbb5fa42209bbfd/lib/rubocop/config_loader.rb#L56