### PR TITLE
Fix missing margin

### DIFF
--- a/app/assets/stylesheets/pages/home/_home-objects.scss
+++ b/app/assets/stylesheets/pages/home/_home-objects.scss
@@ -13,7 +13,7 @@
   }
 
   p {
-    margin: 0;
+    margin-bottom: 0;
   }
 }
 


### PR DESCRIPTION
By default, all `p` elements have some bottom margin, but on the
home page, we were overriding that with `margin: 0;` - that was done
using an overly-specific selector _and_ by using the `margin` shorthand:

https://github.com/houndci/hound/blob/5cdb8ec492d77aa2cf4f566e3f6b17f2f389ab54/app/assets/stylesheets/pages/home/_home-objects.scss#L15-L17

This meant our `margin-top-large` utility class was not working.

Part of this problem is what is called an ‘accidental reset’: https://css-tricks.com/accidental-css-resets/

By only setting the `margin-bottom`, we are only resetting the exact 
piece we want to reset, not _all_ margins.

## Before

<img width="859" alt="Screen Shot 2020-08-10 at 15 36 25" src="https://user-images.githubusercontent.com/903327/89823562-ab24b480-db1f-11ea-8049-45044e1ef3c0.png">

## After

<img width="859" alt="Screen Shot 2020-08-10 at 15 36 49" src="https://user-images.githubusercontent.com/903327/89823512-9811e480-db1f-11ea-8cc8-21cef600cef3.png">
