### PR TITLE
Look for existing paying Stripe user first

### DIFF
--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -72,13 +72,22 @@ class RepoSubscriber
   end
 
   def stripe_user
-    @_stripe_user ||= if user.stripe_customer_id.present?
-      user
-    else
-      same_org_repos = repo.owner.repos.joins(:subscription)
-      if same_org_repos.any?
-        same_org_repos.first.subscription.user
+    @_stripe_user ||= begin
+      org_payee = find_org_paying_user
+
+      if org_payee.present?
+        org_payee
+      elsif user.stripe_customer_id.present?
+        user
       end
+    end
+  end
+
+  def find_org_paying_user
+    same_org_repos = repo.owner.repos.joins(:subscription)
+
+    if same_org_repos.any?
+      same_org_repos.first.subscription.user
     end
   end
 

--- a/app/services/repo_subscriber.rb
+++ b/app/services/repo_subscriber.rb
@@ -73,10 +73,10 @@ class RepoSubscriber
 
   def stripe_user
     @_stripe_user ||= begin
-      org_payee = find_org_paying_user
+      org_paying_user = find_org_paying_user
 
-      if org_payee.present?
-        org_payee
+      if org_paying_user.present?
+        org_paying_user
       elsif user.stripe_customer_id.present?
         user
       end

--- a/spec/services/repo_subscriber_spec.rb
+++ b/spec/services/repo_subscriber_spec.rb
@@ -150,21 +150,21 @@ describe RepoSubscriber do
         owner = create(:owner)
         repo1 = create(:repo, owner: owner)
         repo2 = create(:repo, owner: owner)
-        stripe_user = create(:user, :stripe, repos: [repo1, repo2])
-        user = create(:user, repos: [repo1, repo2])
-        create(:subscription, user: stripe_user, repo: repo1)
+        main_stripe_user = create(:user, :stripe, repos: [repo1, repo2])
+        current_user = create(:user, :stripe, repos: [repo1, repo2])
+        create(:subscription, user: main_stripe_user, repo: repo1)
         stub_customer_find_request_with_subscriptions
         stub_subscription_create_request(
-          plan: stripe_user.current_plan.id,
+          plan: main_stripe_user.current_plan.id,
           repo_ids: repo2.id,
         )
         stub_subscription_update_request(repo_ids: repo2.id)
 
-        subscription = RepoSubscriber.subscribe(repo2, user, nil)
+        subscription = RepoSubscriber.subscribe(repo2, current_user, nil)
 
         expect(subscription).to have_attributes(
           repo_id: repo2.id,
-          user_id: stripe_user.id,
+          user_id: main_stripe_user.id,
         )
       end
     end


### PR DESCRIPTION
This fixes the logic where a user that activates a repo already has a
Stripe account, but it's not set-up for being charged (older users).
We now will try to find an existing paying user within the same org,
before checking if the current user has a Stripe account.