### PR TITLE
Activate repo with existing stripe customer

### DIFF
--- a/app/javascript/components/ReposContainer/components/App.jsx
+++ b/app/javascript/components/ReposContainer/components/App.jsx
@@ -141,13 +141,13 @@ export default class App extends React.Component {
   }
 
   createSubscriptionWithExistingCard(repo) {
-    Ajax.createSubscription({
-      repo_id: repo.id
-    }).then( resp => {
-      this.activateAndTrackRepoSubscription(
-        repo, resp.stripe_subscription_id
-      );
-    }).catch(error => this.onSubscriptionError(repo, error));
+    Ajax.createSubscription({ repo_id: repo.id })
+      .then(resp => {
+        this.activateAndTrackRepoSubscription(
+          repo, resp.stripe_subscription_id
+        );
+      })
+      .catch(error => this.onSubscriptionError(repo, error));
   }
 
   activateFreeRepo(repo) {


### PR DESCRIPTION
If an org (that a given repo belongs to) already has paid/subscribed
repos, we will now use that Stripe account to allow enabling another
paid repo under that Strip account. This should prevent users from same
GitHub orgs needing to create new Stripe accounts to enable more repos.