### PR TITLE
Enable Redis TLS in Sidekiq

### DIFF
--- a/app/models/github_event.rb
+++ b/app/models/github_event.rb
@@ -14,7 +14,6 @@ class GitHubEvent
 
   def process
     Rails.logger.info("Received GitHub event: #{type} -- #{action}")
-
     case type
     when MARKETPLACE_PURCHASE
       update_purchase

--- a/app/models/github_event.rb
+++ b/app/models/github_event.rb
@@ -14,7 +14,6 @@ class GitHubEvent
 
   def process
     Rails.logger.info("Received GitHub event: #{type} -- #{action}")
-    Rails.logger.info(ENV["REDIS_URL"])
 
     case type
     when MARKETPLACE_PURCHASE

--- a/app/models/github_event.rb
+++ b/app/models/github_event.rb
@@ -14,6 +14,8 @@ class GitHubEvent
 
   def process
     Rails.logger.info("Received GitHub event: #{type} -- #{action}")
+    Rails.logger.info(ENV["REDIS_URL"])
+
     case type
     when MARKETPLACE_PURCHASE
       update_purchase

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,13 +1,13 @@
-# Sidekiq.configure_server do |config|
-#   config.redis = {
-#     url: ENV["REDIS_URL"],
-#     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
-#   }
-# end
-#
-# Sidekiq.configure_client do |config|
-#   config.redis = {
-#     url: ENV["REDIS_URL"],
-#     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
-#   }
-# end
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV["REDIS_URL"],
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+  }
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,7 @@
 Sidekiq.configure_server do |config|
   config.redis = {
     url: ENV["REDIS_URL"],
-    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
   }
 end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,13 +1,13 @@
-Sidekiq.configure_server do |config|
-  config.redis = {
-    url: ENV["REDIS_URL"],
-    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
-  }
-end
-
-Sidekiq.configure_client do |config|
-  config.redis = {
-    url: ENV["REDIS_URL"],
-    ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
-  }
-end
+# Sidekiq.configure_server do |config|
+#   config.redis = {
+#     url: ENV["REDIS_URL"],
+#     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+#   }
+# end
+#
+# Sidekiq.configure_client do |config|
+#   config.redis = {
+#     url: ENV["REDIS_URL"],
+#     ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE }
+#   }
+# end


### PR DESCRIPTION
Heroku will be upgrading our Redis to 7.0, which also means we need to switch to SSL connection.