### PR TITLE
Fix HTML validation errors

### DIFF
--- a/app/views/application/_footer.haml
+++ b/app/views/application/_footer.haml
@@ -20,4 +20,4 @@
     Questions? Try
     #{link_to "Help", ENV.fetch("HELP_URL"), new_window_options}
     or tweet
-    #{link_to "@houndci", "https://twitter.com/share?text=@houndci &url=\"\"", new_window_options}.
+    #{link_to "@houndci", "https://twitter.com/share?text=@houndci", new_window_options}.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= javascript_include_tag "https://checkout.stripe.com/checkout.js" %>
     <%= javascript_include_tag "application" %>
     <% if content_for? :meta_description %>
-      <%= tag.meta content: content_for(:meta_description) %>
+      <%= tag.meta content: content_for(:meta_description), name: "description" %>
     <% end %>
     <%= csrf_meta_tags %>
   </head>


### PR DESCRIPTION
Resolves two HTML validation errors:

1. Element `meta` is missing one or more of the following attributes: `http-equiv`, `itemprop`, `name`, `property`.
1. Bad value `https://twitter.com/share?text=@houndci &url=""` for attribute `href` on element `a`: Illegal character in query: space is not allowed.

![Screen Shot 2020-08-11 at 15 26 02](https://user-images.githubusercontent.com/903327/89940162-17b6b680-dbe7-11ea-87ef-204ac3c85f63.png)
