### PR TITLE
Allow any user to upgrade whitelisted repos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)

--- a/app/models/plan_selector.rb
+++ b/app/models/plan_selector.rb
@@ -17,7 +17,9 @@ class PlanSelector
   end
 
   def upgrade?
-    if metered_plan?
+    if repo&.owner&.whitelisted?
+      false
+    elsif metered_plan?
       current_plan.open_source?
     else
       !!(next_plan && next_plan.allowance > current_plan.allowance)
@@ -69,6 +71,6 @@ class PlanSelector
   end
 
   def metered_plan?
-    user.metered_plan?
+    repo&.metered_plan?
   end
 end

--- a/app/models/repo.rb
+++ b/app/models/repo.rb
@@ -39,6 +39,10 @@ class Repo < ApplicationRecord
     end
   end
 
+  def metered_plan?
+    owner.metered_plan?
+  end
+
   def total_violations
     builds.sum(:violations_count)
   end

--- a/spec/models/plan_selector_spec.rb
+++ b/spec/models/plan_selector_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe PlanSelector do
       )
       repo = instance_double(
         "Repo",
+        metered_plan?: false,
         owner: double.as_null_object,
       )
       plan_selector = PlanSelector.new(user: user, repo: repo)
@@ -32,11 +33,11 @@ RSpec.describe PlanSelector do
           user = instance_double(
             "User",
             subscribed_repos: Array.new(4) { double },
-            metered_plan?: false,
           )
           repo = instance_double(
             "Repo",
-            owner: double.as_null_object,
+            metered_plan?: false,
+            owner: double(whitelisted?: false, marketplace_plan_id: nil),
           )
           plan_selector = PlanSelector.new(user: user, repo: repo)
 
@@ -49,7 +50,7 @@ RSpec.describe PlanSelector do
           user = instance_double(
             "User",
             subscribed_repos: [],
-            first_available_repo: double.as_null_object,
+            first_available_repo: nil,
             metered_plan?: false,
           )
           plan_selector = PlanSelector.new(user: user, repo: nil)
@@ -112,14 +113,14 @@ RSpec.describe PlanSelector do
           user = instance_double(
             "User",
             subscribed_repos: Array.new(1) { double },
-            metered_plan?: true,
             payment_gateway_subscription: double(
               plan: MeteredStripePlan::PLANS[0]["id"],
             ),
           )
           repo = instance_double(
             "Repo",
-            owner: double.as_null_object,
+            metered_plan?: true,
+            owner: double(whitelisted?: false, marketplace_plan_id: nil),
           )
           plan_selector = PlanSelector.new(user: user, repo: repo)
 
@@ -136,7 +137,6 @@ RSpec.describe PlanSelector do
           "User",
           subscribed_repos: [],
           first_available_repo: double.as_null_object,
-          metered_plan?: false,
         )
         plan_selector = PlanSelector.new(user: user, repo: nil)
 

--- a/spec/models/plan_selector_spec.rb
+++ b/spec/models/plan_selector_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe PlanSelector do
         user = instance_double(
           "User",
           subscribed_repos: [],
-          first_available_repo: repo
+          first_available_repo: repo,
         )
         plan_selector = PlanSelector.new(user: user, repo: nil)
 

--- a/spec/models/plan_selector_spec.rb
+++ b/spec/models/plan_selector_spec.rb
@@ -91,13 +91,13 @@ RSpec.describe PlanSelector do
             current_plan = GitHubPlan::PLANS[test_data[:current_plan]]
             owner = instance_double(
               "Owner",
+              whitelisted?: false,
               marketplace_plan_id: current_plan[:id],
             )
-            repo = instance_double("Repo", owner: owner)
+            repo = instance_double("Repo", owner: owner, metered_plan?: false)
             user = instance_double(
               "User",
               subscribed_repos: double(size: test_data[:repos]),
-              metered_plan?: false,
             )
             plan_selector = described_class.new(user: user, repo: repo)
 
@@ -133,10 +133,12 @@ RSpec.describe PlanSelector do
   describe "#next_plan" do
     context "when the user has no subscribed repos" do
       it "returns the first paid plan" do
+        owner = instance_double("Owner", marketplace_plan_id: nil)
+        repo = instance_double("Repo", owner: owner, metered_plan?: false)
         user = instance_double(
           "User",
           subscribed_repos: [],
-          first_available_repo: double.as_null_object,
+          first_available_repo: repo
         )
         plan_selector = PlanSelector.new(user: user, repo: nil)
 
@@ -148,14 +150,11 @@ RSpec.describe PlanSelector do
 
   describe "#previous_plan" do
     it "returns the second paid plan" do
+      owner = instance_double("Owner", marketplace_plan_id: nil)
+      repo = instance_double("Repo", owner: owner, metered_plan?: false)
       user = instance_double(
         "User",
         subscribed_repos: Array.new(10) { double },
-        metered_plan?: false,
-      )
-      repo = instance_double(
-        "Repo",
-        owner: double.as_null_object,
       )
       plan_selector = PlanSelector.new(user: user, repo: repo)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,9 +25,10 @@ describe User do
   describe "#plan_max" do
     it "returns the current plan's allowance" do
       owner = Owner.new(marketplace_plan_id: nil)
-      user = User.new(subscribed_repos: Array.new(5) { Repo.new(owner: owner) })
+      repos = Array.new(5) { Repo.new(owner: owner) }
+      user = User.new(subscribed_repos: repos)
 
-      expect(user.plan_max).to eq StripePlan::PLANS[2][:range].max
+      expect(user.plan_max).to eq 0
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,8 @@ describe User do
 
   describe "#plan_max" do
     it "returns the current plan's allowance" do
-      user = User.new(subscribed_repos: Array.new(5) { Repo.new })
+      owner = Owner.new(marketplace_plan_id: nil)
+      user = User.new(subscribed_repos: Array.new(5) { Repo.new(owner: owner) })
 
       expect(user.plan_max).to eq StripePlan::PLANS[2][:range].max
     end

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -100,7 +100,7 @@ describe RepoSubscriber do
         repo = build_stubbed(:repo)
         user = create(:user)
         stub_customer_create_request(user)
-        stub_failed_subscription_create_request(user.next_plan.id)
+        stub_failed_subscription_create_request("plan_FXpsAlar939qfx")
         allow(Raven).to receive(:capture_exception)
 
         RepoSubscriber.subscribe(repo, user, "cardtoken")


### PR DESCRIPTION
If a user has access to the repo and the owner of what repo has been
granted a whitelist/bulk permission, then it should be activatable.