### PR TITLE
Use webdrivers gem to simplify local development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,5 +55,6 @@ group :test do
   gem "launchy"
   gem "selenium-webdriver", ">= 4.0.0.alpha4"
   gem "shoulda-matchers"
+  gem "webdrivers", "~> 4.4"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,6 +348,10 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
+    webdrivers (4.4.1)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     webmock (3.8.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -413,6 +417,7 @@ DEPENDENCIES
   split
   stripe
   uglifier (>= 2.7.2)
+  webdrivers (~> 4.4)
   webmock
   webpacker
   webpacker-react (~> 1.0.0.beta.1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require "active_support/core_ext"
 require "attr_extras"
 require "byebug"
 require "webmock/rspec"
+require "webdrivers"
 
 ENV["REDIS_URL"] = "redis://localhost:6379/1"
 
@@ -14,7 +15,11 @@ RSpec.configure do |config|
   config.order = "random"
   config.include GitHubApiHelper
   config.include StripeApiHelper
-  WebMock.disable_net_connect!(allow_localhost: true)
+  WebMock.disable_net_connect!(
+    allow_localhost: true,
+    # https://github.com/titusfortner/webdrivers/issues/4
+    allow: "chromedriver.storage.googleapis.com",
+  )
 
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true


### PR DESCRIPTION
I noticed when doing an unrelated PR (#1809) that running the specs locally requires `chromedriver`.

```
Failures:

  1) Account user with Stripe Customer ID
     Failure/Error: visit root_path

     Selenium::WebDriver::Error::WebDriverError:
       Unable to find chromedriver. Please download the server from
       https://chromedriver.storage.googleapis.com/index.html and place it somewhere on your PATH.
       More info at https://github.com/SeleniumHQ/selenium/wiki/ChromeDriver.
     # ./spec/support/helpers/authentication_helper.rb:10:in `sign_in_as'
     # ./spec/features/account_spec.rb:17:in `block (2 levels) in <top (required)>'
     # ./spec/support/background_jobs.rb:4:in `block (3 levels) in <top (required)>'
     # ./spec/support/background_jobs.rb:22:in `block in run_background_jobs_immediately'
     # ./spec/support/background_jobs.rb:21:in `run_background_jobs_immediately'
     # ./spec/support/background_jobs.rb:3:in `block (2 levels) in <top (required)>'
```

This PR simplifies local development by using [webdrivers][1] to automatically download the correct
version of `chromedriver`.

[1]: https://github.com/titusfortner/webdrivers